### PR TITLE
Fix Pluto notebook re-evaluation error

### DIFF
--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -112,7 +112,7 @@ function _resolve_lib(mod::Module, lib_name::String)
     # try to use the module's active library.
     if isempty(lib_name)
         if isdefined(mod, :__LASTCALL_ACTIVE_LIB)
-            lib_name = getfield(mod, :__LASTCALL_ACTIVE_LIB)
+            lib_name = getfield(mod, :__LASTCALL_ACTIVE_LIB)[]
         else
             return get_current_library()
         end

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -164,10 +164,12 @@ macro rust_str(code)
         $__module__.__LASTCALL_LIBS[lib_name] = $(esc(code))
 
         # Track the "current" library for this module
+        # Use Ref{String} so the binding is const but the value can be mutated
+        # This avoids Pluto's "cannot assign to imported variable" error
         if !isdefined($__module__, :__LASTCALL_ACTIVE_LIB)
-            @eval $__module__ __LASTCALL_ACTIVE_LIB = ""
+            @eval $__module__ const __LASTCALL_ACTIVE_LIB = Ref("")
         end
-        $__module__.__LASTCALL_ACTIVE_LIB = lib_name
+        $__module__.__LASTCALL_ACTIVE_LIB[] = lib_name
 
         # Track active library for macro expansion in this session
         lock(REGISTRY_LOCK) do


### PR DESCRIPTION
## Summary
- Fix "cannot assign a value to imported variable" error when re-evaluating cells in Pluto notebooks
- Use `Ref{String}` for `__LASTCALL_ACTIVE_LIB` instead of a mutable variable binding
- The binding is now `const` so it doesn't conflict with Pluto's workspace module system

## Problem
When a Pluto cell containing `rust"""..."""` was re-evaluated, the following error occurred:
```
cannot assign a value to imported variable workspace#8.__LASTCALL_ACTIVE_LIB from module workspace#9
```

## Solution
Changed from:
```julia
@eval $__module__ __LASTCALL_ACTIVE_LIB = ""
$__module__.__LASTCALL_ACTIVE_LIB = lib_name
```

To:
```julia
@eval $__module__ const __LASTCALL_ACTIVE_LIB = Ref("")
$__module__.__LASTCALL_ACTIVE_LIB[] = lib_name
```

This keeps the binding constant while allowing the value inside the `Ref` to be mutated.

## Test plan
- [x] All existing tests pass (122 tests)
- [ ] Manual verification in Pluto notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)