### PR TITLE
Deprecate @rust_llvm and the LLVM IR integration path (#265, Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+- The LLVM IR integration path is deprecated and will be removed in a future
+  breaking release ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+  Affected entry points emit `Base.depwarn` and keep working unchanged:
+  `@rust_llvm`, `compile_and_register_rust_function`, `get_registered_function`,
+  `compile_rust_to_llvm_ir`, `load_llvm_ir`, `get_function_signature`,
+  `get_or_compile_function`, `OptimizationConfig`, `set_default_opt_config`,
+  `optimize_module!`, `optimize_function!`, `optimize_for_speed!`,
+  `optimize_for_size!`, `optimize_balanced!`.
+  Reasons: `@rust_llvm` performs the same function-pointer `ccall` as `@rust`,
+  and rustc tracks a newer LLVM than the one bundled with Julia, so the emitted
+  IR cannot be parsed reliably. Use `@rust` instead.
+
+### Changed
+- Rust syntax is no longer parsed on the Julia side. `rust"""` blocks,
+  `@rust_crate` and generics go through the `rustcall-extract` CLI
+  (`deps/rustcall_core`, `deps/rustcall_extract`), which emits a TOML FFI
+  manifest ([#264](https://github.com/AtelierArith/RustCall.jl/issues/264),
+  [#266](https://github.com/AtelierArith/RustCall.jl/pull/266)).
+
 ### Added
 - CI/CD pipeline with GitHub Actions
 - Support for multiple Julia versions (1.10, 1.11, nightly)

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ affine(Int32(2), Int32(10), Int32(3)) # 23
 - `@rust`: call exported functions through a C-compatible ABI
 - `@irust`: compile a small Rust expression with Julia variable capture
 - `@rust_crate`: build and load an external crate annotated with `#[julia]`
-- `@rust_llvm`: experimental LLVM-based call path
+- `@rust_llvm`: deprecated LLVM-based call path, scheduled for removal ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)); use `@rust`
 
 Rust dependencies can be declared inline with `// cargo-deps:` or fenced `cargo` blocks. The first build may need network access.
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -12,6 +12,9 @@ This page provides the API documentation for RustCall.jl.
 @rust_llvm
 ```
 
+`@rust_llvm` is deprecated and will be removed in a future release; use `@rust`
+instead (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+
 ## Types
 
 ### Result and Option Types
@@ -138,7 +141,12 @@ RustCall.list_cached_libraries
 RustCall.cleanup_old_cache
 ```
 
-## LLVM Optimization
+## LLVM Optimization (deprecated)
+
+The LLVM IR integration path is deprecated ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)). Every function in
+this section and the next, together with `compile_rust_to_llvm_ir` and
+`load_llvm_ir` above, emits a deprecation warning and will be removed in a future
+release.
 
 ```@docs
 RustCall.OptimizationConfig
@@ -147,7 +155,7 @@ RustCall.optimize_for_speed!
 RustCall.optimize_for_size!
 ```
 
-## LLVM Function Registration
+## LLVM Function Registration (deprecated)
 
 ```@docs
 RustCall.RustFunctionInfo

--- a/docs/src/developer_pitfalls.md
+++ b/docs/src/developer_pitfalls.md
@@ -65,7 +65,7 @@ Define the method for one canonical type and add a comment:
 
 ```julia
 # Void type (Cvoid === Nothing in Julia, so this handles both)
-RustCall.julia_type_to_llvm_ir_string(::Type{Nothing}) = "void"
+RustCall._julia_type_to_llvm_ir_string(::Type{Nothing}) = "void"
 ```
 
 If you need to handle both names in user-facing code (e.g., dispatching on a

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -523,9 +523,12 @@ function use_resource()
 end
 ```
 
-### LLVM IR Integration
+### LLVM IR Integration (deprecated)
 
-The LLVM call path is experimental, but it can be useful for repeated hot paths.
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)). `@rust_llvm` uses the same `ccall` as `@rust`, so
+    use `@rust` for hot paths. The snippets below emit deprecation warnings.
 
 ```julia
 using RustCall
@@ -1048,7 +1051,7 @@ data = rand(10000)
 
 **Performance tips:**
 - Use `GC.@preserve` for large arrays to prevent garbage collection during Rust calls
-- Consider `@rust_llvm` for performance-critical code with LLVM optimizations
+- Let `rustc` optimize the Rust side (`-C opt-level`); `@rust_llvm` is deprecated and offers no speedup over `@rust`
 - Leverage caching to avoid recompilation (functions are cached automatically)
 - Always specify explicit types in `@rust` macro calls
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,9 +15,9 @@
 - **String support**: Pass Julia strings to Rust functions expecting C strings
 - **Compilation caching**: SHA256-based caching system for compiled libraries
 
-### Phase 2: LLVM IR Integration ✅
-- **`@rust_llvm` macro**: Direct LLVM IR integration (experimental)
-- **LLVM optimization**: Configurable optimization passes
+### Phase 2: Runtime and Ownership ✅
+- **`@rust_llvm` macro**: Deprecated. The LLVM IR integration path is scheduled for removal because it has no benefit over `@rust` and rustc's LLVM IR no longer matches Julia's LLVM ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265))
+- **LLVM optimization**: Deprecated together with `@rust_llvm`
 - **Ownership types**: `RustBox`, `RustRc`, `RustArc`, `RustVec`, `RustSlice`
 - **Array operations**: Indexing, iteration, Julia ↔ Rust conversion
 - **Generics support**: Automatic monomorphization and type parameter inference

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -49,68 +49,40 @@ RustCall.clear_cache()
 
 ## LLVM Optimization
 
-RustCall.jl supports optimization at the LLVM IR level. Using the `@rust_llvm` macro enables more advanced optimizations.
+!!! warning "Deprecated"
+    The LLVM IR integration path (`@rust_llvm`, `compile_rust_to_llvm_ir`,
+    `load_llvm_ir`, `OptimizationConfig`, `optimize_module!` and friends) is
+    deprecated and will be removed in a future release. Every entry point now
+    emits a deprecation warning. See [#265](https://github.com/AtelierArith/RustCall.jl/issues/265).
 
-### Optimization Level Settings
+The path was an experiment inspired by Cxx.jl: load the LLVM IR that rustc emits
+into Julia's LLVM and optimize across the language boundary. It is being removed
+for two reasons.
 
-```julia
-using RustCall
+- **The call path is equivalent to `@rust`.** `@rust_llvm` calls the Rust
+  function through a function pointer with a plain `ccall`; no Rust IR is inlined
+  into Julia code, so there is no performance difference.
+- **rustc and Julia do not share an LLVM version.** rustc follows LLVM releases
+  every six weeks while Julia pins a major version per release (Julia 1.12 ships
+  LLVM 18, rustc 1.98 emits LLVM 22 IR). The textual IR format is not forward
+  compatible, so newer rustc output cannot be parsed reliably by Julia's LLVM.
 
