### PR TITLE
Fix unsafe pointer arithmetic in RustVec and RustSlice indexing (#83)

### DIFF
--- a/test/test_arrays.jl
+++ b/test/test_arrays.jl
@@ -182,6 +182,17 @@ end
         end
     end
 
+    @testset "RustVec isbitstype validation" begin
+        # isbits types should work
+        @test_nowarn RustVec{Int32}(C_NULL, UInt(0), UInt(0))
+        @test_nowarn RustVec{Float64}(C_NULL, UInt(0), UInt(0))
+
+        # Non-isbits types should be rejected
+        @test_throws ErrorException RustVec{String}(C_NULL, UInt(0), UInt(0))
+        @test_throws ErrorException RustVec{Any}(C_NULL, UInt(0), UInt(0))
+        @test_throws ErrorException RustVec{Vector{Int}}(C_NULL, UInt(0), UInt(0))
+    end
+
     @testset "RustVec Type Constructors" begin
         # Test generic constructor handles all supported types via type inference
         # The generic RustVec(v::Vector{T}) where T handles these automatically


### PR DESCRIPTION
## Summary

- Replace manual pointer arithmetic (`ptr + idx * sizeof(T)`) with Julia's built-in `unsafe_load(Ptr{T}(ptr), i)` and `unsafe_store!(Ptr{T}(ptr), val, i)` which handle stride and alignment correctly
- Add `isbitstype(T)` validation in `RustVec{T}` constructor to reject non-isbits types that would cause undefined behavior with pointer-based element access
- Add tests for isbitstype validation (`String`, `Any`, `Vector{Int}` correctly rejected)

This eliminates three classes of potential undefined behavior:
1. Zero-sized type aliasing (all indices pointing to same address)
2. Alignment faults on strict architectures
3. Stride mismatch between Julia and Rust

Closes #83

## Test plan

- [x] All 122 existing tests pass (including RustVec integration tests with actual memory access)
- [x] New isbitstype validation tests verify non-isbits types are rejected at construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)