### PR TITLE
[codex] add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "name": "RustCall.jl",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+    "remoteUser": "vscode",
+    "features": {
+        "ghcr.io/julialang/devcontainer-features/julia:1": {
+            "channel": "release"
+        }
+    },
+    "mounts": [
+        "source=rustcall-julia-depot,target=/home/vscode/.julia,type=volume",
+        "source=rustcall-cargo-registry,target=/home/vscode/.cargo/registry,type=volume",
+        "source=rustcall-cargo-git,target=/home/vscode/.cargo/git,type=volume"
+    ],
+    "postCreateCommand": "bash .devcontainer/post-create.sh",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "julialang.language-julia",
+                "rust-lang.rust-analyzer",
+                "tamasfe.even-better-toml",
+                "mhutchie.git-graph"
+            ]
+        }
+    },
+    "remoteEnv": {
+        "JULIA_PROJECT": "@.",
+        "PATH": "/home/vscode/.cargo/bin:${containerEnv:PATH}"
+    }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    libssl-dev \
+    pkg-config
+
+if ! command -v rustup >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+fi
+
+export PATH="$HOME/.cargo/bin:$PATH"
+
+rustup default stable
+rustup component add clippy rustfmt
+
+julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build("RustCall")'

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ using Pkg
 Pkg.instantiate()
 ```
 
+If you prefer VS Code Dev Containers, this repository now includes `.devcontainer/devcontainer.json`. Reopen the checkout in the container and the initial setup will install Rust, instantiate the Julia project, and run `Pkg.build("RustCall")`.
+
 ### 1. Define and Call Rust Functions (Simple Way)
 
 ```julia

--- a/docs/plans/2026-04-20-devcontainer-design.md
+++ b/docs/plans/2026-04-20-devcontainer-design.md
@@ -1,0 +1,75 @@
+# Devcontainer Design
+
+**Date:** 2026-04-20
+
+## Goal
+
+Add a repository-scoped `.devcontainer` setup so contributors can open `RustCall.jl` in a VS Code dev container with Julia, Rust, and the package build prerequisites ready to go.
+
+## Constraints
+
+- Reuse the existing `.devcontainer/devcontainer.json` draft instead of replacing it with a Dockerfile-based setup.
+- Keep the configuration Linux-focused and minimal; the repository already tests Windows and macOS in CI.
+- Ensure the first container setup can instantiate the Julia environment and build the Rust helper library.
+- Keep the setup maintainable in-repo without introducing extra container build assets unless they provide clear value.
+
+## Options Considered
+
+### 1. Extend `devcontainer.json` only
+
+Use the existing Ubuntu base image, keep the Julia feature, install Rust and required Ubuntu packages from a setup script, and run `Pkg.instantiate()` plus `Pkg.build("RustCall")` automatically.
+
+**Pros**
+
+- Smallest diff.
+- Keeps the existing draft.
+- Easy to understand and maintain.
+
+**Cons**
+
+- Some setup work happens after container creation rather than during image build.
+
+### 2. Add a custom `Dockerfile`
+
+Bake Julia, Rust, and build packages into a custom image referenced by `devcontainer.json`.
+
+**Pros**
+
+- Higher reproducibility at image-build time.
+
+**Cons**
+
+- More files and maintenance burden.
+- Unnecessary for the current repository needs.
+
+### 3. Add Docker Compose
+
+Model the development container with compose for future multi-service expansion.
+
+**Pros**
+
+- Flexible if the repository later depends on companion services.
+
+**Cons**
+
+- Overbuilt for a single-package development environment.
+
+## Chosen Approach
+
+Proceed with option 1.
+
+The final setup will:
+
+- keep `mcr.microsoft.com/devcontainers/base:ubuntu-24.04`
+- install Julia via the existing Julia devcontainer feature
+- install Rust stable plus `clippy` and `rustfmt` during post-create setup
+- install only basic Ubuntu build dependencies needed for Rust and Julia package builds
+- set `JULIA_PROJECT=@.` for interactive use inside the container
+- persist Julia and Cargo caches with named volumes
+- document the devcontainer workflow briefly in `README.md`
+
+## Validation
+
+- Verify `devcontainer.json` parses as valid JSON.
+- Run the repository setup command locally: `julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build("RustCall")'`.
+- Review the resulting git diff and publish a draft PR.