-# Create optimization configuration
-config = RustCall.OptimizationConfig(
-    level=3,  # 0-3 (3 is most optimized)
-    enable_vectorization=true,
-    enable_loop_unrolling=true,
-    enable_licm=true
-)
-
-rust_code = """
-#[no_mangle]
-pub extern "C" fn compute(x: f64) -> f64 {
-    x * x + 1.0
-}
-"""
-
-# Compile Rust to LLVM IR and load module
-wrapped = RustCall.wrap_rust_code(rust_code)
-compiler = RustCall.get_default_compiler()
-ir_path = RustCall.compile_rust_to_llvm_ir(wrapped; compiler=compiler)
-rust_mod = RustCall.load_llvm_ir(ir_path; source_code=wrapped)
-mod = rust_mod.mod
-
-# Apply optimization
-RustCall.optimize_module!(mod; config=config)
-```
-
-### Optimization Presets
-
-```julia
-# Speed-optimized
-RustCall.optimize_for_speed!(mod)
-
-# Size-optimized
-RustCall.optimize_for_size!(mod)
-```
-
-### Optimization Level Selection
-
-- **Level 0**: No optimization (for debugging)
-- **Level 1**: Basic optimizations
-- **Level 2**: Standard optimizations (default)
-- **Level 3**: Maximum optimization (may take longer to compile)
+Use `@rust` for all calls. Optimization of the Rust code itself belongs to
+`rustc` (`-C opt-level`, see `RustCall.RustCompiler`).
 
 ## Function Call Optimization
 
 ### `@rust` vs `@rust_llvm`
 
-- **`@rust`**: Standard call via `ccall`. Highly stable, recommended for most cases
-- **`@rust_llvm`**: Call via LLVM IR integration (experimental). Has optimization potential but limitations with some types
+- **`@rust`**: Standard call via `ccall`. Highly stable, recommended for all cases
+- **`@rust_llvm`**: Deprecated (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)). Internally it performs the same
+  `ccall` as `@rust`, so it has no performance benefit, and it emits a deprecation warning
 
 ```julia
 # Standard call (recommended)
 result = @rust add(Int32(10), Int32(20))::Int32
 
-# LLVM integration call (experimental)
+# Deprecated: same call mechanism, plus a deprecation warning
 result = @rust_llvm add(Int32(10), Int32(20))
 ```
 
@@ -128,20 +100,10 @@ result = @rust add(Int32(10), Int32(20))::Int32
 
 ### Function Registration Optimization
 
-Frequently called functions can be optimized by registering them beforehand:
-
-```julia
-# Register function for LLVM path
-RustCall.compile_and_register_rust_function("""
-#[no_mangle]
-pub extern "C" fn add(a: i32, b: i32) -> i32 {
-    a + b
-}
-""", "add")
-
-# Call through LLVM path
-result = @rust_llvm add(Int32(10), Int32(20))
-```
+`RustCall.compile_and_register_rust_function` registered a function for the
+deprecated LLVM path. It is no longer recommended: `rust"""..."""` blocks
+already compile once and are cached, so an explicit registration step buys
+nothing. Prefer `@rust` with explicit argument and return types.
 
 ## Memory Management
 
@@ -218,7 +180,9 @@ end
 
 ### Basic Operations
 
-The following benchmarks were run on Julia 1.12, Rust 1.92.0, macOS:
+The following benchmarks were run on Julia 1.12, Rust 1.92.0, macOS. The
+`@rust_llvm` column is kept for reference only; the macro is deprecated and uses the
+same call mechanism as `@rust`.
 
 | Operation | Julia Native | @rust | @rust_llvm |
 |-----------|-------------|-------|------------|
@@ -262,7 +226,7 @@ The following benchmarks were run on Julia 1.12, Rust 1.92.0, macOS:
 # Basic benchmarks
 julia --project benchmark/benchmarks.jl
 
-# LLVM integration benchmarks
+# LLVM integration benchmarks (deprecated path, emits deprecation warnings)
 julia --project benchmark/benchmarks_llvm.jl
 
 # Ownership type benchmarks

--- a/docs/src/status.md
+++ b/docs/src/status.md
@@ -1,13 +1,13 @@
 # Project Status
 
-Last updated: 2026-04-22
+Last updated: 2026-09-05
 
 ## Summary
 
 | Item | Current State |
 |------|---------------|
 | Core FFI (`rust"""`, `@rust`, `@irust`) | ✅ Implemented |
-| LLVM integration (`@rust_llvm`) | ✅ Implemented (experimental path) |
+| LLVM integration (`@rust_llvm`) | ⚠️ Deprecated, scheduled for removal ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)) |
 | Cargo dependency integration | ✅ Implemented |
 | Struct/object mapping | ✅ Implemented |
 | `#[julia]` attribute support | ✅ Implemented |
@@ -39,7 +39,7 @@ Based on the repository state on 2026-02-07. Only the summary/test runner status
 ### Compilation and code generation
 - `src/compiler.jl`: rustc invocation and compile orchestration.
 - `src/codegen.jl`: `ccall` generation utilities.
-- `src/llvmintegration.jl`, `src/llvmcodegen.jl`, `src/llvmoptimization.jl`: LLVM path.
+- `src/llvmintegration.jl`, `src/llvmcodegen.jl`, `src/llvmoptimization.jl`: LLVM path (deprecated, #265).
 
 ### Type and runtime layer
 - `src/types.jl`: Rust wrapper types (`RustResult`, `RustOption`, ownership types).
@@ -88,7 +88,7 @@ Pkg.build("RustCall")
 ## Current Limitations
 
 - The direct FFI path is centered on `extern "C"` entry points; it does not model Rust lifetimes or borrow-checker guarantees on the Julia side.
-- `@rust_llvm` is available but remains an experimental path compared with standard `@rust` calls.
+- `@rust_llvm` and the LLVM optimization API are deprecated: the call path is equivalent to `@rust`, and rustc's LLVM IR cannot be parsed reliably by Julia's bundled LLVM. They emit deprecation warnings and will be removed in a future release.
 - Ownership helpers such as `RustBox`, `RustRc`, `RustArc`, `RustVec`, and `RustSlice` depend on the helper library built during package installation.
 - Generic structs and more advanced trait patterns still need explicit handling in some cases, especially for external bindings.
 - Cargo-backed workflows are cached, but first builds can be slow and some crates may still need platform-specific build configuration.
@@ -96,7 +96,7 @@ Pkg.build("RustCall")
 ## Delivered Milestones
 
 - Phase 1: direct `rust"""..."""`, `@rust`, `@irust`, type mapping, string support, and cache-backed compilation.
-- Phase 2: ownership/runtime helpers, generics support, and the experimental LLVM path.
+- Phase 2: ownership/runtime helpers, generics support, and the experimental LLVM path (now deprecated).
 - Phase 3: Cargo dependency parsing and external crate use inside inline Rust code.
 - Phase 4: Rust struct and method mapping into Julia-facing objects.
 - Phase 5: `#[julia]`-driven wrapper generation.
@@ -104,6 +104,6 @@ Pkg.build("RustCall")
 
 ## Near-Term Priorities
 
-- Stabilize and document `@rust_llvm` behavior across more type patterns.
+- Remove the deprecated LLVM IR integration path and the `LLVM.jl` dependency (#265, Phase 2).
 - Continue regression hardening for crate binding and hot reload workflows.
 - Prepare distribution tasks for crates.io publication of proc-macro tooling.

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -346,9 +346,17 @@ end
 
 ## LLVM IR Integration (Advanced)
 
+!!! warning "Deprecated"
+    `@rust_llvm` and the LLVM optimization API are deprecated and will be removed
+    in a future release ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)). `@rust_llvm` performs the same `ccall`
+    as `@rust`, and the LLVM IR emitted by current rustc versions cannot be parsed
+    by the LLVM bundled with Julia. Use `@rust` instead. The examples below are
+    kept for users migrating away from the path; each call emits a deprecation
+    warning.
+
 ### Using @rust_llvm Macro
 
-The `@rust_llvm` macro enables optimized calls via LLVM IR integration (experimental):
+The `@rust_llvm` macro was the entry point of the LLVM IR integration path:
 
 ```julia
 rust"""
