### PR TITLE
[codex] fix @rust_crate function-scope usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,17 @@ p = MyCrate.Point(3.0, 4.0)
 MyCrate.distance(p)  # => 5.0
 ```
 
+Inside a function or other local scope, capture the return value from `@rust_crate`
+and call through that binding:
+
+```julia
+function load_my_crate(crate_path)
+    bindings = @rust_crate crate_path name="MyCrate"
+    p = bindings.Point(3.0, 4.0)
+    return bindings.add(Int32(1), Int32(2)), bindings.distance(p), p.x
+end
+```
+
 ## Type Mapping
 
 RustCall.jl automatically maps Rust types to Julia types:

--- a/docs/src/crate_bindings.md
+++ b/docs/src/crate_bindings.md
@@ -84,6 +84,18 @@ c.value        # => 1 (calls get_value)
 c.value = 5    # calls set_value
 ```
 
+When loading a crate inside a function or other local scope, capture the return
+value from `@rust_crate` and use that binding directly:
+
+```julia
+function load_my_library(crate_path)
+    bindings = @rust_crate crate_path name="MyLibrary"
+    c = bindings.Counter(Int32(0))
+    bindings.increment(c)
+    return bindings.get(c), c.value
+end
+```
+
 ## The `#[julia]` Attribute
 
 The `#[julia]` attribute simplifies FFI function definitions.

