### PR TITLE
Fix LLVM IR generation string interpolation (#69, #70)

### DIFF
--- a/src/llvmcodegen.jl
+++ b/src/llvmcodegen.jl
@@ -79,7 +79,7 @@ function generate_llvmcall_ir(func_name::String, ret_type::Type, arg_types::Vect
     llvm_args = [julia_type_to_llvm_ir_string(t) for t in arg_types]
 
     # Build argument list
-    arg_list = join(["$llvm_args[$i] %$(i-1)" for i in 1:length(arg_types)], ", ")
+    arg_list = join(["$(llvm_args[i]) %$(i-1)" for i in 1:length(arg_types)], ", ")
     arg_refs = join(["%$(i-1)" for i in 1:length(arg_types)], ", ")
 
     if ret_type == Cvoid || ret_type == Nothing
@@ -120,7 +120,7 @@ julia_type_to_llvm_ir_string(::Type{UInt128}) = "i128"
 julia_type_to_llvm_ir_string(::Type{Float32}) = "float"
 julia_type_to_llvm_ir_string(::Type{Float64}) = "double"
 
-# Void type (Cvoid is an alias for Nothing in Julia)
+# Void type (Cvoid === Nothing in Julia, so this handles both)
 julia_type_to_llvm_ir_string(::Type{Nothing}) = "void"
 
 # Pointer types (opaque pointer in modern LLVM)

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -52,6 +52,21 @@ using Test
         ir = RustCall.generate_llvmcall_ir("test_add", Int32, Type[Int32, Int32])
         @test occursin("i32", ir)
         @test occursin("call", ir)
+
+        # Verify correct interpolation: args should be "i32 %0, i32 %1", not "["i32", "i32"][1] %0"
+        @test occursin("i32 %0", ir)
+        @test occursin("i32 %1", ir)
+        @test !occursin("[", ir)  # No array-like syntax in the IR
+
+        # Test void return type
+        ir_void = RustCall.generate_llvmcall_ir("test_void", Cvoid, Type[Int32])
+        @test occursin("call void", ir_void)
+        @test occursin("ret void", ir_void)
+
+        # Test with mixed argument types
+        ir_mixed = RustCall.generate_llvmcall_ir("test_mixed", Float64, Type[Int32, Float64])
+        @test occursin("i32 %0", ir_mixed)
+        @test occursin("double %1", ir_mixed)
     end
 
     # Only run integration tests if rustc is available


### PR DESCRIPTION
## Summary
- Fixed broken string interpolation in `generate_llvmcall_ir` that produced invalid LLVM IR (`"$llvm_args[$i]"` -> `"$(llvm_args[i])"`)
- Clarified that `Cvoid === Nothing` in Julia, so the existing `Nothing` handler already covers `Cvoid` (no separate method needed, avoids method overwrite warning)
- Added tests verifying correct IR format, void return types, and mixed argument types

## Test plan
- [x] All 122 existing tests pass
- [x] No precompilation warnings
- [x] New tests verify `i32 %0` format (not `["i32"][1] %0`)
- [x] New tests verify void return IR and mixed argument types

Closes #69
Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)