### PR TITLE
Fix @irust ABI safety, qualified @rust resolution, and registry locking

### DIFF
--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -163,9 +163,13 @@ function rust_impl_qualified(mod, expr, source)
     func_name_str = string(func_name)
     escaped_args = map(esc, args)
 
-    return quote
-        $(GlobalRef(RustCall, :_rust_call_from_lib))($(lib_name_str), $(func_name_str), $(escaped_args...))
-    end
+    return Expr(
+        :call,
+        GlobalRef(RustCall, :_rust_call_from_lib),
+        Expr(:call, GlobalRef(RustCall, :_resolve_lib), mod, lib_name_str),
+        func_name_str,
+        escaped_args...
+    )
 end
 
 """

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -189,7 +189,10 @@ Ensure that a Rust library is loaded in the current session.
 Useful for precompiled modules that need to reload libraries at runtime.
 """
 function ensure_loaded(lib_name::String, code::String)
-    if !haskey(RUST_LIBRARIES, lib_name)
+    needs_reload = lock(REGISTRY_LOCK) do
+        !haskey(RUST_LIBRARIES, lib_name)
+    end
+    if needs_reload
         _compile_and_load_rust(code, "reload", 0)
     end
     return nothing
@@ -412,8 +415,13 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
     lib_name = "rust_cargo_$(string(code_hash, base=16))"
 
     # Check if already compiled and loaded in memory
-    if haskey(RUST_LIBRARIES, lib_name)
-        CURRENT_LIB[] = lib_name
+    is_in_memory = lock(REGISTRY_LOCK) do
+        haskey(RUST_LIBRARIES, lib_name)
+    end
+    if is_in_memory
+        lock(REGISTRY_LOCK) do
+            CURRENT_LIB[] = lib_name
+        end
         @debug "Using cached Cargo library from memory" lib_name=lib_name
 
         # Ensure generic functions are registered
@@ -435,8 +443,10 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
         # Load from cache
         lib_handle = Libdl.dlopen(cached_lib, Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW)
         if lib_handle != C_NULL
-            RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
-            CURRENT_LIB[] = lib_name
+            lock(REGISTRY_LOCK) do
+                RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
+                CURRENT_LIB[] = lib_name
+            end
             @debug "Loaded Cargo library from cache" lib_name=lib_name cache_key=cache_key[1:8]
 
             # Ensure generic functions are registered
@@ -476,8 +486,10 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
         end
 
         # Register the library
-        RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
-        CURRENT_LIB[] = lib_name
+        lock(REGISTRY_LOCK) do
+            RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
+            CURRENT_LIB[] = lib_name
+        end
 
         @info "Successfully built Rust code with Cargo" lib_name=lib_name
 
@@ -682,7 +694,9 @@ end
 List all currently loaded Rust libraries.
 """
 function list_loaded_libraries()
-    return collect(keys(RUST_LIBRARIES))
+    return lock(REGISTRY_LOCK) do
+        collect(keys(RUST_LIBRARIES))
+    end
 end
 
 """
@@ -710,18 +724,24 @@ end
 Unload a Rust library and free its resources.
 """
 function unload_library(lib_name::String)
-    if !haskey(RUST_LIBRARIES, lib_name)
+    local lib_handle
+    found = lock(REGISTRY_LOCK) do
+        if !haskey(RUST_LIBRARIES, lib_name)
+            return false
+        end
+        lib_handle, _ = RUST_LIBRARIES[lib_name]
+        delete!(RUST_LIBRARIES, lib_name)
+        if CURRENT_LIB[] == lib_name
+            CURRENT_LIB[] = ""
+        end
+        return true
+    end
+    if !found
         @warn "Library '$lib_name' not loaded"
         return
     end
 
-    lib_handle, _ = RUST_LIBRARIES[lib_name]
     Libdl.dlclose(lib_handle)
-    delete!(RUST_LIBRARIES, lib_name)
-
-    if CURRENT_LIB[] == lib_name
-        CURRENT_LIB[] = ""
-    end
 end
 
 """