--- a/docs/plans/2026-04-20-devcontainer.md
+++ b/docs/plans/2026-04-20-devcontainer.md
@@ -1,0 +1,66 @@
+# Devcontainer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a minimal repository devcontainer that provisions Julia, Rust, and the package build prerequisites for RustCall.jl contributors.
+
+**Architecture:** Reuse the existing `.devcontainer/devcontainer.json` draft, add one setup script for post-create provisioning, and document the workflow in `README.md`. Keep the environment Linux-only and avoid introducing a custom Dockerfile unless the minimal setup proves insufficient.
+
+**Tech Stack:** Dev Containers (`devcontainer.json`), Ubuntu 24.04 base image, Julia feature, Rust toolchain via `rustup`, Julia package manager, git/GitHub.
+
+---
+
+### Task 1: Record the container configuration
+
+**Files:**
+- Modify: `.devcontainer/devcontainer.json`
+- Create: `.devcontainer/post-create.sh`
+
+**Step 1: Write the configuration changes**
+
+- Expand `devcontainer.json` to include Rust-aware VS Code extensions, cache mounts, a post-create hook, and the runtime environment variables needed by Julia and Cargo.
+- Add `post-create.sh` to install Ubuntu build prerequisites, install the Rust stable toolchain if absent, add `clippy` and `rustfmt`, and run `Pkg.instantiate()` plus `Pkg.build("RustCall")`.
+
+**Step 2: Run a focused validation**
+
+Run: `python3 -m json.tool .devcontainer/devcontainer.json >/dev/null`
+Expected: exit code 0
+
+### Task 2: Document contributor usage
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add a short devcontainer section**
+
+- Explain that contributors can reopen the repository in the dev container.
+- State that the container installs Rust and builds `RustCall` on first creation.
+- Keep the note short and near the local setup instructions.
+
+**Step 2: Review rendered markdown context**
+
+Run: `sed -n '1,170p' README.md`
+Expected: new section appears in the setup area with concise instructions.
+
+### Task 3: Verify repository setup and publish
+
+**Files:**
+- Modify: `.devcontainer/devcontainer.json`
+- Create: `.devcontainer/post-create.sh`
+- Modify: `README.md`
+
+**Step 1: Run repository setup verification**
+
+Run: `julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build("RustCall")'`
+Expected: exit code 0
+
+**Step 2: Review git diff**
+
+Run: `git status --short && git diff -- .devcontainer README.md docs/plans`
+Expected: only the intended devcontainer and planning changes are present.
+
+**Step 3: Commit and publish**
+
+- Commit the planning docs intentionally.
+- Commit the devcontainer implementation intentionally.
+- Push the topic branch and open a draft PR titled `[codex] add devcontainer`.


### PR DESCRIPTION
## Summary
- add a repository-scoped `.devcontainer` configuration for VS Code Dev Containers
- provision Rust, Julia project setup, and Rust helper builds through a post-create script
- document the devcontainer workflow in `README.md`
- record the design and implementation plan in `docs/plans/`

## Why
Contributors currently need to assemble Julia, Rust, and the package build prerequisites manually before they can work on `RustCall.jl`. This change adds a lightweight, repo-local development container so the standard Linux development setup is reproducible and easier to start.

## Validation
- `python3 -m json.tool .devcontainer/devcontainer.json >/dev/null`
- `bash -n .devcontainer/post-create.sh`
- `julia --project -e 'using Pkg; Pkg.instantiate(); Pkg.build("RustCall")'`
