### PR TITLE
Bump pyo3 to 0.29 in sample_crate_pyo3 (Dependabot alerts #2, #3)

### DIFF
--- a/examples/sample_crate_pyo3/Cargo.toml
+++ b/examples/sample_crate_pyo3/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 juliacall_macros = { path = "../../deps/juliacall_macros" }
-pyo3 = { version = "0.24", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.29", features = ["extension-module"], optional = true }
 
 [features]
 default = []

--- a/examples/sample_crate_pyo3/README.md
+++ b/examples/sample_crate_pyo3/README.md
@@ -156,7 +156,7 @@ All APIs are generated from `#[julia_pyo3]` - **same function names** in both la
 ```toml
 [dependencies]
 juliacall_macros = { path = "../../deps/juliacall_macros" }
-pyo3 = { version = "0.24", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.29", features = ["extension-module"], optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

Fixes Dependabot security alert #2 (and #3, which affects the same dependency).

| | |
|---|---|
| Package | `pyo3` (crates.io) |
| Manifest | `examples/sample_crate_pyo3/Cargo.toml` |
| Vulnerable range | `< 0.29.0` |
| First patched version | `0.29.0` (resolves to `0.29.2`) |
| Alert #2 | [GHSA-36hh-v3qg-5jq4](https://github.com/advisories/GHSA-36hh-v3qg-5jq4) - out-of-bounds read in `nth` / `nth_back` for `PyList` and `PyTuple` iterators |
| Alert #3 | [GHSA-chgr-c6px-7xpp](https://github.com/advisories/GHSA-chgr-c6px-7xpp) - missing `Sync` bound on `PyCFunction::new_closure` closures |

## Change

- `examples/sample_crate_pyo3/Cargo.toml`: `pyo3 = "0.24"` -> `pyo3 = "0.29"` (optional dependency behind the `python` feature).
- `examples/sample_crate_pyo3/README.md`: the snippet mirroring the manifest is updated to match.

No lockfile is checked in for this example crate, so the manifest bump is the whole fix. `deps/juliacall_macros` does not depend on `pyo3` itself (its `python` feature only toggles code generation), so no other crate is affected.

## Verification (in `examples/sample_crate_pyo3`)

- `cargo build` - OK
- `cargo check --features python` - OK (pyo3 0.29.2; generated `#[julia_pyo3]` bindings compile unchanged)
- `cargo build --features python` with `-C link-arg=-undefined -C link-arg=dynamic_lookup` (macOS extension-module linking, as maturin does) - OK
- `cargo test` - OK
- `cargo clippy -- -D warnings` reports the same 8 pre-existing `not_unsafe_ptr_arg_deref` errors on `main` as on this branch (macro-generated FFI wrappers); this example crate is not part of the CI clippy set and the result is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
