### PR TITLE
[codex] fix crate binding constructor proxy

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -206,8 +206,8 @@ RustCall.get_cargo_cache_size
 The explicit-binding runtime contract is:
 
 - `@rust_crate` and `RustCall.load_crate_bindings` return a `RustCall.CrateBindings` value.
-- Property access preserves non-function bindings such as types and constants.
-- Callable exported functions remain proxy-backed so calls stay world-age-safe.
+- Property access preserves non-callable bindings such as constants and modules.
+- Callable exports, including generated constructors, remain proxy-backed so calls stay world-age-safe.
 
 ```@docs
 RustCall.CrateBindings

--- a/examples/README.md
+++ b/examples/README.md
@@ -106,7 +106,6 @@ SampleCrate.add(Int32(1), Int32(2))
 
 # Structs with property access
 p = SampleCrate.Point(3.0, 4.0)
-p isa SampleCrate.Point  # => true
 p.x  # => 3.0
 p.y  # => 4.0
 SampleCrate.distance_from_origin(p)  # => 5.0

--- a/examples/sample_crate/README.md
+++ b/examples/sample_crate/README.md
@@ -21,7 +21,6 @@ SampleCrate.add(Int32(2), Int32(3))  # => 5
 
 # Using structs
 p = SampleCrate.Point(3.0, 4.0)
-p isa SampleCrate.Point  # => true
 SampleCrate.distance_from_origin(p)  # => 5.0
 
 # Property access
@@ -45,7 +44,6 @@ const SampleCrate = @rust_crate sample_crate_path
 @testset "SampleCrate" begin
     @testset "Point" begin
         p = SampleCrate.Point(3.0, 4.0)
-        @test p isa SampleCrate.Point
         @test SampleCrate.distance_from_origin(p) == 5.0
         @test p.x == 3.0
         @test p.y == 4.0

--- a/examples/sample_crate/example.jl
+++ b/examples/sample_crate/example.jl
@@ -25,7 +25,6 @@ const SampleCrate = @rust_crate sample_crate_path
 
 @testset "distance_from_origin" begin
     p = SampleCrate.Point(3.0, 4.0)
-    @test p isa SampleCrate.Point
     @test SampleCrate.distance_from_origin(p) == 5.0
     # Access fields using property access syntax
     @test p.x == 3.0

--- a/examples/sample_crate_pyo3/README.md
+++ b/examples/sample_crate_pyo3/README.md
@@ -100,7 +100,6 @@ SampleCratePyo3.fibonacci(10)        # => 55
 
 # Point struct
 p = SampleCratePyo3.Point(3.0, 4.0)
-p isa SampleCratePyo3.Point          # => true
 p.x, p.y                             # => 3.0, 4.0
 SampleCratePyo3.distance_from_origin(p)  # => 5.0
 SampleCratePyo3.translate(p, 1.0, 2.0)

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1138,9 +1138,9 @@ end
 
 Runtime wrapper returned by `@rust_crate` and [`load_crate_bindings`](@ref).
 
-Property access preserves non-function exports such as types and constants,
-while exported functions are routed through a proxy so calls remain
-world-age-safe after dynamic loading.
+Property access preserves non-callable exports such as constants and modules,
+while callable exports such as functions and constructors are routed through
+proxies so calls remain world-age-safe after dynamic loading.
 """
 struct CrateBindings
     module_ref::Module
@@ -1159,7 +1159,7 @@ end
 _unwrap_crate_binding_value(value) = value
 _unwrap_crate_binding_value(value::CrateBindingObject) = getfield(value, :value)
 
-_should_proxy_crate_binding(value) = value isa Function
+_should_proxy_crate_binding(value) = value isa Function || value isa Type
 
 function _wrap_crate_binding_value(bindings::CrateBindings, value)
     if value isa CrateBindings || value isa CrateBindingMember || value isa CrateBindingObject
@@ -1251,7 +1251,7 @@ Use the returned [`CrateBindings`](@ref) value directly:
 const MyCrate = load_crate_bindings("/path/to/my_crate")
 MyCrate.add(Int32(1), Int32(2))
 p = MyCrate.Point(3.0, 4.0)
-p isa MyCrate.Point
+p.x == 3.0
 ```
 
 `output_module_name` controls the generated runtime module name stored inside the

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -354,9 +354,9 @@ function _run_top_level_explicit_binding_contract()
         const SampleCrateContract = @rust_crate raw\"$(abspath(SAMPLE_CRATE_PATH))\" name=\"SampleCrateInjected\"
 
         @test SampleCrateContract.add(Int32(2), Int32(3)) == Int32(5)
