### PR TITLE
Fix Documenter warnings for @ref cross-references

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(
         prettyurls = get(ENV, "CI", nothing) == "true",
         canonical = "https://atelierarith.github.io/LastCall.jl",
         assets = String[],
+        edit_link = :commit,
     ),
     pages = [
         "Home" => "index.md",

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -536,4 +536,4 @@ rust"""
 
 ## Summary
 
-These examples demonstrate practical usage of LastCall.jl. For more detailed information, see the [Tutorial](@ref tutorial.md) and [API Reference](@ref api.md).
+These examples demonstrate practical usage of LastCall.jl. For more detailed information, see the [Tutorial](@ref "tutorial.md") and [API Reference](@ref "api.md").

--- a/docs/src/generics.md
+++ b/docs/src/generics.md
@@ -233,6 +233,6 @@ This ensures that calling the same generic function with the same types reuses t
 
 ## See Also
 
-- [Tutorial](@ref tutorial.md) - General tutorial
-- [Examples](@ref) - More examples
+- [Tutorial](@ref "tutorial.md") - General tutorial
+- [Examples](@ref "examples.md") - More examples
 - `test/test_generics.jl` - Test suite with examples

--- a/docs/src/struct_mapping.md
+++ b/docs/src/struct_mapping.md
@@ -517,7 +517,7 @@ If `copy()` doesn't work:
 
 ## See Also
 
-- [Tutorial](@ref): General tutorial on using LastCall.jl
-- [Examples](@ref): More examples of LastCall.jl usage
-- [API Reference](@ref): Complete API documentation
-- [Generics](@ref): Using generics with LastCall.jl
+- [Tutorial](@ref "tutorial.md"): General tutorial on using LastCall.jl
+- [Examples](@ref "examples.md"): More examples of LastCall.jl usage
+- [API Reference](@ref "api.md"): Complete API documentation
+- [Generics](@ref "generics.md"): Using generics with LastCall.jl

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -402,7 +402,7 @@ result2 = @rust func2()::Int32
 
 ### Q: Can I use Rust generics?
 
-A: Yes, with automatic monomorphization. See [Generics](@ref) for details.
+A: Yes, with automatic monomorphization. See [Generics](@ref "generics.md") for details.
 
 ### Q: Can I return Rust structs?
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -434,6 +434,6 @@ clear_cache()
 
 ## Next Steps
 
-- See [Examples](@ref) for more advanced usage examples
-- Check [Troubleshooting](@ref) to solve problems
-- Review [API Reference](@ref api.md) for all features
+- See [Examples](@ref "examples.md") for more advanced usage examples
+- Check [Troubleshooting](@ref "troubleshooting.md") to solve problems
+- Review [API Reference](@ref "api.md") for all features


### PR DESCRIPTION
This PR fixes Documenter warnings related to @ref cross-references in the documentation.

## Changes

- Fixed @ref references to use correct format: [Name](@ref "page.md")
- Updated all cross-references in:
  - docs/src/struct_mapping.md
  - docs/src/tutorial.md
  - docs/src/examples.md
  - docs/src/generics.md
  - docs/src/troubleshooting.md
- Fixed edit_link configuration in docs/make.jl

## Warnings Fixed

- Cannot resolve @ref for Tutorial, Examples, API Reference, Generics
- Unable to determine HTML(edit_link = ...) from remote HEAD branch

## Testing

Run servedocs() to verify warnings are resolved.