### PR TITLE
Add warning when extract_function_code falls back to entire block (#79)

### DIFF
--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -616,6 +616,8 @@ function _detect_and_register_generic_functions(code::String, lib_name::String)
             func_code = extract_function_code(code, func_name)
 
             if func_code === nothing
+                @warn "Failed to extract function '$(func_name)' from code block; " *
+                      "falling back to entire block. This may cause issues with generic specialization."
                 func_code = code
             end
 

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -185,4 +185,24 @@ using Test
         @test infos[1].has_derive_julia_struct
         @test get(infos[1].derive_options, "Clone", false)
     end
+
+    @testset "extract_function_code returns nothing for nonexistent function" begin
+        code = """
+        fn real_function() {
+            let x = 1;
+        }
+        """
+        @test RustCall.extract_function_code(code, "nonexistent") === nothing
+    end
+
+    @testset "detect_and_register warns on extraction fallback" begin
+        # Code with a generic function whose name doesn't match the fn pattern
+        # (no braces after function signature — causes extract_function_code to fail)
+        code = """
+        #[no_mangle]
+        pub extern "C" fn missing_body<T>(x: T) -> T
+        """
+        # Should emit a warning about falling back to entire block
+        @test_warn "Failed to extract function" RustCall._detect_and_register_generic_functions(code, "test_lib")
+    end
 end


### PR DESCRIPTION
## Summary

- Emit `@warn` when `extract_function_code` returns `nothing` and the generic function registration falls back to using the entire code block, making the fallback visible instead of completely silent
- Add test verifying `extract_function_code` returns `nothing` for nonexistent functions
- Add test verifying the warning is emitted during `_detect_and_register_generic_functions` when extraction fails

Closes #79

## Test plan

- [x] All 122 test groups pass
- [x] New test confirms warning emission on extraction fallback
- [x] New test confirms `nothing` return for nonexistent functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)