### PR TITLE
Fix CI: Replace non-existent dtolnay/rust-action with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-action@master
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy, rustfmt


### PR DESCRIPTION
## Summary
- Fix the CI workflow that was failing due to referencing a non-existent GitHub Action

## Problem
The CI workflow referenced `dtolnay/rust-action@master` which does not exist, causing all CI runs to fail with:
```
##[error]Unable to resolve action dtolnay/rust-action, repository not found
```

## Solution
Replace `dtolnay/rust-action` with the correct action name `dtolnay/rust-toolchain`.

## Test plan
- [x] Local Julia tests pass
- [x] CI should pass after this fix (Rust tests job will now work)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)