### PR TITLE
[codex] fix example unicode handling and docs

### DIFF
--- a/examples/MyExample.jl/README.md
+++ b/examples/MyExample.jl/README.md
@@ -9,17 +9,20 @@ This package depends on RustCall.jl. To use this example package:
 ```julia
 using Pkg
 
+# Enter the example package directory first so relative paths are unambiguous
+cd("examples/MyExample.jl")
+
 # Activate this package's environment
-Pkg.activate("examples/MyExample.jl")
+Pkg.activate(".")
 
 # Add RustCall.jl as a dev dependency (since it's not yet registered)
-Pkg.develop(path="../../")  # Path relative to this package
+Pkg.develop(path="../..")  # Path relative to examples/MyExample.jl
 
 # Instantiate dependencies
 Pkg.instantiate()
 ```
 
-**Note**: Since RustCall.jl is not yet registered in the Julia package registry, you need to add it as a dev dependency using `Pkg.develop()`. The path `../../` assumes you're running from the `examples/MyExample.jl` directory and points to the root of the RustCall.jl repository.
+**Note**: Since RustCall.jl is not yet registered in the Julia package registry, you need to add it as a dev dependency using `Pkg.develop()`. After changing into `examples/MyExample.jl`, the path `../..` points to the root of the RustCall.jl repository.
 
 ## Usage
 

--- a/examples/MyExample.jl/src/MyExample.jl
+++ b/examples/MyExample.jl/src/MyExample.jl
@@ -127,17 +127,18 @@ end
 Reverse a string using Rust.
 """
 function reverse_string(text::String)::String
-    input_len = length(text)
-    output_len = input_len + 1  # +1 for null terminator
+    output_len = ncodeunits(text) + 1  # +1 for null terminator
     output = Vector{UInt8}(undef, output_len)
 
-    input_ptr = pointer(text)
-    output_ptr = pointer(output)
+    GC.@preserve text output begin
+        input_ptr = pointer(text)
+        output_ptr = pointer(output)
 
-    @rust reverse_string(input_ptr, output_ptr, output_len)::Cvoid
+        @rust reverse_string(input_ptr, output_ptr, output_len)::Cvoid
 
-    # Convert back to Julia string
-    return unsafe_string(pointer(output))
+        # Convert back to Julia string while the buffer is preserved
+        return unsafe_string(pointer(output))
+    end
 end
 
 # ============================================================================

--- a/examples/MyExample.jl/test/runtests.jl
+++ b/examples/MyExample.jl/test/runtests.jl
@@ -26,6 +26,7 @@ using Test
         @test reverse_string("") == ""
         @test reverse_string("a") == "a"
         @test reverse_string("racecar") == "racecar"  # Palindrome
+        @test reverse_string("世界") == "界世"
     end
 
     @testset "Array Operations" begin

--- a/examples/README.md
+++ b/examples/README.md
@@ -146,7 +146,7 @@ SampleCratePyo3.add(Int32(2), Int32(3))  # => 5
 **How to use from Python:**
 ```python
 import sample_crate_pyo3 as m
-m.py_add(2, 3)  # => 5
+m.add(2, 3)  # => 5
 ```
 
 ## Learning Progression


### PR DESCRIPTION
## What changed
- fix `examples/MyExample.jl` string reversal to size the Rust output buffer by UTF-8 byte count and preserve Julia buffers while passing raw pointers
- add a regression test covering `reverse_string("世界") == "界世"`
- repair the `MyExample.jl` README setup flow so the documented `Pkg.develop` path works from a fresh checkout
- update the top-level `examples/README.md` Python snippet to use `sample_crate_pyo3.add(...)`

## Why
These example paths had drifted in ways that broke real user flows:
- `reverse_string` used `length(text)` instead of the UTF-8 byte count, which truncated multibyte input
- the `MyExample.jl` README implied that `Pkg.activate("examples/MyExample.jl")` changed the current directory, so `Pkg.develop(path="../../")` could fail when run from the repo root
- the top-level Python example referenced `py_add`, but the crate exports `add`

## Impact
- `MyExample.reverse_string` now handles multibyte UTF-8 inputs correctly
- the example package setup instructions are runnable from a fresh source checkout
- the Python dual-binding example docs now match the actual exported API

## Root cause
The runtime bug came from mixing Julia character counts with UTF-8 byte-oriented buffers at the FFI boundary. The documentation issues came from path assumptions and an outdated example name.

## Validation
- `julia --project=. test/runtests.jl` in `examples/MyExample.jl`
- `julia -e 'using Pkg; cd("/Users/terasaki/work/atelierarith/RustCall.jl/examples/MyExample.jl"); Pkg.activate("."); Pkg.develop(path="../.."); Pkg.instantiate(); using MyExample; println(reverse_string("世界"))'`
