### PR TITLE
[codex] fix struct documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ result = @rust process_data(Int32(21))::Int32
 
 ## Rust Structs as Julia Objects (Phase 4)
 
-RustCall.jl automatically detects `pub struct` definitions and generates Julia wrappers, allowing you to use Rust objects as first-class Julia types.
+RustCall.jl generates Julia wrappers for Rust structs marked with `#[julia]`, allowing you to use Rust objects as first-class Julia types.
 
 ### Basic Struct Usage
 
@@ -619,6 +619,7 @@ using RustCall
 
 # Define a Rust struct with methods
 rust"""
+#[julia]
 pub struct Person {
     age: u32,
     height: f64,
@@ -656,6 +657,7 @@ height = get_height(person)
 using RustCall
 
 rust"""
+#[julia]
 pub struct Point<T> {
     x: T,
     y: T,
@@ -687,6 +689,7 @@ Rust structs are automatically managed with finalizers that call Rust's `Drop` i
 using RustCall
 
 rust"""
+#[julia]
 pub struct Resource {
     data: Vec<u8>,
 }

--- a/docs/src/struct_mapping.md
+++ b/docs/src/struct_mapping.md
@@ -212,8 +212,9 @@ println(pair_float.first)   # => 3.14
 println(pair_float.second)  # => 2.71
 ```
 
-!!! note "Future Feature"
-    Generic struct support is planned for a future release.
+!!! note
+    Generic struct support works for examples like `Pair{Int32}` and `Pair{Float64}` shown above.
+    More complex patterns may still need additional testing.
 
 
 ## Memory Management
@@ -264,14 +265,21 @@ println(calc.get_value())  # => 0.0
 
 ## Static Methods
 
-Static methods (methods without `self`) are also supported:
+Static methods (methods without `self`) are supported on `#[derive(JuliaStruct)]`
+types with fields:
 
 ```julia
 rust"""
 #[derive(JuliaStruct)]
-pub struct MathUtils;
+pub struct MathUtils {
+    dummy: i32,
+}
 
 impl MathUtils {
+    pub fn new() -> Self {
+        MathUtils { dummy: 0 }
+    }
+
     pub fn add(a: f64, b: f64) -> f64 {
         a + b
     }
@@ -282,14 +290,15 @@ impl MathUtils {
 }
 """
 
-# Create an instance and call methods
+# Create an instance and call static methods
 utils = MathUtils()
-result1 = utils.add(3.0, 4.0)      # => 7.0
-result2 = utils.multiply(3.0, 4.0) # => 12.0
+result1 = add(3.0, 4.0)      # => 7.0
+result2 = multiply(3.0, 4.0) # => 12.0
 ```
 
-!!! note "Future Feature"
-    Unit struct (struct without fields) support is planned for a future release.
+!!! note
+    Unit struct support is still planned for a future release, so the example
+    above uses a regular struct.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

This PR fixes the struct-related documentation examples that were inconsistent with current RustCall behavior.

## What Changed

- Updated the Phase 4 struct examples in `README.md` to use `#[julia]` where Julia wrappers are expected to be generated.
- Clarified the README text so it describes the supported struct-wrapper path accurately.
- Updated `docs/src/struct_mapping.md` to reflect that the documented generic struct example works.
- Replaced the broken unit-struct static method example with a supported non-unit struct example.
- Clarified that unit struct support is still future work.

## Why

A docs-driven verification pass found that some examples looked runnable but did not work as written.

## Root Cause

The docs had drifted from the implementation details of struct wrapper generation:

- The README implied that plain `pub struct` definitions automatically produced Julia bindings.
- `struct_mapping.md` still described generic struct support as future work even though the documented example worked.
- The same page included a unit-struct example even though unit struct support is not implemented yet.

## Impact

- Readers can now copy the documented struct examples and run them successfully.
- The docs no longer mix supported behavior with unsupported examples.
- The struct mapping guidance is more consistent for downstream users evaluating the package.

## Validation

- `julia --project <<'EOF' ...` targeted re-test for the corrected README struct examples
- `julia --project <<'EOF' ...` targeted re-test for the corrected `struct_mapping.md` examples
- `julia --project=docs docs/make.jl`
