### PR TITLE
Fix silent memory leak when Rust helpers library not loaded (#77)

### DIFF
--- a/test/test_ownership.jl
+++ b/test/test_ownership.jl
@@ -415,4 +415,12 @@ using Test
         @test !isdefined(RustCall, :update_rc_finalizer)
         @test !isdefined(RustCall, :update_arc_finalizer)
     end
+
+    @testset "Leak counter API" begin
+        # get_leaked_object_count should be defined and return an Int
+        @test isdefined(RustCall, :get_leaked_object_count)
+        count = RustCall.get_leaked_object_count()
+        @test count isa Int
+        @test count >= 0
+    end
 end


### PR DESCRIPTION
## Summary

- Replace `DROP_WARNING_SHOWN` single-warning flag with `LEAKED_OBJECT_COUNT` counter that tracks how many ownership objects leaked their Rust memory
- Each drop function now logs the leak with type name, pointer address, and cumulative count, using `maxlog=10` to prevent unbounded spam while still surfacing multiple leaks (previously only the first leak was reported)
- Add `get_leaked_object_count()` API for programmatic leak detection
- Add test for the leak counter API

Closes #77

## Test plan

- [x] All 122 existing tests pass
- [x] New test verifies `get_leaked_object_count` returns a non-negative Int

🤖 Generated with [Claude Code](https://claude.com/claude-code)