### PR TITLE
Fix argument type normalization bug in FFI calls

### DIFF
--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -104,8 +104,8 @@ default_numeric_arg_type(::Type{T}) where {T} = T
 normalize_arg_type(::Type{R}, ::Type{T}) where {R,T} = T
 normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:AbstractString} = String
 normalize_arg_type(::Type{R}, ::Type{Cstring}) where {R} = Cstring
-normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:Integer} = default_numeric_arg_type(R)
-normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:AbstractFloat} = default_numeric_arg_type(R)
+normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:Integer} = T  # Preserve integer types
+normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:AbstractFloat} = T  # Preserve float types
 normalize_arg_type(::Type{R}, ::Type{Ptr{T}}) where {R,T} = Ptr{T}  # Preserve pointer types
 normalize_arg_type(::Type{R}, ::Type{Ref{T}}) where {R,T} = Ref{T}  # Preserve Ref types
 


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the argument type normalization logic that was causing segmentation faults when calling Rust functions with Float64 array pointers.

## Problem

The `normalize_arg_type` function was incorrectly using the return type `R` to normalize argument types. This caused:
- Integer arguments (e.g., `Int64` from `length()`) to be converted to `Float64` when the return type was `Float64`
- Incorrect `ccall` type signatures, leading to segmentation faults
- Array operation benchmarks failing with segfaults

## Solution

Modified `normalize_arg_type` in `src/codegen.jl` to preserve integer and float types based on their own types, not the return type:

```julia
# Before (incorrect)
normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:Integer} = default_numeric_arg_type(R)
normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:AbstractFloat} = default_numeric_arg_type(R)

# After (correct)
normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:Integer} = T  # Preserve integer types
normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:AbstractFloat} = T  # Preserve float types
```

## Testing

- Fixed segmentation faults in array operation benchmarks (`benchmarks_arrays.jl`)
- All Float64 pointer operations now work correctly
- Generic function benchmarks (`benchmarks_generics.jl`) continue to work
- Direct `ccall` tests pass

## Impact

This fix enables proper FFI calls with typed pointers, especially for array operations with Float64 arrays.