### PR TITLE
[codex] fix issues 232-235 regressions

### DIFF
--- a/docs/plans/2026-04-20-issue-232-235-bugfixes.md
+++ b/docs/plans/2026-04-20-issue-232-235-bugfixes.md
@@ -1,0 +1,155 @@
+# Issue 232-235 Bugfixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the four confirmed bugs tracked in issues `#232`, `#233`, `#234`, and `#235` with regression tests.
+
+**Architecture:** Keep each fix local to the parser or helper that currently misbehaves. Add one regression test per bug first, then implement the smallest parser/state-machine change needed to satisfy that test without broad refactors.
+
+**Tech Stack:** Julia 1.12+, RustCall.jl test suite, `Test` stdlib
+
+---
+
+### Task 1: Reproduce issue #232 in generics parsing
+
+**Files:**
+- Modify: `test/test_generics.jl`
+- Modify: `src/generics.jl`
+
+**Step 1: Write the failing test**
+
+Add tests for `_parse_fn_arg_types` covering:
+- `fn foo<const N: usize = { 1 + 2 }, T>(x: T) -> T { x }`
+- `fn foo<T: Trait<{ 1 + 2 }>>(x: T) -> T { x }`
+
+Expected result in both cases: `["T"]`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project test/test_generics.jl`
+
+Expected: failure showing `_parse_fn_arg_types` returns `String[]`.
+
+**Step 3: Write minimal implementation**
+
+Replace the regex-only `fn ... <...>(` detection with bracket-counting that:
+- finds `fn <name>`
+- detects an optional generic parameter list beginning with `<`
+- skips to the matching `>`
+- verifies the next non-space character is `(`
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project test/test_generics.jl`
+
+Expected: new test passes.
+
+### Task 2: Reproduce issue #233 in `#[julia]` signature parsing
+
+**Files:**
+- Modify: `test/test_julia_attribute.jl`
+- Modify: `src/julia_functions.jl`
+
+**Step 1: Write the failing test**
+
+Add tests for:
+- argument parsing of `fn foo(x: [u8; { if 1 < 2 { 3 } else { 4 } }], y: i32)`
+- return type parsing of `fn foo() -> [u8; { if 1 < 2 { 3 } else { 4 } }]`
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project test/test_julia_attribute.jl`
+
+Expected: parser swallows `y: i32` into the first argument type and truncates the return type to `"[u8;"`.
+
+**Step 3: Write minimal implementation**
+
+Adjust helper scanning so that:
+- `_find_open_brace` ignores braces that belong to nested `{}` expressions before the function body
+- `_split_at_depth_zero` tracks curly-brace depth and does not let comparison operators corrupt angle-bracket depth
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project test/test_julia_attribute.jl`
+
+Expected: new tests pass.
+
+### Task 3: Reproduce issue #234 in trailing-backslash counting
+
+**Files:**
+- Modify: `test/test_dependencies.jl`
+- Modify: `src/dependencies.jl`
+
+**Step 1: Write the failing test**
+
+Add a regression test asserting:
+
+```julia
+@test RustCall._count_trailing_backslashes("あ\\") == 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project test/test_dependencies.jl`
+
+Expected: `StringIndexError`.
+
+**Step 3: Write minimal implementation**
+
+Rewrite `_count_trailing_backslashes` to iterate backward with `prevind`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project test/test_dependencies.jl`
+
+Expected: new test passes.
+
+### Task 4: Reproduce issue #235 in brace suggestions
+
+**Files:**
+- Modify: `test/test_error_handling.jl`
+- Modify: `src/exceptions.jl`
+
+**Step 1: Write the failing test**
+
+Add a regression test asserting that `suggest_fix_for_error("error: unclosed delimiter", "fn foo() { let s = \"{\"; }")` does not report an extra opening brace.
+
+**Step 2: Run test to verify it fails**
+
+Run: `julia --project test/test_error_handling.jl`
+
+Expected: current suggestions include `Found 1 more opening brace(s)...`.
+
+**Step 3: Write minimal implementation**
+
+Replace raw brace counting with a small scanner that ignores braces inside string literals and escaped quotes.
+
+**Step 4: Run test to verify it passes**
+
+Run: `julia --project test/test_error_handling.jl`
+
+Expected: new test passes.
+
+### Task 5: Final verification
+
+**Files:**
+- No additional code changes expected
+
+**Step 1: Run targeted suite**
+
+Run:
+
+```bash
+julia --project test/test_generics.jl
+julia --project test/test_julia_attribute.jl
+julia --project test/test_dependencies.jl
+julia --project test/test_error_handling.jl
+```
+
+Expected: all pass.
+
+**Step 2: Run broader regression coverage**
+
+Run: `julia --project -e 'using Pkg; Pkg.test()'`
+
+Expected: full test suite passes, or failures are unrelated and clearly identified.

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -285,9 +285,12 @@ of backslashes (e.g., `\\"` is escaped, `\\\\"` is not).
 """
 function _count_trailing_backslashes(s::AbstractString)
     count = 0
-    for i in lastindex(s):-1:firstindex(s)
+    i = lastindex(s)
+    while i >= firstindex(s)
         s[i] == '\\' || break
         count += 1
+        i == firstindex(s) && break
+        i = prevind(s, i)
     end
     return count
 end

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -556,8 +556,7 @@ function suggest_fix_for_error(stderr::String, source_code::String)
     if occursin("expected `}`, found", stderr_lower) || occursin("unclosed delimiter", stderr_lower)
         push!(suggestions, "Mismatched braces. Check that all opening `{` have matching closing `}`.")
         # Count braces
-        open_braces = count(c -> c == '{', source_code)
-        close_braces = count(c -> c == '}', source_code)
+        open_braces, close_braces = _count_braces_outside_strings(source_code)
         if open_braces > close_braces
             push!(suggestions, "Found $(open_braces - close_braces) more opening brace(s) than closing brace(s).")
         elseif close_braces > open_braces
@@ -599,6 +598,36 @@ function suggest_fix_for_error(stderr::String, source_code::String)
     end
 
     return unique(suggestions)
+end
+
+function _count_braces_outside_strings(source_code::AbstractString)
+    open_braces = 0
+    close_braces = 0
+    in_string = false
+    escaped = false
+
+    for c in source_code
+        if in_string
+            if escaped
+                escaped = false
+            elseif c == '\\'
+                escaped = true
+            elseif c == '"'
+                in_string = false
+            end
+            continue
+        end
+
+        if c == '"'
+            in_string = true
+        elseif c == '{'
+            open_braces += 1
+        elseif c == '}'
+            close_braces += 1
+        end
+    end
+
+    return open_braces, close_braces
 end
 
 """

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -751,15 +751,34 @@ function _parse_fn_arg_types(code::AbstractString, func_name::AbstractString)
     types = String[]
 
     # Find the function signature: fn name<...>(...) or fn name(...)
-    # We need to find the parenthesized argument list
-    fn_pattern = Regex("fn\\s+$(func_name)\\s*(?:<[^{]*?>)?\\s*\\(")
-    m = match(fn_pattern, code)
+    # Use bracket-counting for the optional generic parameter list because
+    # const generics and bounds can contain braces.
+    prefix_pattern = Regex("fn\\s+$(func_name)\\s*")
+    m = match(prefix_pattern, code)
     if m === nothing
         return types
     end
 
+    pos = m.offset + length(m.match)
+
+    if pos <= ncodeunits(code) && code[pos] == '<'
+        close_pos = _find_matching_angle_bracket(code, pos)
+        if close_pos == 0
+            return types
+        end
+        pos = nextind(code, close_pos)
+    end
+
+    while pos <= ncodeunits(code) && isspace(code[pos])
+        pos = nextind(code, pos)
+    end
+
+    if pos > ncodeunits(code) || code[pos] != '('
+        return types
+    end
+
     # Find the matching closing parenthesis using bracket counting
-    paren_start = m.offset + length(m.match) - 1  # position of '('
+    paren_start = pos
     depth = 1
     i = nextind(code, paren_start)
     while i <= ncodeunits(code) && depth > 0

--- a/src/julia_functions.jl
+++ b/src/julia_functions.jl
@@ -179,16 +179,32 @@ end
 Find the next '{' at bracket depth 0, starting from start_pos. Returns 0 if not found.
 """
 function _find_open_brace(s::AbstractString, start_pos::Int)
-    depth = 0
+    angle = 0
+    paren = 0
+    bracket = 0
+    curly = 0
     i = start_pos
     while i <= ncodeunits(s)
         c = s[i]
-        if c == '<'
-            depth += 1
-        elseif c == '>'
-            depth -= 1
-        elseif c == '{' && depth == 0
-            return i
+        if c == '<' && curly == 0
+            angle += 1
+        elseif c == '>' && curly == 0
+            angle = max(0, angle - 1)
+        elseif c == '('
+            paren += 1
+        elseif c == ')'
+            paren = max(0, paren - 1)
+        elseif c == '['
+            bracket += 1
+        elseif c == ']'
+            bracket = max(0, bracket - 1)
+        elseif c == '{'
+            if angle == 0 && paren == 0 && bracket == 0 && curly == 0
+                return i
+            end
+            curly += 1
+        elseif c == '}'
+            curly = max(0, curly - 1)
         end
         i = nextind(s, i)
     end
@@ -206,12 +222,13 @@ function _split_at_depth_zero(s::AbstractString, delimiter::Char)
     angle = 0
     paren = 0
     bracket = 0
+    curly = 0
 
     for c in s
-        if c == '<'
+        if c == '<' && curly == 0
             angle += 1
             write(current, c)
-        elseif c == '>'
+        elseif c == '>' && curly == 0
             angle = max(0, angle - 1)
             write(current, c)
         elseif c == '('
@@ -226,7 +243,13 @@ function _split_at_depth_zero(s::AbstractString, delimiter::Char)
         elseif c == ']'
             bracket = max(0, bracket - 1)
             write(current, c)
-        elseif c == delimiter && angle == 0 && paren == 0 && bracket == 0
+        elseif c == '{'
+            curly += 1
+            write(current, c)
+        elseif c == '}'
+            curly = max(0, curly - 1)
+            write(current, c)
+        elseif c == delimiter && angle == 0 && paren == 0 && bracket == 0 && curly == 0
             push!(parts, String(take!(current)))
         else
             write(current, c)

--- a/test/test_dependencies.jl
+++ b/test/test_dependencies.jl
@@ -235,6 +235,7 @@ using Test
         @test RustCall._count_trailing_backslashes("hello\\\\") == 2
         @test RustCall._count_trailing_backslashes("hello\\\\\\") == 3
         @test RustCall._count_trailing_backslashes("\\") == 1
+        @test RustCall._count_trailing_backslashes("あ\\") == 1
     end
 
     @testset "split_cargo_deps handles escaped quotes" begin

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -83,6 +83,11 @@ using Test
         @test !isempty(suggestions_brace)
         @test any(s -> occursin("brace", lowercase(s)), suggestions_brace)
 
+        stderr_string_brace = "error: unclosed delimiter"
+        source_string_brace = "fn foo() { let s = \"{\"; }"
+        suggestions_string_brace = RustCall.suggest_fix_for_error(stderr_string_brace, source_string_brace)
+        @test !any(s -> occursin("more opening brace", lowercase(s)), suggestions_string_brace)
+
         # Test missing #[no_mangle]
         stderr_ffi = "error: cannot find function `test`"
         source_ffi = "pub extern \"C\" fn test() -> i32 { 42 }"

--- a/test/test_generics.jl
+++ b/test/test_generics.jl
@@ -441,6 +441,20 @@ end
         @test type_params == Dict(:T => Float64)
     end
 
+    @testset "_parse_fn_arg_types handles braces in generic parameter lists" begin
+        types = RustCall._parse_fn_arg_types(
+            "fn foo<const N: usize = { 1 + 2 }, T>(x: T) -> T { x }",
+            "foo",
+        )
+        @test types == ["T"]
+
+        types = RustCall._parse_fn_arg_types(
+            "fn foo<T: Trait<{ 1 + 2 }>>(x: T) -> T { x }",
+            "foo",
+        )
+        @test types == ["T"]
+    end
+
     @testset "Code Specialization" begin
         # Test specializing generic code
         code = """

--- a/test/test_julia_attribute.jl
+++ b/test/test_julia_attribute.jl
@@ -67,6 +67,30 @@ using Test
         """
         sigs = RustCall.parse_julia_functions(code5)
         @test length(sigs) == 0
+
+        # Const expressions in types should not confuse argument splitting
+        code6 = """
+        #[julia]
+        fn foo(x: [u8; { if 1 < 2 { 3 } else { 4 } }], y: i32) {
+            let _ = x;
+            let _ = y;
+        }
+        """
+        sigs = RustCall.parse_julia_functions(code6)
+        @test length(sigs) == 1
+        @test sigs[1].arg_names == ["x", "y"]
+        @test sigs[1].arg_types == ["[u8; { if 1 < 2 { 3 } else { 4 } }]", "i32"]
+
+        # Return type parsing should skip nested const-expression braces
+        code7 = """
+        #[julia]
+        fn make_array() -> [u8; { if 1 < 2 { 3 } else { 4 } }] {
+            [0; 3]
+        }
+        """
+        sigs = RustCall.parse_julia_functions(code7)
+        @test length(sigs) == 1
+        @test sigs[1].return_type == "[u8; { if 1 < 2 { 3 } else { 4 } }]"
     end
 
     @testset "transform_julia_attribute" begin


### PR DESCRIPTION
## Summary

This PR fixes the four confirmed parser and diagnostics bugs tracked from #231 and split into:
- #232
- #233
- #234
- #235

## What Changed

- Reworked `_parse_fn_arg_types` to find `fn name<...>(...)` signatures with bracket-counting instead of a regex that breaks when generic parameter lists contain `{...}`.
- Updated `parse_julia_functions` helpers to track curly-brace depth so const expressions inside types no longer break argument splitting or return-type parsing.
- Rewrote `_count_trailing_backslashes` to iterate with `prevind`, avoiding `StringIndexError` on UTF-8 input.
- Replaced raw brace counting in `suggest_fix_for_error` with a scanner that ignores braces inside string literals.
- Added targeted regression tests for all four issues.
- Added a short implementation note under `docs/plans/2026-04-20-issue-232-235-bugfixes.md`.

## Root Cause

The affected code paths used shallow string matching or byte-like indexing assumptions in places that need syntax-aware scanning:
- regex-only parsing for generic parameter lists
- delimiter tracking that ignored `{}` nesting
- reverse iteration over UTF-8 strings with invalid intermediate indices
- naive brace counting in diagnostic suggestions

## Impact

- Generic parsing now handles const-generic and const-expression forms more reliably.
- `#[julia]` wrappers no longer misparse signatures containing const expressions in array lengths or similar type positions.
- dependency parsing helpers now work with non-ASCII strings.
- syntax suggestions avoid misleading extra-brace hints from braces embedded in string literals.

## Validation

- `julia --project test/test_generics.jl`
- `julia --project test/test_julia_attribute.jl`
- `julia --project test/test_dependencies.jl`
- `julia --project test/test_error_handling.jl`
- `julia --project -e 'using Pkg; Pkg.test()'`