### PR TITLE
Bump RustToolChain compat to 0.1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 BenchmarkTools = "1.6.3"
 LLVM = "9"
 ParallelTestRunner = "2.5"
-RustToolChain = "0.1.1"
+RustToolChain = "0.1.8"
 julia = "1.12"
 
 [extras]


### PR DESCRIPTION
## Summary
- Widen the `RustToolChain` compat bound in `Project.toml` from `0.1.1` to `0.1.8` to allow newer upstream RustToolChain.jl releases.

## Note
- The package is registered in the General registry. Since this changes `[compat]` without a `version` bump, a new release (e.g. `0.1.1`) will be needed before this can be re-registered — flagging in case that step should happen alongside or after this PR. `docs/Project.toml` still pins `RustToolChain = "0.1.1"` and may need the same bump for the docs build to resolve consistently.

## Test plan
- [ ] `julia --project -e 'using Pkg; Pkg.resolve(); Pkg.instantiate()'` resolves cleanly against RustToolChain 0.1.8
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)