@@ -364,11 +372,14 @@ info = RustCall.compile_and_register_rust_function("""
 pub extern "C" fn fast_add(a: i32, b: i32) -> i32 { a + b }
 """, "fast_add")
 
-# Call with @rust_llvm (potentially optimized)
+# Call with @rust_llvm (deprecated; same call mechanism as @rust)
 result = @rust_llvm fast_add(Int32(10), Int32(20))  # => 30
+
+# Equivalent, recommended form
+result = @rust fast_add(Int32(10), Int32(20))::Int32  # => 30
 ```
 
-### LLVM Optimization Settings
+### LLVM Optimization Settings (deprecated)
 
 ```julia
 using RustCall
@@ -438,7 +449,7 @@ To measure performance:
 julia --project benchmark/benchmarks.jl
 ```
 
-This compares performance of Julia native, `@rust`, and `@rust_llvm`.
+This compares performance of Julia native, `@rust`, and the deprecated `@rust_llvm`.
 
 ## Best Practices
 

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -96,7 +96,7 @@ function infer_function_types(lib_name::String, func_name::String)
         if mod_lib_name == lib_name
             fn = get_function(mod, func_name)
             if fn !== nothing
-                return get_function_signature(fn)
+                return _get_function_signature(fn)
             end
         end
     end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -178,8 +178,18 @@ Compile Rust code to LLVM IR and return the path to the generated .ll file.
 
 # Throws
 - `CompilationError` if compilation fails
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function compile_rust_to_llvm_ir(code::String; compiler::RustCompiler = get_default_compiler())
+    _llvm_path_depwarn("compile_rust_to_llvm_ir", :compile_rust_to_llvm_ir)
+    return _compile_rust_to_llvm_ir(code; compiler)
+end
+
+function _compile_rust_to_llvm_ir(code::String; compiler::RustCompiler = get_default_compiler())
     # Create a unique temporary directory for this compilation
     if compiler.debug_mode && compiler.debug_dir !== nothing
         tmp_dir = compiler.debug_dir

--- a/src/llvmcodegen.jl
+++ b/src/llvmcodegen.jl
@@ -83,8 +83,8 @@ This creates a simple wrapper that calls the actual function.
 """
 function generate_llvmcall_ir(func_name::String, ret_type::Type, arg_types::Vector{Type})
     # Map Julia types to LLVM IR types
-    llvm_ret = _julia_type_to_llvm_ir_string(ret_type)
-    llvm_args = [_julia_type_to_llvm_ir_string(t) for t in arg_types]
+    llvm_ret = _llvm_ir_type(ret_type)
+    llvm_args = [_llvm_ir_type(t) for t in arg_types]
 
     # Build argument list
     arg_list = join(["$(llvm_args[i]) %$(i-1)" for i in 1:length(arg_types)], ", ")
@@ -108,6 +108,13 @@ end
 
 Convert a Julia type to its LLVM IR string representation.
 Supports basic types, pointers, tuples, and structs.
+
+Methods that downstream code adds to this name for its own types are still
+honoured, also for nested occurrences (tuple elements, struct fields), and
+take precedence over the built-in conversions. Such calls dispatch directly
+to the downstream method, so they do not emit the deprecation warning; they
+stop working when the function is removed together with the rest of the
+LLVM IR integration path.
 
 !!! warning "Deprecated"
     The LLVM IR integration path is deprecated and will be removed in a future
@@ -163,13 +170,6 @@ _julia_type_to_llvm_ir_string(t::Type{<:Tuple}) = _tuple_type_to_llvm_ir(t)
 
 # Struct types fallback (immutable structs)
 function _julia_type_to_llvm_ir_string(t::Type)
-    # Compatibility hook: downstream code may have extended the public
-    # (deprecated) name for a custom type. Nested conversions (tuple elements,
-    # struct fields) must keep dispatching to such methods, so consult them
-    # before the generic fallbacks.
-    if _has_public_llvm_ir_extension(t)
-        return julia_type_to_llvm_ir_string(t)
-    end
     if isstructtype(t) && !isabstracttype(t) && !isprimitivetype(t)
         return _struct_type_to_llvm_ir(t)
     else
@@ -186,6 +186,22 @@ function _has_public_llvm_ir_extension(t::Type)
 end
 
 """
+    _llvm_ir_type(t::Type) -> String
+
+Conversion entry point used internally (call IR, tuple elements, struct
+fields). Compatibility hook for the deprecation period: a method that
+downstream code added to the public `julia_type_to_llvm_ir_string` wins over
+the built-in conversion, exactly as it did when the built-ins were methods of
+the public name; otherwise the private, warning-free table is used.
+"""
+function _llvm_ir_type(t::Type)
+    if _has_public_llvm_ir_extension(t)
+        return julia_type_to_llvm_ir_string(t)
+    end
+    return _julia_type_to_llvm_ir_string(t)
+end
+
+"""
     _tuple_type_to_llvm_ir(t::Type{<:Tuple}) -> String
 
 Convert a Julia Tuple type to LLVM IR struct representation.
@@ -196,7 +212,7 @@ function _tuple_type_to_llvm_ir(t::Type{<:Tuple})
     end
 
     param_types = t.parameters
-    llvm_types = [_julia_type_to_llvm_ir_string(param) for param in param_types]
+    llvm_types = [_llvm_ir_type(param) for param in param_types]
     return "{$(join(llvm_types, ", "))}"
 end
 
@@ -230,7 +246,7 @@ function _struct_type_to_llvm_ir(t::Type)
                 push!(llvm_fields, "i8")
             end
         end
-        llvm_type = _julia_type_to_llvm_ir_string(ft)
+        llvm_type = _llvm_ir_type(ft)
         push!(llvm_fields, llvm_type)
         current_offset = Int(field_offset) + sizeof(ft)
     end

--- a/src/llvmcodegen.jl
+++ b/src/llvmcodegen.jl
@@ -1,5 +1,8 @@
 # LLVM IR code generation using llvmcall
 # Phase 2: Direct LLVM IR integration
+#
+# DEPRECATED (#265): this whole path is scheduled for removal. Every public
+# entry point emits `Base.depwarn`; internal helpers are prefixed with `_`.
 
 using LLVM
 
@@ -38,6 +41,11 @@ end
     RustFunctionInfo
 
 Information about a compiled Rust function for llvmcall.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 struct RustFunctionInfo
     name::String
@@ -100,6 +108,11 @@ end
 
 Convert a Julia type to its LLVM IR string representation.
 Supports basic types, pointers, tuples, and structs.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function julia_type_to_llvm_ir_string end
 
@@ -232,12 +245,17 @@ end
     compile_and_register_rust_function(code::String, func_name::String)
 
 Compile Rust code and register the function for llvmcall usage.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function compile_and_register_rust_function(code::String, func_name::String)
+    _llvm_path_depwarn("compile_and_register_rust_function", :compile_and_register_rust_function)
+
     # Check if already registered
-    existing = lock(LLVM_REGISTRY_LOCK) do
-        get(LLVM_FUNCTION_REGISTRY, func_name, nothing)
-    end
+    existing = _get_registered_function(func_name)
     if existing !== nothing
         return existing
     end
@@ -247,8 +265,8 @@ function compile_and_register_rust_function(code::String, func_name::String)
     compiler = get_default_compiler()
 
     # Compile to LLVM IR for analysis
-    ir_path = compile_rust_to_llvm_ir(wrapped_code; compiler=compiler)
-    rust_mod = load_llvm_ir(ir_path; source_code=wrapped_code)
+    ir_path = _compile_rust_to_llvm_ir(wrapped_code; compiler=compiler)
+    rust_mod = _load_llvm_ir(ir_path; source_code=wrapped_code)
 
     # Get function signature
     fn = get_function(rust_mod, func_name)
@@ -256,7 +274,7 @@ function compile_and_register_rust_function(code::String, func_name::String)
         error("Function '$func_name' not found in compiled code")
     end
 
-    ret_type, arg_types = get_function_signature(fn)
+    ret_type, arg_types = _get_function_signature(fn)
 
     # Also compile to shared library for function pointer
     lib_path = compile_rust_to_shared_lib(wrapped_code; compiler=compiler)
@@ -279,8 +297,18 @@ end
     get_registered_function(func_name::String) -> Union{RustFunctionInfo, Nothing}
 
 Get a registered Rust function's information.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function get_registered_function(func_name::String)
+    _llvm_path_depwarn("get_registered_function", :get_registered_function)
+    return _get_registered_function(func_name)
+end
+
+function _get_registered_function(func_name::String)
     return lock(LLVM_REGISTRY_LOCK) do
         get(LLVM_FUNCTION_REGISTRY, func_name, nothing)
     end
@@ -294,7 +322,15 @@ end
     @rust_llvm func_name(args...)
 
 Call a Rust function using LLVM IR integration (Phase 2).
-This uses @generated functions to produce optimized code at compile time.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
+
+In practice the call goes through the same function-pointer `ccall` as
+`@rust`; unregistered functions fall back to `dlsym` on the current library.
+Migrate to `@rust name(args...)::ReturnType`.
 
 # Example
 ```julia
