### PR TITLE
Fix escaped quote detection in split_cargo_deps (#81)

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -277,6 +277,22 @@ function parse_cargo_deps_line(line::AbstractString)
 end
 
 """
+    _count_trailing_backslashes(s::AbstractString) -> Int
+
+Count consecutive trailing backslash characters. Used to determine whether
+a quote is escaped: the quote is escaped only if preceded by an odd number
+of backslashes (e.g., `\\"` is escaped, `\\\\"` is not).
+"""
+function _count_trailing_backslashes(s::AbstractString)
+    count = 0
+    for i in lastindex(s):-1:firstindex(s)
+        s[i] == '\\' || break
+        count += 1
+    end
+    return count
+end
+
+"""
     split_cargo_deps(line::String) -> Vector{String}
 
 Split cargo-deps line by commas, respecting braces and quotes.
@@ -288,7 +304,7 @@ function split_cargo_deps(line::String)
     in_quote = false
 
     for char in line
-        if char == '"' && (isempty(current) || current[end] != '\\')
+        if char == '"' && iseven(_count_trailing_backslashes(current))
             in_quote = !in_quote
             current *= char
         elseif char == '{' && !in_quote


### PR DESCRIPTION
## Summary

- Added `_count_trailing_backslashes()` helper function that counts consecutive trailing backslash characters
- Replaced naive `current[end] != '\\'` check in `split_cargo_deps` with `iseven(_count_trailing_backslashes(current))` to correctly handle double backslashes (`\\"`) where the quote is NOT escaped
- A quote is only escaped when preceded by an odd number of backslashes

Closes #81

## Test plan

- [x] Added unit tests for `_count_trailing_backslashes` (empty string, no backslash, 1-3 trailing backslashes)
- [x] Added tests for `split_cargo_deps` with escaped quotes and double backslashes
- [x] All 122 existing test groups pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)