### PR TITLE
[codex] fix documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,31 +394,34 @@ using RustCall
 if RustCall.is_rust_helpers_available()
     # RustBox - heap-allocated value (single ownership)
     box = RustCall.RustBox(Int32(42))
-    @test RustCall.is_valid(box)
+    RustCall.is_valid(box)  # => true
     RustCall.drop!(box)  # Explicitly drop
-    @test RustCall.is_dropped(box)
+    RustCall.is_dropped(box)  # => true
 
     # RustRc - reference counting (single-threaded)
     rc1 = RustCall.RustRc(Int32(100))
     rc2 = RustCall.clone(rc1)  # Increment reference count
     RustCall.drop!(rc1)  # Still valid because rc2 holds a reference
-    @test RustCall.is_valid(rc2)
+    RustCall.is_valid(rc2)  # => true
     RustCall.drop!(rc2)
 
     # RustArc - atomic reference counting (thread-safe)
     arc1 = RustCall.RustArc(Int32(200))
     arc2 = RustCall.clone(arc1)  # Thread-safe clone
     RustCall.drop!(arc1)
-    @test RustCall.is_valid(arc2)
+    RustCall.is_valid(arc2)  # => true
     RustCall.drop!(arc2)
 
-    # RustVec - growable array
-    vec = RustCall.RustVec{Int32}(ptr, len, cap)
-    @test length(vec) == len
+    # RustVec - growable array backed by Rust-managed memory
+    vec = RustCall.create_rust_vec(Int32[1, 2, 3])
+    vec[1] = 42
+    collect(vec)  # => Int32[42, 2, 3]
+    RustCall.drop!(vec)
 
-    # RustSlice - slice view
-    slice = RustCall.RustSlice{Int32}(ptr, len)
-    @test length(slice) == len
+    # RustSlice - borrowed view into existing memory
+    julia_vec = Int32[10, 20, 30]
+    slice = RustCall.RustSlice{Int32}(pointer(julia_vec), UInt(length(julia_vec)))
+    slice[2]  # => 20
 end
 ```
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,9 @@ Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
 RustToolChain = "e9dc52e2-edb8-4742-9783-5e542d30dbb5"
 
+[sources]
+RustCall = { path = ".." }
+
 [compat]
 Documenter = "1"
 RustToolChain = "0.1.1"

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -912,18 +912,18 @@ const IRUST_FUNCTIONS = Dict{UInt64, Tuple{String, String}}()
 Execute Rust code at function scope.
 
 This macro compiles Rust code into a temporary function and calls it.
-Julia variables can be referenced using `\$var` syntax or passed as arguments.
+Julia variables can be referenced using `\\\$var` syntax or passed as arguments.
 
 # Features
-- Automatic variable binding with `\$var` syntax
+- Automatic variable binding with `\\\$var` syntax
 - Improved type inference from code
 - Better error messages
 
 # Examples
 ```julia
-# Using \$var syntax (recommended)
+# Using \\\$var syntax (recommended)
 function myfunc(x)
-    @irust("\$x * 2")
+    @irust("\\\$x * 2")
 end
 
 # Using explicit arguments (legacy, still supported)
@@ -933,7 +933,7 @@ end
 
 # Multiple variables
 function add_and_multiply(a, b, c)
-    @irust("\$a + \$b * \$c")
+    @irust("\\\$a + \\\$b * \\\$c")
 end
 ```
 
@@ -990,12 +990,12 @@ end
 """
     _parse_irust_variables(code::String) -> (Vector{Symbol}, String)
 
-Parse `\$var` syntax in irust code and extract variable names.
-Returns (list of variable symbols, processed code with \$var replaced by argN).
+Parse `\\\$var` syntax in irust code and extract variable names.
+Returns (list of variable symbols, processed code with `\\\$var` replaced by argN).
 
 # Example
 ```julia
-vars, code = _parse_irust_variables("\$x + \$y * 2")
+vars, code = _parse_irust_variables("\\\$x + \\\$y * 2")
 # vars = [:x, :y]
 # code = "arg1 + arg2 * 2"
 ```


### PR DESCRIPTION
## Summary

This updates the published documentation so the documented flows match the current repository behavior.

- replace the README ownership snippet with a runnable example that does not rely on `@test` or undefined `ptr`/`len`/`cap` values
- make the docs environment resolve the local checkout via `docs/Project.toml` so `julia --project=docs -e 'using Pkg; Pkg.instantiate()'` works from a clone
- escape literal `@irust` `$var` syntax correctly in the API docstrings so the docs build no longer emits the previous interpolation warning

## Root Cause

The docs had drifted in three places:

- the README ownership section still contained partial test-style code instead of a copy-pasteable user example
- the docs project expected `RustCall` to be registered instead of using the local checkout
- the `@irust` docstrings rendered literal `$var` text in a way that Documenter treated as interpolation during HTML generation

## Impact

- readers can now run the README ownership example as shown
- contributors can instantiate the docs environment directly from the repository checkout
- `docs/make.jl` no longer emits the old `api.md` interpolation warning

## Validation

- `julia --project -e 'using RustCall'`
- `julia --project=docs -e 'using Pkg; Pkg.instantiate()'`
- direct execution of the revised ownership snippet
- `julia --project=docs docs/make.jl`

## Notes

The generated feature-test report from the earlier docs audit was left uncommitted and is not part of this PR.