### PR TITLE
[codex] fix example setup and crate binding display

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ This will compile the Rust helpers library that provides FFI functions for owner
 
 ## Quick Start
 
+If you are running these examples from a source checkout of this repository, instantiate the project first:
+
+```julia
+using Pkg
+Pkg.instantiate()
+```
+
 ### 1. Define and Call Rust Functions (Simple Way)
 
 ```julia
@@ -156,6 +163,8 @@ pub extern "C" fn random_number() -> i32 {
 
 @rust random_number()::Int32  # => random number 1-100
 ```
+
+This path downloads crates from the Rust registry, so it requires network access the first time you run it.
 
 ### 5. Rust Structs as Julia Objects
 

--- a/examples/MyExample.jl/Project.toml
+++ b/examples/MyExample.jl/Project.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Your Name <your.email@example.com>"]
 
 [deps]
-RustCall = "84591b13-8127-4a16-8156-1f71d7525150"
+RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
 
 [compat]
 julia = "1.10"

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -752,6 +752,16 @@ function _generate_crate_struct_wrapper(info::RustStructInfo)
             end
         end
         export $struct_name
+
+        function Base.show(io::IO, self::$struct_name)
+            print(io, nameof(@__MODULE__), ".", $struct_name_str, "(")
+            show(io, getfield(self, :ptr))
+            print(io, ")")
+        end
+
+        function Base.show(io::IO, ::MIME"text/plain", self::$struct_name)
+            Base.show(io, self)
+        end
     end)
 
     # Generate constructor and method wrappers
@@ -1233,7 +1243,22 @@ end
 
 Base.show(io::IO, bindings::CrateBindings) = print(io, "CrateBindings(", nameof(getfield(bindings, :module_ref)), ")")
 Base.show(io::IO, member::CrateBindingMember) = print(io, nameof(getfield(getfield(member, :bindings), :module_ref)), ".", getfield(member, :name))
-Base.show(io::IO, proxy::CrateBindingObject) = show(io, getfield(proxy, :value))
+
+function _show_crate_binding_object(io::IO, proxy::CrateBindingObject)
+    value = getfield(proxy, :value)
+    module_name = nameof(getfield(getfield(proxy, :bindings), :module_ref))
+    type_name = nameof(typeof(value))
+
+    print(io, module_name, ".", type_name, "(")
+    for (idx, field_name) in enumerate(fieldnames(typeof(value)))
+        idx > 1 && print(io, ", ")
+        show(io, getfield(value, field_name))
+    end
+    print(io, ")")
+end
+
+Base.show(io::IO, proxy::CrateBindingObject) = _show_crate_binding_object(io, proxy)
+Base.show(io::IO, ::MIME"text/plain", proxy::CrateBindingObject) = _show_crate_binding_object(io, proxy)
 
 function _instantiate_runtime_bindings(bindings_expr::Expr)
     runtime_namespace = Module(gensym(:RustCallCrateRuntime))
@@ -1685,6 +1710,14 @@ function _emit_struct_code(info::RustStructInfo)
     push!(lines, "    end")
     push!(lines, "end")
     push!(lines, "export $struct_name")
+    push!(lines, "function Base.show(io::IO, self::$struct_name)")
+    push!(lines, "    print(io, nameof(@__MODULE__), \".$struct_name(\")")
+    push!(lines, "    show(io, getfield(self, :ptr))")
+    push!(lines, "    print(io, \")\")")
+    push!(lines, "end")
+    push!(lines, "function Base.show(io::IO, ::MIME\"text/plain\", self::$struct_name)")
+    push!(lines, "    Base.show(io, self)")
+    push!(lines, "end")
     push!(lines, "")
 
     # Method wrappers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using ParallelTestRunner
 args = parse_args(ARGS)
 testsuite = find_tests(@__DIR__)
 serial_testsuite = Dict{String, Expr}()
-serial_test_names = ("test_cache", "test_core_api")
+serial_test_names = ("test_cache", "test_core_api", "test_cargo")
 
 for test_name in collect(keys(testsuite))
     basename = split(test_name, '/')[end]

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -357,6 +357,9 @@ function _run_top_level_explicit_binding_contract()
         @test SampleCrateContract.Point isa DataType
         point = SampleCrateContract.Point(3.0, 4.0)
         @test point isa SampleCrateContract.Point
+        point_display = sprint(show, point)
+        @test occursin("SampleCrateInjected.Point(", point_display)
+        @test !occursin("RustCallCrateRuntime", point_display)
         @test SampleCrateContract.distance_from_origin(point) == 5.0
         @test point.x == 3.0
         @test !isdefined(Main, :SampleCrateInjected)


### PR DESCRIPTION
## Summary
- fix the `MyExample.jl` example package to depend on the real `RustCall` package UUID
- document the source-checkout `Pkg.instantiate()` prerequisite and the network requirement for `cargo-deps` examples
- clean up `@rust_crate`-generated struct display so user-visible values no longer expose the internal runtime module name
- add a regression test covering the display contract for generated crate bindings

## Why
The example package setup path was broken because `examples/MyExample.jl/Project.toml` pointed at the wrong UUID, so the documented `Pkg.develop(path="../../")` flow could not succeed. Separately, values produced through `@rust_crate` displayed internal `RustCallCrateRuntime` names, which leaked implementation details into user-facing output.

## Impact
Users can now follow the beginner example package instructions successfully from a local checkout, the top-level docs describe the necessary local setup more clearly, and `@rust_crate` values render with the public module name instead of the internal runtime namespace.

## Root Cause
- `MyExample.jl` had a stale `RustCall` dependency UUID in its example `Project.toml`
- generated crate-binding struct wrappers relied on Julia's default display, which used the hidden runtime module path

## Validation
- `julia --project test/test_crate_bindings.jl`
- `julia --project test/test_docs_examples.jl`
- `julia --project=. test/runtests.jl` (in `examples/MyExample.jl`)
