### PR TITLE
Add Float32/Float64 support to RustRc and Float32 to RustArc (#98)

### DIFF
--- a/deps/rust_helpers/src/lib.rs
+++ b/deps/rust_helpers/src/lib.rs
@@ -105,6 +105,17 @@ pub extern "C" fn rust_rc_new_i64(value: i64) -> *mut c_void {
     Rc::into_raw(Rc::new(value)) as *mut c_void
 }
 
+/// Create an Rc<f32> from a value
+#[no_mangle]
+pub extern "C" fn rust_rc_new_f32(value: f32) -> *mut c_void {
+    Rc::into_raw(Rc::new(value)) as *mut c_void
+}
+
+/// Create an Rc<f64> from a value
+#[no_mangle]
+pub extern "C" fn rust_rc_new_f64(value: f64) -> *mut c_void {
+    Rc::into_raw(Rc::new(value)) as *mut c_void
+}
 
 /// Clone an Rc<i32> (increment reference count)
 #[no_mangle]
@@ -131,6 +142,30 @@ pub unsafe extern "C" fn rust_rc_clone_i64(ptr: *mut c_void) -> *mut c_void {
     Rc::into_raw(cloned) as *mut c_void
 }
 
+/// Clone an Rc<f32> (increment reference count)
+#[no_mangle]
+pub unsafe extern "C" fn rust_rc_clone_f32(ptr: *mut c_void) -> *mut c_void {
+    if ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+    let rc = Rc::from_raw(ptr as *const f32);
+    let cloned = Rc::clone(&rc);
+    std::mem::forget(rc);
+    Rc::into_raw(cloned) as *mut c_void
+}
+
+/// Clone an Rc<f64> (increment reference count)
+#[no_mangle]
+pub unsafe extern "C" fn rust_rc_clone_f64(ptr: *mut c_void) -> *mut c_void {
+    if ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+    let rc = Rc::from_raw(ptr as *const f64);
+    let cloned = Rc::clone(&rc);
+    std::mem::forget(rc);
+    Rc::into_raw(cloned) as *mut c_void
+}
+
 /// Drop an Rc<i32> (decrement reference count)
 #[no_mangle]
 pub unsafe extern "C" fn rust_rc_drop_i32(ptr: *mut c_void) {
@@ -144,6 +179,22 @@ pub unsafe extern "C" fn rust_rc_drop_i32(ptr: *mut c_void) {
 pub unsafe extern "C" fn rust_rc_drop_i64(ptr: *mut c_void) {
     if !ptr.is_null() {
         let _ = Rc::from_raw(ptr as *const i64);
+    }
+}
+
+/// Drop an Rc<f32> (decrement reference count)
+#[no_mangle]
+pub unsafe extern "C" fn rust_rc_drop_f32(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        let _ = Rc::from_raw(ptr as *const f32);
+    }
+}
+
+/// Drop an Rc<f64> (decrement reference count)
+#[no_mangle]
+pub unsafe extern "C" fn rust_rc_drop_f64(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        let _ = Rc::from_raw(ptr as *const f64);
     }
 }
 
@@ -163,12 +214,17 @@ pub extern "C" fn rust_arc_new_i64(value: i64) -> *mut c_void {
     Arc::into_raw(Arc::new(value)) as *mut c_void
 }
 
+/// Create an Arc<f32> from a value
+#[no_mangle]
+pub extern "C" fn rust_arc_new_f32(value: f32) -> *mut c_void {
+    Arc::into_raw(Arc::new(value)) as *mut c_void
+}
+
 /// Create an Arc<f64> from a value
 #[no_mangle]
 pub extern "C" fn rust_arc_new_f64(value: f64) -> *mut c_void {
     Arc::into_raw(Arc::new(value)) as *mut c_void
 }
-
 
 /// Clone an Arc<i32> (increment reference count)
 #[no_mangle]
@@ -192,6 +248,18 @@ pub unsafe extern "C" fn rust_arc_clone_i64(ptr: *mut c_void) -> *mut c_void {
     let arc = Arc::from_raw(ptr as *const i64);
     let cloned = Arc::clone(&arc);
     std::mem::forget(arc);  // Keep original reference alive
+    Arc::into_raw(cloned) as *mut c_void
+}
+
+/// Clone an Arc<f32> (increment reference count)
+#[no_mangle]
+pub unsafe extern "C" fn rust_arc_clone_f32(ptr: *mut c_void) -> *mut c_void {
+    if ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+    let arc = Arc::from_raw(ptr as *const f32);
+    let cloned = Arc::clone(&arc);
+    std::mem::forget(arc);
     Arc::into_raw(cloned) as *mut c_void
 }
 
@@ -220,6 +288,14 @@ pub unsafe extern "C" fn rust_arc_drop_i32(ptr: *mut c_void) {
 pub unsafe extern "C" fn rust_arc_drop_i64(ptr: *mut c_void) {
     if !ptr.is_null() {
         let _ = Arc::from_raw(ptr as *const i64);
+    }
+}
+
+/// Drop an Arc<f32> (decrement reference count)
+#[no_mangle]
+pub unsafe extern "C" fn rust_arc_drop_f32(ptr: *mut c_void) {
+    if !ptr.is_null() {
+        let _ = Arc::from_raw(ptr as *const f32);
     }
 }
 

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -308,6 +308,14 @@ function create_rust_rc(value::T) where T
         fn_ptr = safe_dlsym(lib, :rust_rc_new_i64)
         ptr = ccall(fn_ptr, Ptr{Cvoid}, (Int64,), value)
         return RustRc{Int64}(ptr)
+    elseif T == Float32
+        fn_ptr = safe_dlsym(lib, :rust_rc_new_f32)
+        ptr = ccall(fn_ptr, Ptr{Cvoid}, (Float32,), value)
+        return RustRc{Float32}(ptr)
+    elseif T == Float64
+        fn_ptr = safe_dlsym(lib, :rust_rc_new_f64)
+        ptr = ccall(fn_ptr, Ptr{Cvoid}, (Float64,), value)
+        return RustRc{Float64}(ptr)
     else
         error("Unsupported type for RustRc: $T")
     end
@@ -338,6 +346,14 @@ function clone(rc::RustRc{T}) where T
         fn_ptr = safe_dlsym(lib, :rust_rc_clone_i64)
         new_ptr = ccall(fn_ptr, Ptr{Cvoid}, (Ptr{Cvoid},), rc.ptr)
         return RustRc{Int64}(new_ptr)
+    elseif T == Float32
+        fn_ptr = safe_dlsym(lib, :rust_rc_clone_f32)
+        new_ptr = ccall(fn_ptr, Ptr{Cvoid}, (Ptr{Cvoid},), rc.ptr)
+        return RustRc{Float32}(new_ptr)
+    elseif T == Float64
+        fn_ptr = safe_dlsym(lib, :rust_rc_clone_f64)
+        new_ptr = ccall(fn_ptr, Ptr{Cvoid}, (Ptr{Cvoid},), rc.ptr)
+        return RustRc{Float64}(new_ptr)
     else
         error("Unsupported type for RustRc clone: $T")
     end
@@ -373,6 +389,12 @@ function drop_rust_rc(rc::RustRc{T}) where T
         ccall(fn_ptr, Cvoid, (Ptr{Cvoid},), rc.ptr)
     elseif T == Int64
         fn_ptr = safe_dlsym(lib, :rust_rc_drop_i64)
+        ccall(fn_ptr, Cvoid, (Ptr{Cvoid},), rc.ptr)
+    elseif T == Float32
+        fn_ptr = safe_dlsym(lib, :rust_rc_drop_f32)
+        ccall(fn_ptr, Cvoid, (Ptr{Cvoid},), rc.ptr)
+    elseif T == Float64
+        fn_ptr = safe_dlsym(lib, :rust_rc_drop_f64)
         ccall(fn_ptr, Cvoid, (Ptr{Cvoid},), rc.ptr)
     else
         error("Unsupported type for RustRc drop: $T")
@@ -413,6 +435,10 @@ function create_rust_arc(value::T) where T
         fn_ptr = safe_dlsym(lib, :rust_arc_new_i64)
         ptr = ccall(fn_ptr, Ptr{Cvoid}, (Int64,), value)
         return RustArc{Int64}(ptr)
+    elseif T == Float32
+        fn_ptr = safe_dlsym(lib, :rust_arc_new_f32)
+        ptr = ccall(fn_ptr, Ptr{Cvoid}, (Float32,), value)
+        return RustArc{Float32}(ptr)
     elseif T == Float64
         fn_ptr = safe_dlsym(lib, :rust_arc_new_f64)
         ptr = ccall(fn_ptr, Ptr{Cvoid}, (Float64,), value)
@@ -447,6 +473,10 @@ function clone(arc::RustArc{T}) where T
         fn_ptr = safe_dlsym(lib, :rust_arc_clone_i64)
         new_ptr = ccall(fn_ptr, Ptr{Cvoid}, (Ptr{Cvoid},), arc.ptr)
         return RustArc{Int64}(new_ptr)
+    elseif T == Float32
+        fn_ptr = safe_dlsym(lib, :rust_arc_clone_f32)
+        new_ptr = ccall(fn_ptr, Ptr{Cvoid}, (Ptr{Cvoid},), arc.ptr)
+        return RustArc{Float32}(new_ptr)
     elseif T == Float64
         fn_ptr = safe_dlsym(lib, :rust_arc_clone_f64)
         new_ptr = ccall(fn_ptr, Ptr{Cvoid}, (Ptr{Cvoid},), arc.ptr)
@@ -487,6 +517,9 @@ function drop_rust_arc(arc::RustArc{T}) where T
     elseif T == Int64
         fn_ptr = safe_dlsym(lib, :rust_arc_drop_i64)
         ccall(fn_ptr, Cvoid, (Ptr{Cvoid},), arc.ptr)
+    elseif T == Float32
+        fn_ptr = safe_dlsym(lib, :rust_arc_drop_f32)
+        ccall(fn_ptr, Cvoid, (Ptr{Cvoid},), arc.ptr)
     elseif T == Float64
         fn_ptr = safe_dlsym(lib, :rust_arc_drop_f64)
         ccall(fn_ptr, Cvoid, (Ptr{Cvoid},), arc.ptr)
@@ -518,10 +551,13 @@ RustBox(value::Bool) = create_rust_box(value)
 # RustRc constructors
 RustRc(value::Int32) = create_rust_rc(value)
 RustRc(value::Int64) = create_rust_rc(value)
+RustRc(value::Float32) = create_rust_rc(value)
+RustRc(value::Float64) = create_rust_rc(value)
 
 # RustArc constructors
 RustArc(value::Int32) = create_rust_arc(value)
 RustArc(value::Int64) = create_rust_arc(value)
+RustArc(value::Float32) = create_rust_arc(value)
 RustArc(value::Float64) = create_rust_arc(value)
 
 # ============================================================================

--- a/test/test_ownership.jl
+++ b/test/test_ownership.jl
@@ -30,11 +30,14 @@ using Test
     @testset "RustRc Constructors" begin
         @test hasmethod(RustRc, Tuple{Int32})
         @test hasmethod(RustRc, Tuple{Int64})
+        @test hasmethod(RustRc, Tuple{Float32})
+        @test hasmethod(RustRc, Tuple{Float64})
     end
 
     @testset "RustArc Constructors" begin
         @test hasmethod(RustArc, Tuple{Int32})
         @test hasmethod(RustArc, Tuple{Int64})
+        @test hasmethod(RustArc, Tuple{Float32})
         @test hasmethod(RustArc, Tuple{Float64})
     end
 
@@ -201,6 +204,28 @@ using Test
                 drop!(rc2)
                 @test is_dropped(rc2)
             end
+
+            @testset "RustRc{Float32}" begin
+                rc = RustRc(Float32(3.14))
+                @test is_valid(rc)
+                rc2 = clone(rc)
+                @test rc.ptr == rc2.ptr
+                drop!(rc)
+                @test is_valid(rc2)
+                drop!(rc2)
+                @test is_dropped(rc2)
+            end
+
+            @testset "RustRc{Float64}" begin
+                rc = RustRc(Float64(2.71828))
+                @test is_valid(rc)
+                rc2 = clone(rc)
+                @test rc.ptr == rc2.ptr
+                drop!(rc)
+                @test is_valid(rc2)
+                drop!(rc2)
+                @test is_dropped(rc2)
+            end
         end
 
         @testset "RustArc Thread-Safe Reference Counting" begin
@@ -236,6 +261,17 @@ using Test
 
                 drop!(arc3)
                 @test is_dropped(arc3)
+            end
+
+            @testset "RustArc{Float32}" begin
+                arc = RustArc(Float32(1.41421))
+                @test is_valid(arc)
+                arc2 = clone(arc)
+                @test arc.ptr == arc2.ptr
+                drop!(arc)
+                @test is_valid(arc2)
+                drop!(arc2)
+                @test is_dropped(arc2)
             end
 
             @testset "RustArc{Float64}" begin


### PR DESCRIPTION
## Summary

- Add `rust_rc_new_f32`, `rust_rc_new_f64`, `rust_rc_clone_f32/f64`, `rust_rc_drop_f32/f64` to Rust helpers
- Add `rust_arc_new_f32`, `rust_arc_clone_f32`, `rust_arc_drop_f32` to Rust helpers
- Add Float32/Float64 dispatch branches in Julia `create_rust_rc`, `clone(::RustRc)`, `drop_rust_rc`
- Add Float32 dispatch branches in Julia `create_rust_arc`, `clone(::RustArc)`, `drop_rust_arc`
- Add convenience constructors: `RustRc(::Float32)`, `RustRc(::Float64)`, `RustArc(::Float32)`

Type support is now consistent across all ownership types:

| Type | RustBox | RustRc | RustArc |
|------|---------|--------|---------|
| Int32 | Yes | Yes | Yes |
| Int64 | Yes | Yes | Yes |
| Float32 | Yes | **Yes** | **Yes** |
| Float64 | Yes | **Yes** | Yes |

## Test plan

- [x] `RustRc{Float32}`: create, clone (shared pointer), drop one, drop last
- [x] `RustRc{Float64}`: create, clone (shared pointer), drop one, drop last
- [x] `RustArc{Float32}`: create, clone (shared pointer), drop one, drop last
- [x] Constructor `hasmethod` checks updated for new types
- [x] All 123 test groups pass (Ownership Types: 221 assertions, up from 206)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)