### PR TITLE
[codex] fix safe_divide documentation example

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -611,22 +611,20 @@ Use error codes or Result types for safe error handling:
 ```julia
 rust"""
 #[no_mangle]
-pub extern "C" fn safe_divide(a: i32, b: i32, result: *mut i32) -> bool {
+pub extern "C" fn safe_divide(a: i32, b: i32) -> i32 {
     if b == 0 {
-        return false;  // Indicate error
+        return -1;  // Indicate error
     }
-    unsafe { *result = a / b; }
-    true  // Indicate success
+    a / b
 }
 """
 
 function divide_safely(a::Int32, b::Int32)
-    result = Ref{Int32}(0)
-    success = @rust safe_divide(a, b, result)::Bool
-    if !success
+    result = @rust safe_divide(a, b)::Int32
+    if result == -1
         throw(DomainError(b, "Division by zero"))
     end
-    return result[]
+    return result
 end
 
 # Test successful division


### PR DESCRIPTION
## Summary

This PR fixes the `safe_divide` example in `docs/src/examples.md` so it matches a pattern that actually works with the current RustCall calling model.

## What Changed

- Replaced the out-parameter `safe_divide(a, b, result_ptr) -> bool` example with an error-code `safe_divide(a, b) -> i32` example.
- Updated the Julia wrapper to check for `-1` and throw `DomainError` on division by zero.

## Why

A docs-driven verification pass found that the documented out-parameter version segfaulted when run as written.

## Root Cause

The docs had drifted from the patterns already exercised by the repository's tests. The out-parameter example looked plausible, but the documented Julia wrapper path was not safe in practice for this example. The repository already validated an error-code version of the same flow, so the docs should describe that proven pattern instead.

## Impact

- Readers can now run the `safe_divide` example without crashing Julia.
- The examples guide is more consistent with the package's tested behavior.
- The error-handling section now demonstrates a safer documented pattern.

## Validation

- `julia --project <<'EOF' ...` targeted re-test for the corrected `safe_divide` example
- `julia --project=docs docs/make.jl`
