### PR TITLE
Track leaked pointers for deferred cleanup when helpers library unavailable (#77)

### DIFF
--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -101,6 +101,7 @@ export drop!, is_dropped, is_valid
 export clone  # For RustRc and RustArc
 export is_rust_helpers_available  # Check if Rust helpers library is loaded
 export get_rust_helpers_lib, get_rust_helpers_lib_path  # For testing and advanced usage
+export flush_deferred_drops, deferred_drop_count  # Deferred drop management
 
 # RustVec operations (Phase 2)
 export create_rust_vec, rust_vec_get, rust_vec_set!, copy_to_julia!, to_julia_vector


### PR DESCRIPTION
## Summary

- Replace silent memory leak in drop functions with a deferred drop queue that records pointers for later cleanup
- Automatically flush deferred drops when the Rust helpers library is loaded via `try_load_rust_helpers()`
- Export `flush_deferred_drops()` and `deferred_drop_count()` for manual leak management
- Use `maxlog=10` warnings instead of single-shot `DROP_WARNING_SHOWN` flag so users see multiple leak events
- Refactor drop functions (Box/Rc/Arc/Vec) to determine drop symbol up front, reducing code duplication

## Test plan

- [x] `DeferredDrop` infrastructure exists and is properly defined
- [x] `deferred_drop_count()` tracks queue size correctly
- [x] `_defer_drop` and `_defer_vec_drop` add entries to the queue
- [x] `flush_deferred_drops()` handles unknown symbols gracefully (no crash)
- [x] All existing ownership tests pass (234 assertions)
- [x] All 135 test groups pass (0 failures)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)