@@ -336,8 +372,10 @@ Falls back to ccall if llvmcall is not available.
 - `TypeError`: If argument types don't match expected signature
 """
 function _rust_llvm_call(func_name::String, args...)
+    _llvm_path_depwarn("@rust_llvm", :_rust_llvm_call)
+
     # Get function info
-    info = get_registered_function(func_name)
+    info = _get_registered_function(func_name)
 
     if info === nothing
         # Try to find it in the current library
@@ -426,7 +464,7 @@ The function name is encoded as a type parameter for compile-time dispatch.
     n = length(args)
 
     # Try to get function info at compile time
-    info = get_registered_function(func_name)
+    info = _get_registered_function(func_name)
 
     if info !== nothing && info.func_ptr !== nothing
         expected_arg_types = info.arg_types

--- a/src/llvmcodegen.jl
+++ b/src/llvmcodegen.jl
@@ -163,11 +163,26 @@ _julia_type_to_llvm_ir_string(t::Type{<:Tuple}) = _tuple_type_to_llvm_ir(t)
 
 # Struct types fallback (immutable structs)
 function _julia_type_to_llvm_ir_string(t::Type)
+    # Compatibility hook: downstream code may have extended the public
+    # (deprecated) name for a custom type. Nested conversions (tuple elements,
+    # struct fields) must keep dispatching to such methods, so consult them
+    # before the generic fallbacks.
+    if _has_public_llvm_ir_extension(t)
+        return julia_type_to_llvm_ir_string(t)
+    end
     if isstructtype(t) && !isabstracttype(t) && !isprimitivetype(t)
         return _struct_type_to_llvm_ir(t)
     else
         error("Unsupported Julia type for LLVM IR: $t. Supported types: basic numeric types, Ptr, Tuple, and immutable structs.")
     end
+end
+
+# The single method RustCall itself defines for the public name; any other
+# applicable method was added by downstream code.
+const _PUBLIC_LLVM_IR_FALLBACK = which(julia_type_to_llvm_ir_string, Tuple{Type})
+
+function _has_public_llvm_ir_extension(t::Type)
+    return which(julia_type_to_llvm_ir_string, Tuple{Type{t}}) !== _PUBLIC_LLVM_IR_FALLBACK
 end
 
 """

--- a/src/llvmcodegen.jl
+++ b/src/llvmcodegen.jl
@@ -83,8 +83,8 @@ This creates a simple wrapper that calls the actual function.
 """
 function generate_llvmcall_ir(func_name::String, ret_type::Type, arg_types::Vector{Type})
     # Map Julia types to LLVM IR types
-    llvm_ret = julia_type_to_llvm_ir_string(ret_type)
-    llvm_args = [julia_type_to_llvm_ir_string(t) for t in arg_types]
+    llvm_ret = _julia_type_to_llvm_ir_string(ret_type)
+    llvm_args = [_julia_type_to_llvm_ir_string(t) for t in arg_types]
 
     # Build argument list
     arg_list = join(["$(llvm_args[i]) %$(i-1)" for i in 1:length(arg_types)], ", ")
@@ -114,20 +114,26 @@ Supports basic types, pointers, tuples, and structs.
     release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
     Use `@rust` instead.
 """
-function julia_type_to_llvm_ir_string end
+function julia_type_to_llvm_ir_string(t::Type)
+    _llvm_path_depwarn("julia_type_to_llvm_ir_string", :julia_type_to_llvm_ir_string)
+    return _julia_type_to_llvm_ir_string(t)
+end
+
+# Internal, warning-free implementation (one method per supported type).
+function _julia_type_to_llvm_ir_string end
 
 # Basic integer types
-julia_type_to_llvm_ir_string(::Type{Bool}) = "i8"  # C ABI uses i8 for bool, not i1
-julia_type_to_llvm_ir_string(::Type{Int8}) = "i8"
-julia_type_to_llvm_ir_string(::Type{UInt8}) = "i8"
-julia_type_to_llvm_ir_string(::Type{Int16}) = "i16"
-julia_type_to_llvm_ir_string(::Type{UInt16}) = "i16"
-julia_type_to_llvm_ir_string(::Type{Int32}) = "i32"
-julia_type_to_llvm_ir_string(::Type{UInt32}) = "i32"
-julia_type_to_llvm_ir_string(::Type{Int64}) = "i64"
-julia_type_to_llvm_ir_string(::Type{UInt64}) = "i64"
-julia_type_to_llvm_ir_string(::Type{Int128}) = "i128"
-julia_type_to_llvm_ir_string(::Type{UInt128}) = "i128"
+_julia_type_to_llvm_ir_string(::Type{Bool}) = "i8"  # C ABI uses i8 for bool, not i1
+_julia_type_to_llvm_ir_string(::Type{Int8}) = "i8"
+_julia_type_to_llvm_ir_string(::Type{UInt8}) = "i8"
+_julia_type_to_llvm_ir_string(::Type{Int16}) = "i16"
+_julia_type_to_llvm_ir_string(::Type{UInt16}) = "i16"
+_julia_type_to_llvm_ir_string(::Type{Int32}) = "i32"
+_julia_type_to_llvm_ir_string(::Type{UInt32}) = "i32"
+_julia_type_to_llvm_ir_string(::Type{Int64}) = "i64"
+_julia_type_to_llvm_ir_string(::Type{UInt64}) = "i64"
+_julia_type_to_llvm_ir_string(::Type{Int128}) = "i128"
+_julia_type_to_llvm_ir_string(::Type{UInt128}) = "i128"
 
 # Platform-dependent C types (sized based on runtime sizeof)
 # Only define methods for types that don't alias an already-defined base type,
@@ -138,25 +144,25 @@ const _LLVM_IR_BASE_TYPES = Set{Type}([
 ])
 for ctype in [Cint, Cuint, Clong, Culong, Csize_t, Cssize_t, Cptrdiff_t, Clonglong, Culonglong]
     if ctype ∉ _LLVM_IR_BASE_TYPES