--- a/examples/sample_crate/README.md
+++ b/examples/sample_crate/README.md
@@ -58,6 +58,26 @@ sample_crate_path = joinpath(pkgdir(RustCall), "examples", "sample_crate")
 end
 ```
 
+### Usage in Functions
+
+```julia
+using RustCall
+
+function load_sample_crate()
+    sample_crate_path = joinpath(pkgdir(RustCall), "examples", "sample_crate")
+    bindings = @rust_crate sample_crate_path name="SampleCrateFunctionScope"
+
+    p = bindings.Point(3.0, 4.0)
+    return (
+        bindings.add(Int32(2), Int32(3)),
+        bindings.distance_from_origin(p),
+        p.x,
+    )
+end
+
+load_sample_crate()  # => (5, 5.0, 3.0)
+```
+
 ## Included Features
 
 ### Simple Functions

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1133,6 +1133,92 @@ function get_function_pointer_from_lib(lib_handle::Ptr{Cvoid}, func_name::String
     Libdl.dlsym(lib_handle, func_name)
 end
 
+struct CrateBindingsProxy
+    module_ref::Module
+end
+
+struct CrateBindingMemberProxy
+    bindings::CrateBindingsProxy
+    name::Symbol
+end
+
+struct CrateBindingObjectProxy
+    bindings::CrateBindingsProxy
+    value::Any
+end
+
+_unwrap_crate_binding_value(value) = value
+_unwrap_crate_binding_value(value::CrateBindingObjectProxy) = getfield(value, :value)
+
+function _wrap_crate_binding_value(bindings::CrateBindingsProxy, value)
+    if value isa CrateBindingsProxy || value isa CrateBindingMemberProxy || value isa CrateBindingObjectProxy
+        return value
+    end
+
+    if value isa Module
+        return CrateBindingsProxy(value)
+    end
+
+    if value !== nothing && parentmodule(typeof(value)) === getfield(bindings, :module_ref)
+        return CrateBindingObjectProxy(bindings, value)
+    end
+
+    return value
+end
+
+function Base.getproperty(bindings::CrateBindingsProxy, name::Symbol)
+    if name === :module_ref
+        return getfield(bindings, :module_ref)
+    end
+
+    module_ref = getfield(bindings, :module_ref)
+    if !isdefined(module_ref, name)
+        error("module $(nameof(module_ref)) has no binding $name")
+    end
+
+    return CrateBindingMemberProxy(bindings, name)
+end
+
+Base.propertynames(bindings::CrateBindingsProxy, private::Bool=false) = names(getfield(bindings, :module_ref); all=private)
+
+function (member::CrateBindingMemberProxy)(args...)
+    bindings = getfield(member, :bindings)
+    module_ref = getfield(bindings, :module_ref)
+    binding_name = getfield(member, :name)
+    callable = Base.invokelatest(getproperty, module_ref, binding_name)
+    result = Base.invokelatest(callable, map(_unwrap_crate_binding_value, args)...)
+    return _wrap_crate_binding_value(bindings, result)
+end
+
+function Base.getproperty(proxy::CrateBindingObjectProxy, name::Symbol)
+    if name === :bindings || name === :value
+        return getfield(proxy, name)
+    end
+
+    value = getfield(proxy, :value)
+    result = Base.invokelatest(getproperty, value, name)
+    return _wrap_crate_binding_value(getfield(proxy, :bindings), result)
+end
+
+function Base.setproperty!(proxy::CrateBindingObjectProxy, name::Symbol, value)
+    if name === :bindings || name === :value
+        error("cannot set internal proxy field $name")
+    end
+
+    target = getfield(proxy, :value)
+    raw_value = _unwrap_crate_binding_value(value)
+    result = Base.invokelatest(setproperty!, target, name, raw_value)
+    return _wrap_crate_binding_value(getfield(proxy, :bindings), result)
+end
+
+function Base.propertynames(proxy::CrateBindingObjectProxy, private::Bool=false)
+    Base.invokelatest(propertynames, getfield(proxy, :value), private)
+end
+
+Base.show(io::IO, bindings::CrateBindingsProxy) = print(io, "CrateBindingsProxy(", nameof(getfield(bindings, :module_ref)), ")")
+Base.show(io::IO, member::CrateBindingMemberProxy) = print(io, nameof(getfield(getfield(member, :bindings), :module_ref)), ".", getfield(member, :name))
+Base.show(io::IO, proxy::CrateBindingObjectProxy) = show(io, getfield(proxy, :value))
+
 # ============================================================================
 # @rust_crate Macro
 # ============================================================================
@@ -1191,7 +1277,8 @@ macro rust_crate(path, options...)
             build_release = $release,
             cache_enabled = $cache
         )
-        Core.eval($__module__, bindings)
+        local crate_module = Base.invokelatest(Core.eval, $__module__, bindings)
+        CrateBindingsProxy(crate_module)
     end
 end
 

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -353,6 +353,34 @@ end
     end
 end
 
+@testset "Function Scope Usage" begin
+    if !isdir(SAMPLE_CRATE_PATH)
+        @warn "Sample crate not found, skipping function scope usage tests"
+        return
+    end
+
+    try
+        run(pipeline(`$(cargo()) --version`, devnull))
+    catch
+        @warn "Cargo not available, skipping function scope usage tests"
+        return
+    end
+
+    function use_bindings_in_function(crate_path)
+        bindings = @rust_crate crate_path name="SampleCrateFunctionScope"
+
+        sum_result = bindings.add(Int32(2), Int32(3))
+        point = bindings.Point(3.0, 4.0)
+        distance = bindings.distance_from_origin(point)
+        original_x = point.x
+        point.x = 10.0
+
+        return (sum_result, distance, original_x, point.x)
+    end
+
+    @test use_bindings_in_function(SAMPLE_CRATE_PATH) == (Int32(5), 5.0, 3.0, 10.0)
+end
+
 @testset "Precompilation Support" begin
     if !isdir(SAMPLE_CRATE_PATH)
         @warn "Sample crate not found, skipping precompilation tests"


### PR DESCRIPTION
## Summary

Fix `@rust_crate` when used inside a function or other local scope on Julia 1.12 by returning a world-age-safe proxy while preserving the existing top-level module-generation behavior.

## What Changed

- changed `@rust_crate` to evaluate generated bindings via `Base.invokelatest` and return a `CrateBindingsProxy`
- added proxy types that forward function calls, struct construction, property reads, and property writes through world-age-safe access paths
- added a regression test covering function-scope use of `@rust_crate`
- documented the supported local-scope pattern in the README, crate-bindings docs, and sample crate README

## Root Cause

`@rust_crate` used `Core.eval($__module__, bindings)` to create a fresh module and then expected callers in the same function/closure to use methods defined in that just-created module immediately. On Julia 1.12, those bindings and methods are in a newer world age, so direct calls from the current function frame fail with `MethodError` and world-age warnings.

## Impact

Users can now write code like this safely inside helper functions:

```julia
bindings = @rust_crate crate_path name="MyCrate"
bindings.add(Int32(1), Int32(2))
```

The existing top-level pattern still works:

```julia
@rust_crate crate_path name="MyCrate"
MyCrate.add(Int32(1), Int32(2))
```

## Validation

- `julia --project -e 'using Pkg; Pkg.instantiate(); include("test/test_crate_bindings.jl")'`
