### PR TITLE
Fix race conditions in registries and stale pointers (#71, #72, #73)

### DIFF
--- a/src/generics.jl
+++ b/src/generics.jl
@@ -642,8 +642,10 @@ Infer type parameters for a generic function from argument types.
 ```
 """
 function infer_type_parameters(func_name::String, arg_types::Vector{<:Type})
-    # Get generic function info
-    generic_info = get(GENERIC_FUNCTION_REGISTRY, func_name, nothing)
+    # Get generic function info (protect read with REGISTRY_LOCK)
+    generic_info = lock(REGISTRY_LOCK) do
+        get(GENERIC_FUNCTION_REGISTRY, func_name, nothing)
+    end
     if generic_info === nothing
         error("Function '$func_name' is not registered as a generic function")
     end
@@ -953,8 +955,10 @@ end
 Check if a function is registered as a generic function.
 """
 function is_generic_function(func_name::String)
-    @debug "Checking if function is generic" func_name registry_keys=collect(keys(GENERIC_FUNCTION_REGISTRY))
-    return haskey(GENERIC_FUNCTION_REGISTRY, func_name)
+    return lock(REGISTRY_LOCK) do
+        @debug "Checking if function is generic" func_name registry_keys=collect(keys(GENERIC_FUNCTION_REGISTRY))
+        haskey(GENERIC_FUNCTION_REGISTRY, func_name)
+    end
 end
 
 """


### PR DESCRIPTION
## Summary
- **#71**: Wrapped all `IRUST_FUNCTIONS` dictionary reads/writes in `REGISTRY_LOCK` using double-checked locking pattern to prevent TOCTOU race conditions
- **#72**: Wrapped `GENERIC_FUNCTION_REGISTRY` reads in `infer_type_parameters` and `is_generic_function` with `REGISTRY_LOCK` to prevent crashes from concurrent Dict mutation
- **#73**: Added `MONOMORPHIZED_FUNCTIONS` cache cleanup during hot reload to prevent use-after-free from dangling function pointers to unloaded libraries

## Test plan
- [x] All 122 existing tests pass
- [x] Module loads and precompiles without warnings
- [x] Hot reload tests pass (verifying cache cleanup doesn't break reload workflow)
- [x] Generic function tests pass (verifying lock protection doesn't cause deadlocks)

Closes #71
Closes #72
Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)