-        @eval julia_type_to_llvm_ir_string(::Type{$ctype}) = $(string("i", 8 * sizeof(ctype)))
+        @eval _julia_type_to_llvm_ir_string(::Type{$ctype}) = $(string("i", 8 * sizeof(ctype)))
     end
 end
 
 # Floating point types
-julia_type_to_llvm_ir_string(::Type{Float32}) = "float"
-julia_type_to_llvm_ir_string(::Type{Float64}) = "double"
+_julia_type_to_llvm_ir_string(::Type{Float32}) = "float"
+_julia_type_to_llvm_ir_string(::Type{Float64}) = "double"
 
 # Void type (Cvoid === Nothing in Julia, so this handles both)
-julia_type_to_llvm_ir_string(::Type{Nothing}) = "void"
+_julia_type_to_llvm_ir_string(::Type{Nothing}) = "void"
 
 # Pointer types (opaque pointer in modern LLVM)
-julia_type_to_llvm_ir_string(::Type{<:Ptr}) = "ptr"
+_julia_type_to_llvm_ir_string(::Type{<:Ptr}) = "ptr"
 
 # Tuple types
-julia_type_to_llvm_ir_string(t::Type{<:Tuple}) = _tuple_type_to_llvm_ir(t)
+_julia_type_to_llvm_ir_string(t::Type{<:Tuple}) = _tuple_type_to_llvm_ir(t)
 
 # Struct types fallback (immutable structs)
-function julia_type_to_llvm_ir_string(t::Type)
+function _julia_type_to_llvm_ir_string(t::Type)
     if isstructtype(t) && !isabstracttype(t) && !isprimitivetype(t)
         return _struct_type_to_llvm_ir(t)
     else
@@ -175,7 +181,7 @@ function _tuple_type_to_llvm_ir(t::Type{<:Tuple})
     end
 
     param_types = t.parameters
-    llvm_types = [julia_type_to_llvm_ir_string(param) for param in param_types]
+    llvm_types = [_julia_type_to_llvm_ir_string(param) for param in param_types]
     return "{$(join(llvm_types, ", "))}"
 end
 
@@ -209,7 +215,7 @@ function _struct_type_to_llvm_ir(t::Type)
                 push!(llvm_fields, "i8")
             end
         end
-        llvm_type = julia_type_to_llvm_ir_string(ft)
+        llvm_type = _julia_type_to_llvm_ir_string(ft)
         push!(llvm_fields, llvm_type)
         current_offset = Int(field_offset) + sizeof(ft)
     end

--- a/src/llvmcodegen.jl
+++ b/src/llvmcodegen.jl
@@ -114,7 +114,9 @@ honoured, also for nested occurrences (tuple elements, struct fields), and
 take precedence over the built-in conversions. Such calls dispatch directly
 to the downstream method, so they do not emit the deprecation warning; they
 stop working when the function is removed together with the rest of the
-LLVM IR integration path.
+LLVM IR integration path. Method specificity between the built-in
+conversions and downstream ones is unchanged (the public name keeps a
+method per built-in signature).
 
 !!! warning "Deprecated"
     The LLVM IR integration path is deprecated and will be removed in a future
@@ -177,12 +179,39 @@ function _julia_type_to_llvm_ir_string(t::Type)
     end
 end
 
-# The single method RustCall itself defines for the public name; any other
-# applicable method was added by downstream code.
-const _PUBLIC_LLVM_IR_FALLBACK = which(julia_type_to_llvm_ir_string, Tuple{Type})
+# The public name keeps one (warning) method per built-in signature, mirroring
+# the private table, so method specificity between built-ins and downstream
+# extensions is exactly what it was before the deprecation: an exact `Int32`
+# built-in still beats a downstream `where T<:Integer`, and a downstream exact
+# `Tuple{Float32, Float32}` still beats the built-in `Type{<:Tuple}`.
+for T in [Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128,
+          Float32, Float64, Nothing]
+    @eval function julia_type_to_llvm_ir_string(t::Type{$T})
+        _llvm_path_depwarn("julia_type_to_llvm_ir_string", :julia_type_to_llvm_ir_string)
+        return _julia_type_to_llvm_ir_string(t)
+    end
+end
+for ctype in [Cint, Cuint, Clong, Culong, Csize_t, Cssize_t, Cptrdiff_t, Clonglong, Culonglong]
+    if ctype ∉ _LLVM_IR_BASE_TYPES
+        @eval function julia_type_to_llvm_ir_string(t::Type{$ctype})
+            _llvm_path_depwarn("julia_type_to_llvm_ir_string", :julia_type_to_llvm_ir_string)
+            return _julia_type_to_llvm_ir_string(t)
+        end
+    end
+end
+function julia_type_to_llvm_ir_string(t::Type{<:Ptr})
+    _llvm_path_depwarn("julia_type_to_llvm_ir_string", :julia_type_to_llvm_ir_string)
+    return _julia_type_to_llvm_ir_string(t)
+end
+function julia_type_to_llvm_ir_string(t::Type{<:Tuple})
+    _llvm_path_depwarn("julia_type_to_llvm_ir_string", :julia_type_to_llvm_ir_string)
+    return _julia_type_to_llvm_ir_string(t)
+end
 
+# Whether the method the public name would dispatch to for `t` was added by
+# downstream code (any module other than RustCall).
 function _has_public_llvm_ir_extension(t::Type)
-    return which(julia_type_to_llvm_ir_string, Tuple{Type{t}}) !== _PUBLIC_LLVM_IR_FALLBACK
+    return parentmodule(which(julia_type_to_llvm_ir_string, Tuple{Type{t}})) !== @__MODULE__
 end
 
 """

--- a/src/llvmintegration.jl
+++ b/src/llvmintegration.jl
@@ -2,6 +2,34 @@
 
 using LLVM
 
+# ============================================================================
+# Deprecation of the LLVM IR integration path (#265)
+# ============================================================================
+
+const LLVM_PATH_DEPRECATION_ISSUE = "https://github.com/AtelierArith/RustCall.jl/issues/265"
+
+"""
+    _llvm_path_depwarn(name::AbstractString, funcsym::Symbol)
+
+Emit the deprecation warning shared by every entry point of the LLVM IR
+integration path (`@rust_llvm`, `compile_rust_to_llvm_ir`, `load_llvm_ir`,
+`OptimizationConfig`, ...). `name` is shown to the user; `funcsym` is the
+function whose caller is reported (see `Base.depwarn`).
+
+The path is deprecated because its call mechanism is equivalent to `@rust`
+(a `ccall` through a function pointer) and because rustc tracks a newer LLVM
+than the one bundled with Julia, so the emitted IR cannot be parsed reliably.
+"""
+function _llvm_path_depwarn(name::AbstractString, funcsym::Symbol)
+    Base.depwarn(
+        "`$name` belongs to the LLVM IR integration path, which is deprecated and will be " *
+        "removed in a future release. It has no performance benefit over `@rust`, and the " *
+        "LLVM IR emitted by rustc cannot be parsed reliably by the LLVM bundled with Julia. " *
+        "Use `@rust` instead. See $LLVM_PATH_DEPRECATION_ISSUE.",
+        funcsym,
+    )
+end
+
 """
     RustModule
 
@@ -78,8 +106,18 @@ end
     load_llvm_ir(ir_file::String) -> RustModule
 
 Load an LLVM IR file and create a RustModule.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function load_llvm_ir(ir_file::String; source_code::String = "")
