### PR TITLE
Add load-time validation for extract_block_at in crate_bindings.jl (#82)

### DIFF
--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1,9 +1,20 @@
 # External crate bindings generator (Maturin-like feature)
 # This module provides automatic Julia bindings generation for external Rust crates
 # that use the #[julia] attribute from juliacall_macros.
+#
+# Dependencies (must be included before this file in RustCall.jl):
+#   - structs.jl: extract_block_at, parse_struct_fields, parse_methods_in_impl
+#   - julia_functions.jl: parse_julia_functions_from_source
 
 using TOML
 using SHA
+
+# Validate that required dependencies are available at include time.
+# If structs.jl failed to load or was included after this file, catch it early
+# rather than at runtime when @rust_crate is used.
+if !isdefined(@__MODULE__, :extract_block_at)
+    error("crate_bindings.jl requires extract_block_at from structs.jl — check include order in RustCall.jl")
+end
 
 # ============================================================================
 # Type Definitions


### PR DESCRIPTION
## Summary

- Added dependency documentation at the top of `crate_bindings.jl` listing required functions from `structs.jl` and `julia_functions.jl`
- Added `isdefined(@__MODULE__, :extract_block_at)` check at include time to catch missing dependencies early, rather than at runtime when `@rust_crate` is used with structs
- Added 4 regression tests for `extract_block_at`: module accessibility, balanced brace extraction, nested braces, missing braces, and tuple structs

Closes #82

## Test plan

- [x] Verify `extract_block_at` is accessible from module scope via `isdefined` test
- [x] Test balanced brace block extraction (struct definition)
- [x] Test nested brace handling (impl block with inner function)
- [x] Test `nothing` return when no brace found
- [x] Test tuple struct extraction (semicolon-terminated)
- [x] All 122 existing test groups pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)