### PR TITLE
Fix Documenter deploy: match GITHUB_REPOSITORY casing in deploydocs repo

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,7 +43,7 @@ makedocs(
 )
 
 deploydocs(
-    repo = "github.com/atelierarith/RustCall.jl.git",
+    repo = "github.com/AtelierArith/RustCall.jl.git",
     devbranch = "main",
     push_preview = true,
 )


### PR DESCRIPTION
## Summary
Documenter devbranch deploy was failing because `ENV["GITHUB_REPOSITORY"]` (e.g. `AtelierArith/RustCall.jl`) was not found in the `repo` string (`github.com/atelierarith/RustCall.jl.git`) due to casing.

## Change
- `docs/make.jl`: set `deploydocs(repo = "github.com/AtelierArith/RustCall.jl.git", ...)` so the canonical org/owner name matches GitHub and the deploy criteria pass.

## Verification
- README.md checked: project structure and examples are accurate.
- Single logical commit; no changes to main/master.

Made with [Cursor](https://cursor.com)