+    _llvm_path_depwarn("load_llvm_ir", :load_llvm_ir)
+    return _load_llvm_ir(ir_file; source_code)
+end
+
+function _load_llvm_ir(ir_file::String; source_code::String = "")
     # Read the IR file
     ir_content = read(ir_file, String)
 
@@ -144,8 +182,18 @@ end
     get_function_signature(fn::LLVM.Function) -> Tuple{Type, Vector{Type}}
 
 Get the Julia return type and argument types for an LLVM function.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function get_function_signature(fn::LLVM.Function)
+    _llvm_path_depwarn("get_function_signature", :get_function_signature)
+    return _get_function_signature(fn)
+end
+
+function _get_function_signature(fn::LLVM.Function)
     fn_type = LLVM.function_type(fn)
 
     # Get return type
@@ -294,6 +342,11 @@ This function is a placeholder for future LLVM JIT compilation support.
 Currently, it raises an error indicating that direct LLVM JIT compilation
 is not yet implemented. Use the shared library approach instead.
 
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
+
 # Example
 ```julia
 mod = load_llvm_ir("path/to/file.ll")
@@ -302,6 +355,7 @@ mod = load_llvm_ir("path/to/file.ll")
 ```
 """
 function get_or_compile_function(mod::RustModule, name::String)
+    _llvm_path_depwarn("get_or_compile_function", :get_or_compile_function)
     fn = get_function(mod, name)
     if fn === nothing
         error("Function '$name' not found in module")

--- a/src/llvmoptimization.jl
+++ b/src/llvmoptimization.jl
@@ -20,6 +20,16 @@ struct OptimizationConfig
     enable_vectorization::Bool
     enable_loop_unrolling::Bool
     enable_licm::Bool  # Loop-invariant code motion
+
+    # Positional construction is public API too, so it warns as well (#265).
+    # `_optimization_config` passes `_warn=false` for internal use.
+    function OptimizationConfig(level::Int, size_level::Int, inline_threshold::Int,
+                                enable_vectorization::Bool, enable_loop_unrolling::Bool,
+                                enable_licm::Bool; _warn::Bool = true)
+        _warn && _llvm_path_depwarn("OptimizationConfig", :OptimizationConfig)
+        return new(level, size_level, inline_threshold,
+                   enable_vectorization, enable_loop_unrolling, enable_licm)
+    end
 end
 
 """
@@ -48,7 +58,7 @@ function _optimization_config(;
     @assert 0 <= level <= 3 "Optimization level must be 0-3"
     @assert 0 <= size_level <= 2 "Size level must be 0-2"
     OptimizationConfig(level, size_level, inline_threshold,
-                      enable_vectorization, enable_loop_unrolling, enable_licm)
+                       enable_vectorization, enable_loop_unrolling, enable_licm; _warn=false)
 end
 
 # Default optimization config

--- a/src/llvmoptimization.jl
+++ b/src/llvmoptimization.jl
@@ -32,6 +32,16 @@ struct OptimizationConfig
     end
 end
 
