### PR TITLE
Add CI tests for lastcall_macros proc-macro crate

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,36 @@ on:
   pull_request:
 
 jobs:
+  rust-tests:
+    name: Rust ${{ matrix.rust }} - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+          - beta
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    defaults:
+      run:
+        working-directory: deps/lastcall_macros
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: clippy, rustfmt
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Run tests
+        run: cargo test --all-features
+
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}

--- a/deps/lastcall_macros/src/lib.rs
+++ b/deps/lastcall_macros/src/lib.rs
@@ -253,9 +253,7 @@ fn transform_impl(mut item_impl: ItemImpl) -> TokenStream2 {
 
     // Extract the struct name from the type
     let struct_name = match self_ty.as_ref() {
-        Type::Path(type_path) => {
-            type_path.path.segments.last().map(|s| s.ident.clone())
-        }
+        Type::Path(type_path) => type_path.path.segments.last().map(|s| s.ident.clone()),
         _ => None,
     };
 
@@ -304,7 +302,11 @@ fn generate_method_wrapper(struct_name: &Ident, method: &syn::ImplItemFn) -> Tok
     let wrapper_name = format_ident!("{}_{}", struct_name, method_name);
 
     // Analyze the method signature
-    let is_static = !method.sig.inputs.iter().any(|arg| matches!(arg, FnArg::Receiver(_)));
+    let is_static = !method
+        .sig
+        .inputs
+        .iter()
+        .any(|arg| matches!(arg, FnArg::Receiver(_)));
 
     let is_constructor = method_name_str == "new"
         || matches!(
@@ -312,9 +314,11 @@ fn generate_method_wrapper(struct_name: &Ident, method: &syn::ImplItemFn) -> Tok
             ReturnType::Type(_, ty) if is_self_type(ty, struct_name)
         );
 
-    let _is_mutable = method.sig.inputs.iter().any(|arg| {
-        matches!(arg, FnArg::Receiver(r) if r.mutability.is_some())
-    });
+    let _is_mutable = method
+        .sig
+        .inputs
+        .iter()
+        .any(|arg| matches!(arg, FnArg::Receiver(r) if r.mutability.is_some()));
 
     // Build wrapper arguments
     let mut wrapper_args = Vec::new();

--- a/deps/lastcall_macros/tests/basic.rs
+++ b/deps/lastcall_macros/tests/basic.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
 use lastcall_macros::julia;
 
 // Test that #[julia] on functions compiles correctly
@@ -54,20 +56,16 @@ fn main() {
     let mut point = TestPoint { x: 1.0, y: 2.0 };
     let ptr = &mut point as *mut TestPoint;
 
-    unsafe {
-        assert!((TestPoint_get_x(ptr) - 1.0).abs() < 1e-10);
-        TestPoint_set_x(ptr, 5.0);
-        assert!((TestPoint_get_x(ptr) - 5.0).abs() < 1e-10);
-    }
+    assert!((TestPoint_get_x(ptr) - 1.0).abs() < 1e-10);
+    TestPoint_set_x(ptr, 5.0);
+    assert!((TestPoint_get_x(ptr) - 5.0).abs() < 1e-10);
 
     // Verify Counter FFI functions exist
     let counter_ptr = Counter_new(10);
-    unsafe {
-        assert_eq!(Counter_get_value(counter_ptr), 10);
-        Counter_increment(counter_ptr);
-        assert_eq!(Counter_get_value(counter_ptr), 11);
-        Counter_free(counter_ptr);
-    }
+    assert_eq!(Counter_get_value(counter_ptr), 10);
+    Counter_increment(counter_ptr);
+    assert_eq!(Counter_get_value(counter_ptr), 11);
+    Counter_free(counter_ptr);
 
     println!("All tests passed!");
 }
@@ -77,6 +75,8 @@ fn main() {
 #[no_mangle]
 pub extern "C" fn Counter_free(ptr: *mut Counter) {
     if !ptr.is_null() {
-        unsafe { drop(Box::from_raw(ptr)); }
+        unsafe {
+            drop(Box::from_raw(ptr));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add rust-tests job to GitHub Actions CI workflow
- Test lastcall_macros proc-macro crate on stable and beta Rust toolchains
- Run cargo fmt, clippy, and test on ubuntu, macos, and windows

## Changes
- Added `rust-tests` job to `.github/workflows/CI.yml`
- Fixed Rust code formatting in `deps/lastcall_macros/src/lib.rs`
- Added `#![allow(clippy::not_unsafe_ptr_arg_deref)]` to test file to suppress expected clippy warning for FFI code

## Test plan
- [ ] CI workflow runs successfully on all platforms
- [ ] cargo fmt --check passes
- [ ] cargo clippy passes without warnings
- [ ] cargo test passes

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)