### PR TITLE
[codex] fix crate binding runtime wrappers

### DIFF
--- a/examples/sample_crate_pyo3/main.jl
+++ b/examples/sample_crate_pyo3/main.jl
@@ -13,7 +13,7 @@ println("Loading sample_crate_pyo3 with @rust_crate...")
 println("=" ^ 60)
 
 crate_path = @__DIR__
-@rust_crate crate_path
+const SampleCratePyo3 = @rust_crate crate_path
 
 println("\n✅ Crate loaded as module: SampleCratePyo3\n")
 

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -518,7 +518,7 @@ function emit_crate_module(info::CrateInfo, lib_path::String; module_name::Union
 
     # Build the module body as a block
     module_body = quote
-        import RustCall: call_rust_function, get_function_pointer_from_lib, _check_not_freed
+        import RustCall: call_rust_function, get_function_pointer_from_lib, RustResult, RustOption, _check_not_freed
         import Libdl
 
         const _LIB_PATH = $lib_path
@@ -652,9 +652,9 @@ function _generate_result_function_wrapper(func::RustFunctionSignature, result_i
             c_result = call_rust_function(func_ptr, $c_result_struct_name, $(converted_args...))
             # Convert to RustResult
             if c_result.is_ok == 1
-                RustCall.RustResult{$ok_julia_type, $err_julia_type}(true, c_result.ok_value)
+                RustResult{$ok_julia_type, $err_julia_type}(true, c_result.ok_value)
             else
-                RustCall.RustResult{$ok_julia_type, $err_julia_type}(false, c_result.err_value)
+                RustResult{$ok_julia_type, $err_julia_type}(false, c_result.err_value)
             end
         end
         export $func_name
@@ -693,9 +693,9 @@ function _generate_option_function_wrapper(func::RustFunctionSignature, option_i
             c_option = call_rust_function(func_ptr, $c_option_struct_name, $(converted_args...))
             # Convert to RustOption
             if c_option.is_some == 1
-                RustCall.RustOption{$inner_julia_type}(true, c_option.value)
+                RustOption{$inner_julia_type}(true, c_option.value)
             else
-                RustCall.RustOption{$inner_julia_type}(false, nothing)
+                RustOption{$inner_julia_type}(false, nothing)
             end
         end
         export $func_name

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -6,6 +6,7 @@ using RustToolChain: cargo
 
 # Path to the sample crate
 const SAMPLE_CRATE_PATH = joinpath(dirname(@__DIR__), "examples", "sample_crate")
+const SAMPLE_CRATE_PYO3_PATH = joinpath(dirname(@__DIR__), "examples", "sample_crate_pyo3")
 
 @testset "Crate Bindings" begin
 
@@ -393,6 +394,43 @@ end
     end
 end
 
+@testset "Result and Option Runtime Wrappers" begin
+    if !isdir(SAMPLE_CRATE_PATH)
+        @warn "Sample crate not found, skipping Result/Option wrapper tests"
+        return
+    end
+
+    try
+        run(pipeline(`$(cargo()) --version`, devnull))
+    catch
+        @warn "Cargo not available, skipping Result/Option wrapper tests"
+        return
+    end
+
+    let bindings = @rust_crate SAMPLE_CRATE_PATH name="SampleCrateResultOption"
+        ok = bindings.safe_divide(10.0, 2.0)
+        err = bindings.safe_divide(10.0, 0.0)
+        some = bindings.safe_sqrt(4.0)
+        none = bindings.safe_sqrt(-1.0)
+
+        @test ok isa RustCall.RustResult{Float64, Int32}
+        @test RustCall.is_ok(ok)
+        @test RustCall.unwrap(ok) == 5.0
+
+        @test err isa RustCall.RustResult{Float64, Int32}
+        @test RustCall.is_err(err)
+        @test RustCall.unwrap_or(err, 0.0) == 0.0
+
+        @test some isa RustCall.RustOption{Float64}
+        @test RustCall.is_some(some)
+        @test RustCall.unwrap(some) == 2.0
+
+        @test none isa RustCall.RustOption{Float64}
+        @test RustCall.is_none(none)
+        @test RustCall.unwrap_or(none, 0.0) == 0.0
+    end
+end
+
 @testset "Function Scope Usage" begin
     if !isdir(SAMPLE_CRATE_PATH)
         @warn "Sample crate not found, skipping function scope usage tests"
@@ -420,6 +458,25 @@ end
     end
 
     @test use_bindings_in_function(SAMPLE_CRATE_PATH) == (Int32(5), 5.0, 3.0, 10.0)
+end
+
+@testset "sample_crate_pyo3 Julia Demo" begin
+    if !isdir(SAMPLE_CRATE_PYO3_PATH)
+        @warn "sample_crate_pyo3 not found, skipping Julia demo test"
+        return
+    end
+
+    try
+        run(pipeline(`$(cargo()) --version`, devnull))
+    catch
+        @warn "Cargo not available, skipping Julia demo test"
+        return
+    end
+
+    project_dir = dirname(@__DIR__)
+    cmd = Cmd(`julia --project=../.. main.jl`, dir=SAMPLE_CRATE_PYO3_PATH)
+    proc = run(ignorestatus(cmd), wait=true)
+    @test success(proc)
 end
 
 @testset "Precompilation Support" begin


### PR DESCRIPTION
## Summary
- fix generated `@rust_crate` runtime modules to import and construct `RustResult` / `RustOption` correctly
- add regression coverage for `sample_crate` `Result` / `Option` return paths
- fix the `sample_crate_pyo3` Julia demo to keep the bindings object returned by `@rust_crate`

## Root Cause
The runtime module path created by `emit_crate_module` did not import `RustResult` or `RustOption`, but the generated wrappers referenced them. That made `@rust_crate` bindings crash at runtime for Rust functions returning `Result<T, E>` or `Option<T>`. Separately, the `sample_crate_pyo3` demo script discarded the `@rust_crate` return value and then tried to call `SampleCratePyo3` as if a module had been injected into `Main`.

## Impact
- `@rust_crate` bindings now work for the bundled `sample_crate` `safe_divide` and `safe_sqrt` examples
- the documented `sample_crate_pyo3` Julia demo command now runs successfully
- these paths are covered by regression tests so they do not drift again

## Validation
- `julia --project test/test_crate_bindings.jl`