-        @test SampleCrateContract.Point isa DataType
+        @test SampleCrateContract.Point isa RustCall.CrateBindingMember
         point = SampleCrateContract.Point(3.0, 4.0)
-        @test point isa SampleCrateContract.Point
+        @test point isa RustCall.CrateBindingObject
         @test SampleCrateContract.distance_from_origin(point) == 5.0
         @test point.x == 3.0
         @test !isdefined(Main, :SampleCrateInjected)
@@ -407,13 +407,13 @@ end
         bindings = @rust_crate crate_path name="SampleCrateFunctionScope"
 
         sum_result = bindings.add(Int32(2), Int32(3))
-        point_type = bindings.Point
-        point = Base.invokelatest(point_type, 3.0, 4.0)
+        @assert bindings.Point isa RustCall.CrateBindingMember
+        point = bindings.Point(3.0, 4.0)
         distance = bindings.distance_from_origin(point)
-        original_x = Base.invokelatest(getproperty, point, :x)
-        Base.invokelatest(setproperty!, point, :x, 10.0)
+        original_x = point.x
+        point.x = 10.0
 
-        return (sum_result, distance, original_x, Base.invokelatest(getproperty, point, :x))
+        return (sum_result, distance, original_x, point.x)
     end
 
     @test use_bindings_in_function(SAMPLE_CRATE_PATH) == (Int32(5), 5.0, 3.0, 10.0)

--- a/test/test_docs_examples.jl
+++ b/test/test_docs_examples.jl
@@ -499,11 +499,11 @@ const _DOCS_SAMPLE_CRATE_AVAILABLE = isdir(DOCS_SAMPLE_CRATE_PATH)
             # @rust_crate should return a local bindings value, not inject a module into Main.
             let DocsSampleCrate = @rust_crate DOCS_SAMPLE_CRATE_PATH name="DocsSampleCrateInjected"
                 @test DocsSampleCrate.add(Int32(1), Int32(2)) == Int32(3)
-                @test DocsSampleCrate.Point isa DataType
-                point = Base.invokelatest(DocsSampleCrate.Point, 3.0, 4.0)
-                @test point isa DocsSampleCrate.Point
+                @test DocsSampleCrate.Point isa RustCall.CrateBindingMember
+                point = DocsSampleCrate.Point(3.0, 4.0)
+                @test point isa RustCall.CrateBindingObject
                 @test DocsSampleCrate.distance_from_origin(point) == 5.0
-                @test Base.invokelatest(getproperty, point, :x) == 3.0
+                @test point.x == 3.0
                 @test !isdefined(Main, :DocsSampleCrateInjected)
             end
         else


### PR DESCRIPTION
## Summary
- route callable type exports like generated struct constructors through `CrateBindingMember` so `bindings.Point(...)` stays world-age-safe
- update regression tests to assert the proxy-backed constructor contract in both crate-binding and docs example coverage
- align API/docs/examples with the callable-export contract instead of advertising raw `DataType` returns

## Why
The explicit `CrateBindings` redesign kept raw type exports for constructors, which reintroduced a world-age failure when dynamically loaded bindings were called from already-compiled code paths.

## Validation
- `julia --project test/test_crate_bindings.jl`
- `julia --project test/test_docs_examples.jl`
- `julia --project examples/sample_crate/example.jl`
- `julia --project=docs -e 'using Pkg; Pkg.instantiate()'`
- `julia --project=docs docs/make.jl`

## Notes
- Left `docs/test-reports/` uncommitted because it is a generated local artifact from feature testing.