@@ -730,7 +750,10 @@ end
 Unload all loaded Rust libraries.
 """
 function unload_all_libraries()
-    for lib_name in collect(keys(RUST_LIBRARIES))
+    libs = lock(REGISTRY_LOCK) do
+        collect(keys(RUST_LIBRARIES))
+    end
+    for lib_name in libs
         unload_library(lib_name)
     end
 end
@@ -890,12 +913,15 @@ function _compile_and_call_irust(code::String, args...)
         func_name = "irust_func_$(string(code_hash, base=16))"
 
         # Infer Rust types from Julia types (needed for both cached and new functions)
-        rust_arg_types = collect(map(_julia_to_rust_type, arg_types))  # Ensure Vector
+        rust_arg_types = collect(map(_julia_to_rust_type, arg_types))
 
         # Check if already compiled
         if haskey(IRUST_FUNCTIONS, code_hash)
             lib_name, cached_func_name = IRUST_FUNCTIONS[code_hash]
-            if haskey(RUST_LIBRARIES, lib_name)
+            is_loaded = lock(REGISTRY_LOCK) do
+                haskey(RUST_LIBRARIES, lib_name)
+            end
+            if is_loaded
                 # Re-infer return type for cached function (should match original)
                 rust_ret_type = _infer_return_type_improved(code, arg_types, rust_arg_types)
                 julia_ret_type = _rust_to_julia_type(rust_ret_type)
@@ -904,12 +930,6 @@ function _compile_and_call_irust(code::String, args...)
                 # Stale cache entry: library was unloaded, so recompile transparently.
                 delete!(IRUST_FUNCTIONS, code_hash)
             end
-        end
-
-        # Check for unsupported types
-        unsupported = filter(t -> _julia_to_rust_type(t) == "i64" && t != Int64, arg_types)
-        if !isempty(unsupported)
-            @warn "Some argument types may not be correctly inferred: $unsupported. Consider using explicit types."
         end
 
         # Infer return type from code (improved)
@@ -954,7 +974,9 @@ function _compile_and_call_irust(code::String, args...)
 
         # Generate a unique library name
         lib_name = "irust_$(string(code_hash, base=16))"
-        RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
+        lock(REGISTRY_LOCK) do
+            RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
+        end
         IRUST_FUNCTIONS[code_hash] = (lib_name, func_name)
 
         # Convert Rust return type to Julia type
@@ -992,7 +1014,7 @@ Convert Julia type to Rust type string.
 - Boolean: Bool
 
 # Error Handling
-Unsupported types default to "i64" with a warning.
+Unsupported types throw an error to prevent ABI mismatches.
 """
 function _julia_to_rust_type(julia_type::Type)
     type_map = Dict(
@@ -1011,10 +1033,8 @@ function _julia_to_rust_type(julia_type::Type)
 
     if haskey(type_map, julia_type)
         return type_map[julia_type]
-    else
-        # Default to i64, but this should be handled by caller
-        return "i64"
     end
+    error("Unsupported Julia type for @irust: $julia_type")
 end
 
 """

--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -222,6 +222,14 @@ end
                 drop!(rust_vecf64)
             end
 
+            @testset "RustVec finalizer calls Rust drop" begin
+                rust_vec = create_rust_vec(Int32[1, 2, 3])
+                @test !rust_vec.dropped
+                finalize(rust_vec)
+                @test rust_vec.dropped
+                @test rust_vec.ptr == C_NULL
+            end
+
             @testset "rust_vec_get and rust_vec_set!" begin
                 julia_vec = Int32[10, 20, 30, 40, 50]
                 rust_vec = create_rust_vec(julia_vec)


### PR DESCRIPTION
## Summary
This PR implements the high-priority fixes identified in the recent RustCall review:
- fail-fast type handling for `@irust` to prevent ABI mismatches
- unified library resolution path for qualified `@rust lib::func(...)` calls
- consistent synchronization around `RUST_LIBRARIES` access
- reliable `RustVec` finalization via Rust-side drop

## Changes
- `src/ruststr.jl`
  - removed unsupported-type fallback in `_julia_to_rust_type` (now throws)
  - applied `REGISTRY_LOCK` consistently on `RUST_LIBRARIES` read/write paths
  - aligned related call paths for safe concurrent behavior
- `src/rustmacro.jl`
  - routed qualified calls through `_resolve_lib` before dispatch
- `src/hot_reload.jl`
  - guarded hot-reload registry/library interactions with `REGISTRY_LOCK`
- `src/generics.jl`
  - guarded library registration/function-cache updates with `REGISTRY_LOCK`
- `src/types.jl`
  - updated `RustVec` finalizer to call Rust-side `drop_rust_vec` when available
  - removed duplicate constructor-specific finalizer setup

## Tests
- `julia --project test/test_regressions.jl`
- `julia --project test/test_arrays.jl`
- `julia --project test/test_hot_reload.jl`
- `julia --project -e 'using RustCall; println("loaded")'`
