### PR TITLE
[codex] clarify @rust docs and add CLAUDE git workflow guidance

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -91,6 +91,12 @@ result = @rust multiply(Int32(5), Int32(7))::Int32
 println(result)  # => 35
 ```
 
+#### Why `@rust` here?
+
+`#[julia]` exposes a Rust function through a C-compatible ABI and also generates a Julia wrapper, so you can call `add(10, 20)` directly from Julia.
+
+By contrast, `#[no_mangle] pub extern "C"` only exports a symbol from the Rust library. Julia does not automatically get a function named `multiply`, so `@rust` is the bridge that finds the exported symbol, converts the arguments, and performs the call.
+
 ### Step 1: Define and Compile Rust Code
 
 Use the `rust""` string literal to define and compile Rust code:


### PR DESCRIPTION
## Summary
- add a short tutorial subsection explaining why manual FFI calls use `@rust`
- add `CLAUDE.md` guidance that forbids direct commits to `main` / `master` and requires topic branches plus draft PRs
- keep both changes scoped to documentation and repository guidance only

## Why
The tutorial previously showed two calling styles without explaining why `#[julia]` functions can be called directly while manual FFI requires `@rust`. In addition, the repository guidance did not explicitly document the expected branch-and-PR workflow for agent-authored changes.

## Impact
Readers should have a clearer mental model of the manual FFI path, and future agent work should follow a documented branch-based workflow instead of committing on `main`.

## Validation
- `julia --project=docs docs/make.jl`
- `julia --project -e 'using Pkg; Pkg.test()'` currently fails in `test/test_core_api.jl` at `Optimization passes are not no-ops` with an LLVM IR parse error (`unterminated attribute group`)