### PR TITLE
Use RustToolChain cargo command for test availability checks

### DIFF
--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -2,6 +2,7 @@
 
 using Test
 using RustCall
+using RustToolChain: cargo
 
 # Path to the sample crate
 const SAMPLE_CRATE_PATH = joinpath(dirname(@__DIR__), "examples", "sample_crate")
@@ -173,7 +174,7 @@ end
 
     # Check if cargo is available
     try
-        run(pipeline(`cargo --version`, devnull))
+        run(pipeline(`$(cargo()) --version`, devnull))
     catch
         @warn "Cargo not available, skipping integration tests"
         return
@@ -360,7 +361,7 @@ end
 
     # Check if cargo is available
     try
-        run(pipeline(`cargo --version`, devnull))
+        run(pipeline(`$(cargo()) --version`, devnull))
     catch
         @warn "Cargo not available, skipping precompilation tests"
         return

--- a/test/test_hot_reload.jl
+++ b/test/test_hot_reload.jl
@@ -2,6 +2,7 @@
 
 using Test
 using RustCall
+using RustToolChain: cargo
 
 # Path to the sample crate
 const SAMPLE_CRATE_PATH = joinpath(dirname(@__DIR__), "examples", "sample_crate")
@@ -160,7 +161,7 @@ end
 
     # Check if cargo is available
     try
-        run(pipeline(`cargo --version`, devnull))
+        run(pipeline(`$(cargo()) --version`, devnull))
     catch
         @warn "Cargo not available, skipping hot reload integration tests"
         return


### PR DESCRIPTION
## Summary
- replace direct `cargo --version` invocations in integration/precompilation/hot-reload tests with `RustToolChain.cargo()` command resolution
- add `using RustToolChain: cargo` to the affected test files
- keep skip-on-missing-cargo behavior intact while making command resolution toolchain-aware

## Verification
- README accuracy check: verified `Project Structure` and `Included Examples` entries in `README.md` against current repository directories
- `julia --project test/test_crate_bindings.jl`
- `julia --project test/test_hot_reload.jl`