### PR TITLE
[codex] add git workflow guidance to CLAUDE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,10 @@ Two jobs in `.github/workflows/CI.yml`:
 - Add tests alongside new functionality; include regression coverage for macro/parsing changes
 - `Cxx.jl/` and `julia/` are vendored upstream trees — do not edit for RustCall features
 - **Minimal exports**: Only macros (`@rust`, `@rust_str`, `@irust`, `@irust_str`, `@rust_llvm`, `@rust_crate`) are exported. All other identifiers should be accessed via `RustCall.XXX` or `using RustCall: XXX`. Do not add new `export` statements unless the identifier is a macro intended for end-user use.
+
+## Git Workflow
+
+- Do not commit directly to `main` or `master`
+- Create a topic branch for any implementation or documentation change
+- Push the topic branch and open a draft PR for review-oriented sharing
+- If work is accidentally committed on `main`, move it onto a topic branch and reset local `main` back to `origin/main`


### PR DESCRIPTION
## Summary
- add a `Git Workflow` section to `CLAUDE.md`
- document that agent-authored changes should not be committed directly to `main` / `master`
- require topic branches, draft PRs, and explicit recovery when work lands on `main` by mistake

## Why
The repository guidance described architecture and coding conventions, but it did not document the expected branch-and-PR workflow for agent-authored changes. This update makes that policy explicit in the repository instructions.

## Impact
Future agent work should follow the documented branch-based workflow instead of committing directly on the default branch.

## Validation
- `julia --project=docs docs/make.jl`
- `julia --project -e 'using Pkg; Pkg.test()'` currently fails in `test/test_core_api.jl` at `Optimization passes are not no-ops` with an LLVM IR parse error (`unterminated attribute group`)