+# Defining a typed inner constructor suppresses Julia's default converting
+# outer constructor; keep positional calls with convertible arguments
+# (`OptimizationConfig(Int8(2), Int8(0), Int16(225), true, true, true)`) working.
+function OptimizationConfig(level, size_level, inline_threshold,
+                            enable_vectorization, enable_loop_unrolling, enable_licm)
+    return OptimizationConfig(Int(level), Int(size_level), Int(inline_threshold),
+                              Bool(enable_vectorization), Bool(enable_loop_unrolling),
+                              Bool(enable_licm))
+end
+
 """
     OptimizationConfig(; kwargs...)
 

--- a/src/llvmoptimization.jl
+++ b/src/llvmoptimization.jl
@@ -7,6 +7,11 @@ using LLVM
     OptimizationConfig
 
 Configuration for LLVM optimization passes.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 struct OptimizationConfig
     level::Int  # 0-3
@@ -21,8 +26,18 @@ end
     OptimizationConfig(; kwargs...)
 
 Create an OptimizationConfig with specified settings.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
-function OptimizationConfig(;
+function OptimizationConfig(; kwargs...)
+    _llvm_path_depwarn("OptimizationConfig", :OptimizationConfig)
+    return _optimization_config(; kwargs...)
+end
+
+function _optimization_config(;
     level::Int = 2,
     size_level::Int = 0,
     inline_threshold::Int = 225,
@@ -41,12 +56,13 @@ const DEFAULT_OPT_CONFIG = Ref{OptimizationConfig}()
 
 function get_default_opt_config()
     if !isassigned(DEFAULT_OPT_CONFIG)
-        DEFAULT_OPT_CONFIG[] = OptimizationConfig()
+        DEFAULT_OPT_CONFIG[] = _optimization_config()
     end
     return DEFAULT_OPT_CONFIG[]
 end
 
 function set_default_opt_config(config::OptimizationConfig)
+    _llvm_path_depwarn("set_default_opt_config", :set_default_opt_config)
     DEFAULT_OPT_CONFIG[] = config
 end
 
@@ -55,8 +71,18 @@ end
 
 Apply optimization passes to an LLVM module using LLVM's New Pass Manager.
 Returns the optimized module (modified in place).
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function optimize_module!(mod::LLVM.Module; config::OptimizationConfig = get_default_opt_config())
+    _llvm_path_depwarn("optimize_module!", :optimize_module!)
+    return _optimize_module!(mod; config)
+end
+
+function _optimize_module!(mod::LLVM.Module; config::OptimizationConfig = get_default_opt_config())
     if config.level == 0 && config.size_level == 0
         return mod
     end
@@ -99,8 +125,14 @@ end
     optimize_function!(fn::LLVM.Function; config=get_default_opt_config())
 
 Apply optimization passes to a single LLVM function.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function optimize_function!(fn::LLVM.Function; config::OptimizationConfig = get_default_opt_config())
+    _llvm_path_depwarn("optimize_function!", :optimize_function!)
     mod = LLVM.parent(fn)
 
     if config.level == 0
@@ -201,9 +233,15 @@ end
     optimize_for_speed!(mod::LLVM.Module)
 
 Apply optimizations focused on execution speed.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function optimize_for_speed!(mod::LLVM.Module)
-    config = OptimizationConfig(
+    _llvm_path_depwarn("optimize_for_speed!", :optimize_for_speed!)
+    config = _optimization_config(
         level=3,
         size_level=0,
         inline_threshold=300,
@@ -211,16 +249,22 @@ function optimize_for_speed!(mod::LLVM.Module)
         enable_loop_unrolling=true,
         enable_licm=true
     )
-    return optimize_module!(mod; config=config)
+    return _optimize_module!(mod; config=config)
 end
 
 """
     optimize_for_size!(mod::LLVM.Module)
 
 Apply optimizations focused on code size.
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function optimize_for_size!(mod::LLVM.Module)
-    config = OptimizationConfig(
+    _llvm_path_depwarn("optimize_for_size!", :optimize_for_size!)
+    config = _optimization_config(
         level=2,
         size_level=2,
         inline_threshold=50,
@@ -228,15 +272,21 @@ function optimize_for_size!(mod::LLVM.Module)
         enable_loop_unrolling=false,
         enable_licm=true
     )
-    return optimize_module!(mod; config=config)
+    return _optimize_module!(mod; config=config)
 end
 
 """
     optimize_balanced!(mod::LLVM.Module)
 
 Apply balanced optimizations (default).
+
+!!! warning "Deprecated"
+    The LLVM IR integration path is deprecated and will be removed in a future
+    release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+    Use `@rust` instead.
 """
 function optimize_balanced!(mod::LLVM.Module)
-    config = OptimizationConfig()  # Uses defaults
-    return optimize_module!(mod; config=config)
+    _llvm_path_depwarn("optimize_balanced!", :optimize_balanced!)
+    config = _optimization_config()  # Uses defaults
+    return _optimize_module!(mod; config=config)
 end

--- a/src/llvmoptimization.jl
+++ b/src/llvmoptimization.jl
@@ -75,6 +75,11 @@ end
 const DEFAULT_OPT_CONFIG = Ref{OptimizationConfig}()
 
 function get_default_opt_config()
+    _llvm_path_depwarn("get_default_opt_config", :get_default_opt_config)
+    return _get_default_opt_config()
+end
+
+function _get_default_opt_config()
     if !isassigned(DEFAULT_OPT_CONFIG)
         DEFAULT_OPT_CONFIG[] = _optimization_config()
     end
@@ -97,12 +102,12 @@ Returns the optimized module (modified in place).
     release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
     Use `@rust` instead.
 """
-function optimize_module!(mod::LLVM.Module; config::OptimizationConfig = get_default_opt_config())
+function optimize_module!(mod::LLVM.Module; config::OptimizationConfig = _get_default_opt_config())
     _llvm_path_depwarn("optimize_module!", :optimize_module!)
     return _optimize_module!(mod; config)
 end
 
-function _optimize_module!(mod::LLVM.Module; config::OptimizationConfig = get_default_opt_config())
+function _optimize_module!(mod::LLVM.Module; config::OptimizationConfig = _get_default_opt_config())
     if config.level == 0 && config.size_level == 0
         return mod
     end
@@ -151,7 +156,7 @@ Apply optimization passes to a single LLVM function.
     release (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
     Use `@rust` instead.
 """
-function optimize_function!(fn::LLVM.Function; config::OptimizationConfig = get_default_opt_config())
+function optimize_function!(fn::LLVM.Function; config::OptimizationConfig = _get_default_opt_config())
     _llvm_path_depwarn("optimize_function!", :optimize_function!)
     mod = LLVM.parent(fn)
 

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -253,6 +253,10 @@ end
     # Positional construction bypasses the keyword wrapper but must warn too.
     positional = @test_deprecated RustCall.OptimizationConfig(2, 0, 225, true, true, true)
     @test positional.inline_threshold == 225
+    # Convertible argument types still construct (Julia's default converting
+    # constructor is suppressed by the typed inner constructor).
+    converting = @test_deprecated RustCall.OptimizationConfig(Int8(2), Int8(0), Int16(225), true, true, true)
+    @test converting == positional
 
     @test_deprecated RustCall.set_default_opt_config(RustCall._optimization_config())
     @test_deprecated RustCall.get_registered_function("no_such_function_265")

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -237,6 +237,9 @@ primitive type _Dep265Prim 8 end
 struct _Dep265Wrap
     x::_Dep265Prim
 end
+struct _Dep265Pair
+    v::Tuple{Float32, Float32}
+end
 
 @testset "LLVM path deprecation (#265)" begin
     # Every public entry point of the LLVM IR integration path emits a
@@ -262,6 +265,21 @@ end
     @test RustCall._julia_type_to_llvm_ir_string(Tuple{_Dep265Prim}) == "{i8}"
     @test RustCall._julia_type_to_llvm_ir_string(_Dep265Wrap) == "{i8}"
     @test RustCall._julia_type_to_llvm_ir_string(Tuple{Int32, _Dep265Prim}) == "{i32, i8}"
+    # A downstream override of an already supported signature (e.g. a SIMD ABI
+    # for a tuple) also wins, at top level and nested, as it did when the
+    # built-ins were methods of the public name.
+    @eval RustCall.julia_type_to_llvm_ir_string(::Type{Tuple{Float32, Float32}}) = "<2 x float>"
+    @test RustCall._llvm_ir_type(Tuple{Float32, Float32}) == "<2 x float>"
+    @test RustCall._llvm_ir_type(Tuple{Int32, Tuple{Float32, Float32}}) == "{i32, <2 x float>}"
+    @test RustCall._llvm_ir_type(_Dep265Pair) == "{<2 x float>}"
+    @test occursin("<2 x float>", RustCall.generate_llvmcall_ir("f", Tuple{Float32, Float32}, Type[Int32]))
+    # Built-ins are untouched
+    @test RustCall._llvm_ir_type(Tuple{Float64, Float64}) == "{double, double}"
+    # Calls that hit a downstream method dispatch to it directly and therefore do
+    # not warn (documented exception).
+    if Base.JLOptions().depwarn != 0
+        @test_logs RustCall.julia_type_to_llvm_ir_string(_Dep265Prim)
+    end
 
     # Internal helpers used by @rust and by the deprecated wrappers stay silent.
     if Base.JLOptions().depwarn != 0

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -242,13 +242,19 @@ end
     @test config isa RustCall.OptimizationConfig
     @test config.level == 1
 
+    # Positional construction bypasses the keyword wrapper but must warn too.
+    positional = @test_deprecated RustCall.OptimizationConfig(2, 0, 225, true, true, true)
+    @test positional.inline_threshold == 225
+
     @test_deprecated RustCall.set_default_opt_config(RustCall._optimization_config())
     @test_deprecated RustCall.get_registered_function("no_such_function_265")
+    @test (@test_deprecated RustCall.julia_type_to_llvm_ir_string(Int32)) == "i32"
 
     # Internal helpers used by @rust and by the deprecated wrappers stay silent.
     if Base.JLOptions().depwarn != 0
         @test_logs RustCall._optimization_config()
         @test_logs RustCall._get_registered_function("no_such_function_265")
+        @test_logs RustCall._julia_type_to_llvm_ir_string(Int32)
     end
 
     if RustCall.check_rustc_available()

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -260,6 +260,7 @@ primitive type _Dep265Int <: Integer 8 end
     @test converting == positional
 
     @test_deprecated RustCall.set_default_opt_config(RustCall._optimization_config())
+    @test (@test_deprecated RustCall.get_default_opt_config()) isa RustCall.OptimizationConfig
     @test_deprecated RustCall.get_registered_function("no_such_function_265")
     @test (@test_deprecated RustCall.julia_type_to_llvm_ir_string(Int32)) == "i32"
 
@@ -301,6 +302,7 @@ primitive type _Dep265Int <: Integer 8 end
     # Internal helpers used by @rust and by the deprecated wrappers stay silent.
     if Base.JLOptions().depwarn != 0
         @test_logs RustCall._optimization_config()
+        @test_logs RustCall._get_default_opt_config()
         @test_logs RustCall._get_registered_function("no_such_function_265")
         @test_logs RustCall._julia_type_to_llvm_ir_string(Int32)
     end

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -233,6 +233,11 @@ using Test
     end
 end
 
+primitive type _Dep265Prim 8 end
+struct _Dep265Wrap
+    x::_Dep265Prim
+end
+
 @testset "LLVM path deprecation (#265)" begin
     # Every public entry point of the LLVM IR integration path emits a
     # deprecation warning but keeps working. `@test_deprecated` checks the
@@ -249,6 +254,14 @@ end
     @test_deprecated RustCall.set_default_opt_config(RustCall._optimization_config())
     @test_deprecated RustCall.get_registered_function("no_such_function_265")
     @test (@test_deprecated RustCall.julia_type_to_llvm_ir_string(Int32)) == "i32"
+
+    # Downstream extensions of the public name still apply to nested conversions
+    # (tuple elements, struct fields) even though recursion goes through the
+    # private helper.
+    @eval RustCall.julia_type_to_llvm_ir_string(::Type{$(Symbol("_Dep265Prim"))}) = "i8"
+    @test RustCall._julia_type_to_llvm_ir_string(Tuple{_Dep265Prim}) == "{i8}"
+    @test RustCall._julia_type_to_llvm_ir_string(_Dep265Wrap) == "{i8}"
+    @test RustCall._julia_type_to_llvm_ir_string(Tuple{Int32, _Dep265Prim}) == "{i32, i8}"
 
     # Internal helpers used by @rust and by the deprecated wrappers stay silent.
     if Base.JLOptions().depwarn != 0

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -232,3 +232,55 @@ using Test
         @warn "rustc not found, skipping LLVM integration tests"
     end
 end
+
+@testset "LLVM path deprecation (#265)" begin
+    # Every public entry point of the LLVM IR integration path emits a
+    # deprecation warning but keeps working. `@test_deprecated` checks the
+    # warning under --depwarn=yes (Pkg.test) and just runs the expression
+    # otherwise.
+    config = @test_deprecated RustCall.OptimizationConfig(level=1)
+    @test config isa RustCall.OptimizationConfig
+    @test config.level == 1
+
+    @test_deprecated RustCall.set_default_opt_config(RustCall._optimization_config())
+    @test_deprecated RustCall.get_registered_function("no_such_function_265")
+
+    # Internal helpers used by @rust and by the deprecated wrappers stay silent.
+    if Base.JLOptions().depwarn != 0
+        @test_logs RustCall._optimization_config()
+        @test_logs RustCall._get_registered_function("no_such_function_265")
+    end
+
+    if RustCall.check_rustc_available()
+        rust"""
+        #[no_mangle]
+        pub extern "C" fn dep265_add(a: i32, b: i32) -> i32 { a + b }
+        """
+        result = @test_deprecated @rust_llvm dep265_add(Int32(1), Int32(2))
+        @test result == Int32(3)
+        # The non-deprecated equivalent
+        @test (@rust dep265_add(Int32(1), Int32(2))::Int32) == Int32(3)
+
+        wrapped = RustCall.wrap_rust_code("""
+        #[no_mangle]
+        pub extern "C" fn dep265_mul(a: i32, b: i32) -> i32 { a * b }
+        """)
+        compiler = RustCall.get_default_compiler()
+        ir_path = @test_deprecated RustCall.compile_rust_to_llvm_ir(wrapped; compiler=compiler)
+        @test isfile(ir_path)
+        rust_mod = @test_deprecated RustCall.load_llvm_ir(ir_path; source_code=wrapped)
+        @test rust_mod isa RustCall.RustModule
+        fn = RustCall.get_function(rust_mod, "dep265_mul")
+        if fn !== nothing
+            sig = @test_deprecated RustCall.get_function_signature(fn)
+            @test sig == (Int32, [Int32, Int32])
+            @test_deprecated RustCall.optimize_module!(rust_mod.mod)
+            @test_deprecated RustCall.optimize_for_speed!(rust_mod.mod)
+        end
+        info = @test_deprecated RustCall.compile_and_register_rust_function("""
+        #[no_mangle]
+        pub extern "C" fn dep265_sub(a: i32, b: i32) -> i32 { a - b }
+        """, "dep265_sub")
+        @test info.name == "dep265_sub"
+    end
+end

--- a/test/test_llvmcall.jl
+++ b/test/test_llvmcall.jl
@@ -240,6 +240,7 @@ end
 struct _Dep265Pair
     v::Tuple{Float32, Float32}
 end
+primitive type _Dep265Int <: Integer 8 end
 
 @testset "LLVM path deprecation (#265)" begin
     # Every public entry point of the LLVM IR integration path emits a
@@ -279,6 +280,18 @@ end
     @test occursin("<2 x float>", RustCall.generate_llvmcall_ir("f", Tuple{Float32, Float32}, Type[Int32]))
     # Built-ins are untouched
     @test RustCall._llvm_ir_type(Tuple{Float64, Float64}) == "{double, double}"
+    # A broad downstream method does not override more specific built-ins
+    # (original dispatch ordering), but applies to types it alone covers.
+    @eval RustCall.julia_type_to_llvm_ir_string(::Type{T}) where {T<:Integer} = "broad"
+    @test RustCall._llvm_ir_type(Int32) == "i32"
+    @test RustCall._llvm_ir_type(Tuple{Int64, UInt8}) == "{i64, i8}"
+    @test RustCall._llvm_ir_type(_Dep265Int) == "broad"
+    @test RustCall._llvm_ir_type(Tuple{Int32, _Dep265Int}) == "{i32, broad}"
+    @test occursin("i32", RustCall.generate_llvmcall_ir("g", Int32, Type[Int64]))
+    @test !occursin("broad", RustCall.generate_llvmcall_ir("g", Int32, Type[Int64]))
+    # Built-in signatures still warn through the public name.
+    @test (@test_deprecated RustCall.julia_type_to_llvm_ir_string(Tuple{Int32})) == "{i32}"
+    @test (@test_deprecated RustCall.julia_type_to_llvm_ir_string(Ptr{Cvoid})) == "ptr"
     # Calls that hit a downstream method dispatch to it directly and therefore do
     # not warn (documented exception).
     if Base.JLOptions().depwarn != 0


### PR DESCRIPTION
Phase 1 of #265: deprecate the LLVM IR integration path while keeping it functional. Phase 2 (removal, dropping `LLVM.jl`) is left for a breaking release.

## What changes

- Every public entry point emits `Base.depwarn` once per call site and then behaves exactly as before:
  `@rust_llvm`, `compile_and_register_rust_function`, `get_registered_function`, `compile_rust_to_llvm_ir`, `load_llvm_ir`, `get_function_signature`, `get_or_compile_function`, `OptimizationConfig`, `set_default_opt_config`, `optimize_module!`, `optimize_function!`, `optimize_for_speed!`, `optimize_for_size!`, `optimize_balanced!`.
- Internal callers go through `_`-prefixed helpers (`_load_llvm_ir`, `_get_function_signature`, `_optimization_config`, ...) so that `@rust`'s type-inference fallback and the registration pipeline do not warn on their own, and a single user call does not cascade into several warnings.
- The shared warning text (`_llvm_path_depwarn` in `src/llvmintegration.jl`) states the rationale: `@rust_llvm` is a plain function-pointer `ccall` like `@rust`, and rustc's LLVM IR (LLVM 22 for rustc 1.98) cannot be parsed reliably by the LLVM bundled with Julia (LLVM 18 for Julia 1.12).
- Docstrings carry a `!!! warning "Deprecated"` admonition; `docs/src/{performance,tutorial,examples,api,index,status}.md`, `README.md` and `CHANGELOG.md` describe the deprecation and point to `@rust`.
- `test/test_llvmcall.jl` gains a `LLVM path deprecation (#265)` testset using `@test_deprecated`, and checks that the internal helpers stay silent under `--depwarn=yes`.

## Verification

- `julia --project --depwarn=yes test/test_llvmcall.jl` (78 tests pass, including the new testset)
- `test_core_api`, `test_regressions`, `test_llvm_fixes`, `test_types_memory_safety` under `--depwarn=yes`: no failures (existing calls to the deprecated API now print the warning, which is the intended behaviour under `Pkg.test`)
- `scripts/lint_interpolation.sh`, `scripts/lint_rust_syntax_regex.sh`

Closes nothing yet; #265 stays open for Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
