### PR TITLE
Explicit load/compile policy object (#277, Phase A)

### DIFF
--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -40,6 +40,12 @@ include("llvmintegration.jl")
 include("codegen.jl")
 include("exceptions.jl")
 include("cache.jl")
+
+# Explicit load/compile policy object (#277, Phase A). Additive: not yet used
+# by any call site. Functions here reference RUST_LIBRARIES / CURRENT_LIB from
+# ruststr.jl, which is resolved at call time, so it can sit right after cache.jl.
+include("loadpolicy.jl")
+
 include("memory.jl")
 
 # Phase 3: External library integration

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -1,0 +1,529 @@
+# Explicit load/compile policy object (issue #277, Phase A).
+#
+# Today every compile/load front door carries its own copy of four decisions:
+#
+#   1. the `dlopen` flag set (`RTLD_LOCAL` vs `RTLD_GLOBAL`)          — 12 sites
+#   2. the panic strategy of the produced artifact (`abort` vs `unwind`)
+#      and what the generated `extern "C"` boundary does about it
+#   3. whether the loaded handle is registered in `RUST_LIBRARIES`,
+#      under what kind of key, and whether `CURRENT_LIB` moves        — 7 sites
+#   4. the finalizer / ownership policy of the types the artifact produces
+#
+# Because the policy lives at the call site, the same user-visible construct
+# behaves differently depending on which door it came through — or even on
+# whether the cache hit (#250).  This file introduces one record that names
+# those four decisions, plus one named constructor per existing front door, so
+# that Phase B can move call sites onto the shared loader one at a time without
+# having to agree on the target policy first.
+#
+# Phase A is strictly additive: nothing in this file is called from the rest of
+# `src/` yet, and no existing behaviour changes.  Each constructor below
+# reproduces *what its call sites do today*, divergences included; the
+# divergences are pinned down by `test/test_loadpolicy.jl` so that Phase B
+# migrations are visible as test changes.
+#
+# Related issues: #244 (panic containment), #249 (finalizers), #250 (symbol
+# visibility / unload), #252, #255 (failed hot reload empties the registry),
+# #269 (follow-up), #251 (registry consolidation).
+
+"""
+    SYMBOL_VISIBILITY_RULE
+
+Prose statement of the rule Phase B should apply when choosing `RTLD_GLOBAL`
+over `RTLD_LOCAL`.  Kept as data so the tests and the docs quote one text.
+
+The rule: a library is loaded `RTLD_GLOBAL` **only** when other libraries
+loaded later must resolve undefined symbols against it — in practice only the
+ownership helper library (`deps/rust_helpers`, `src/memory.jl`) and, in the
+future, any explicitly declared "provides symbols to other artifacts" library.
+Everything else — inline `rust\"\"\"` blocks, Cargo-backed blocks, `@rust_crate`
+libraries, monomorphized generics, `@irust` snippets — is a leaf artifact whose
+symbols are reached through its own handle via `dlsym`, and must therefore be
+`RTLD_LOCAL` so that two blocks defining the same `#[no_mangle]` name cannot
+shadow one another in the process-global namespace.
+
+Note that the helper library is one of the few loaded `RTLD_LOCAL` today, and
+the leaf artifacts are mostly loaded `RTLD_GLOBAL` — i.e. current `main` has
+the rule exactly inverted.  Phase A only records this; it changes nothing.
+"""
+const SYMBOL_VISIBILITY_RULE = """
+RTLD_GLOBAL is for libraries whose symbols other libraries resolve against \
+(the ownership helper library); every leaf artifact reached through its own \
+handle via dlsym is RTLD_LOCAL.\
+"""
+
+"""
+    LoadPolicy
+
+One explicit record of the load/compile policy for a single compiled artifact.
+
+Construct one through a named constructor (see [`inline_rustc_policy`](@ref),
+[`inline_cargo_policy`](@ref), [`crate_policy`](@ref),
+[`helper_library_policy`](@ref), [`cache_hit_policy`](@ref)) rather than
+calling this constructor directly, so that every front door keeps a name.
+
+# Fields
+
+- `name::String` — the front door this policy describes, for diagnostics.
+
+- `dlopen_flags::UInt32` — the exact flag set handed to `Libdl.dlopen`.
+  Subsumes the 12 open-coded flag sets listed in `call_sites`.
+
+- `global_symbols::Bool` — whether the flag set includes `RTLD_GLOBAL`, i.e.
+  whether this artifact publishes its symbols into the process-global
+  namespace.  See [`SYMBOL_VISIBILITY_RULE`](@ref) for when that is legitimate.
+
+- `panic_strategy::Symbol` — `:abort` or `:unwind`, the panic strategy the
+  artifact is *compiled* with.  `:abort` corresponds to `-C panic=abort`
+  (`src/compiler.jl:219`, `:381`); `:unwind` is the Cargo path, whose generated
+  `[profile.release]` sets only `opt-level`/`lto` (`src/cargoproject.jl:126-128`).
+
+- `boundary_catches_panics::Bool` — whether the generated `extern "C"` wrapper
+  is expected to wrap the user body in `std::panic::catch_unwind`.  There are
+  zero `catch_unwind` in the tree today, so this is `false` everywhere; on the
+  `:unwind` paths that means a panic crossing the boundary is undefined
+  behaviour (#244).
+
+- `registry::Symbol` — where the loaded handle is recorded:
+  `:rust_libraries` (the `RUST_LIBRARIES` dict), `:module_local` (a `Ref` in
+  the generated `@rust_crate` module), `:helper_slot` (`RUST_HELPERS_LIB`), or
+  `:none`.
+
+- `registry_key_kind::Symbol` — the shape of the key used with
+  `:rust_libraries`: `:content_hash` (`rust_<hash>` from the inline paths),
+  `:lib_basename` (generics), `:irust_hash` (`irust_<hash>`),
+  `:crate_lib_name` (hot reload), or `:none`.
+
+- `sets_current_lib::Bool` — whether the site also moves `CURRENT_LIB[]`.
+
+- `finalizer_frees::Bool` — whether objects produced by this artifact free
+  their Rust allocation in their finalizer.  `false` for inline `#[julia]`
+  structs (`src/structs.jl:157-159`, `:282-285`, disabled "to diagnose
+  segfault"), `true` for `@rust_crate` structs (`src/crate_bindings.jl:550`) —
+  opposite lifetime semantics for the same user-visible construct (#249).
+
+- `call_sites::Vector{String}` — the `file:line` sites this policy is intended
+  to subsume in Phase B.
+
+- `issues::Vector{Int}` — the open issues caused by this policy's divergence.
+
+- `notes::String` — free-form description of the divergence.
+"""
+struct LoadPolicy
+    name::String
+    dlopen_flags::UInt32
+    global_symbols::Bool
+    panic_strategy::Symbol
+    boundary_catches_panics::Bool
+    registry::Symbol
+    registry_key_kind::Symbol
+    sets_current_lib::Bool
+    finalizer_frees::Bool
+    call_sites::Vector{String}
+    issues::Vector{Int}
+    notes::String
+end
+
+const _VALID_PANIC_STRATEGIES = (:abort, :unwind)
+const _VALID_REGISTRIES = (:rust_libraries, :module_local, :helper_slot, :none)
+const _VALID_KEY_KINDS = (:content_hash, :lib_basename, :irust_hash, :crate_lib_name, :none)
+
+"""
+    LoadPolicy(name; kwargs...) -> LoadPolicy
+
+Keyword constructor with the conservative defaults Phase B should converge on:
+`RTLD_LOCAL | RTLD_NOW`, `panic=abort`, registration in `RUST_LIBRARIES` under
+a content hash, `CURRENT_LIB` untouched, and finalizers that free.
+
+Every named constructor below overrides whatever its call sites do differently.
+"""
+function LoadPolicy(name::AbstractString;
+                    dlopen_flags::Integer = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
+                    panic_strategy::Symbol = :abort,
+                    boundary_catches_panics::Bool = false,
+                    registry::Symbol = :rust_libraries,
+                    registry_key_kind::Symbol = :content_hash,
+                    sets_current_lib::Bool = false,
+                    finalizer_frees::Bool = true,
+                    call_sites::AbstractVector{<:AbstractString} = String[],
+                    issues::AbstractVector{<:Integer} = Int[],
+                    notes::AbstractString = "")
+    panic_strategy in _VALID_PANIC_STRATEGIES ||
+        throw(ArgumentError("invalid panic_strategy $(panic_strategy); expected one of $(_VALID_PANIC_STRATEGIES)"))
+    registry in _VALID_REGISTRIES ||
+        throw(ArgumentError("invalid registry $(registry); expected one of $(_VALID_REGISTRIES)"))
+    registry_key_kind in _VALID_KEY_KINDS ||
+        throw(ArgumentError("invalid registry_key_kind $(registry_key_kind); expected one of $(_VALID_KEY_KINDS)"))
+    if registry !== :rust_libraries && registry_key_kind !== :none
+        throw(ArgumentError("registry_key_kind must be :none unless registry is :rust_libraries"))
+    end
+    flags = UInt32(dlopen_flags)
+    return LoadPolicy(String(name), flags,
+                      (flags & UInt32(Libdl.RTLD_GLOBAL)) != 0,
+                      panic_strategy, boundary_catches_panics,
+                      registry, registry_key_kind, sets_current_lib,
+                      finalizer_frees,
+                      String[String(s) for s in call_sites],
+                      Int[Int(i) for i in issues],
+                      String(notes))
+end
+
+# ---------------------------------------------------------------------------
+# Named constructors: one per front door that exists on current `main`.
+# Each reproduces today's behaviour so a Phase B migration is behaviour-neutral
+# at the moment of the swap.
+# ---------------------------------------------------------------------------
+
+"""
+    inline_rustc_policy() -> LoadPolicy
+
+Inline `rust\"\"\"...\"\"\"` block with no `// cargo-deps:`, compiled straight by
+`rustc` and loaded on a cache **miss**.
+
+Subsumes `src/ruststr.jl:284` (dlopen, `RTLD_LOCAL`) and the registration at
+`src/ruststr.jl:291`.  Compiled with `-C panic=abort` (`src/compiler.jl:381`).
+
+Diverges from [`cache_hit_policy`](@ref) — which is the *same block* on a cache
+hit — only in the direction of the divergence being invisible to the user
+(#250).
+"""
+inline_rustc_policy() = LoadPolicy("inline-rustc";
+    dlopen_flags = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
+    panic_strategy = :abort,
+    boundary_catches_panics = false,
+    registry = :rust_libraries,
+    registry_key_kind = :content_hash,
+    sets_current_lib = true,
+    finalizer_frees = false,
+    call_sites = ["src/ruststr.jl:284", "src/ruststr.jl:291",
+                  "src/compiler.jl:381", "src/structs.jl:282-285"],
+    issues = [244, 249, 250],
+    notes = "RTLD_LOCAL here but RTLD_GLOBAL for the same block on a cache " *
+            "hit (src/ruststr.jl:386) and on the Cargo path; inline #[julia] " *
+            "struct finalizers do not free.")
+
+"""
+    inline_cargo_policy() -> LoadPolicy
+
+Inline `rust\"\"\"...\"\"\"` block carrying `// cargo-deps:`, built through a
+generated Cargo project.
+
+Subsumes `src/ruststr.jl:419` (build) and `src/ruststr.jl:386` (Cargo cache
+hit), both `RTLD_GLOBAL`, with registration at `:426` / `:389`.
+
+The generated `Cargo.toml` writes only `opt-level`/`lto`
+(`src/cargoproject.jl:126-128`), so the artifact **unwinds** while the direct
+`rustc` path aborts — and no boundary catches the unwind (#244).
+"""
+inline_cargo_policy() = LoadPolicy("inline-cargo";
+    dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
+    panic_strategy = :unwind,
+    boundary_catches_panics = false,
+    registry = :rust_libraries,
+    registry_key_kind = :content_hash,
+    sets_current_lib = true,
+    finalizer_frees = false,
+    call_sites = ["src/ruststr.jl:386", "src/ruststr.jl:389",
+                  "src/ruststr.jl:419", "src/ruststr.jl:426",
+                  "src/cargoproject.jl:126-128"],
+    issues = [244, 250],
+    notes = "Cargo path unwinds while the rustc path aborts, and loads " *
+            "RTLD_GLOBAL where the rustc path loads RTLD_LOCAL.")
+
+"""
+    crate_policy() -> LoadPolicy
+
+`@rust_crate` bindings, both the in-memory module (`src/crate_bindings.jl:344`)
+and the emitted bindings file template (`src/crate_bindings.jl:1360`).
+
+The handle lives in a module-local `_LIB_HANDLE` `Ref`, not in `RUST_LIBRARIES`,
+so `RustCall`-level unload never sees it.  Crate structs *do* free in their
+finalizer (`src/crate_bindings.jl:550`), the opposite of inline structs (#249).
+Built by Cargo, hence `:unwind`.
+"""
+crate_policy() = LoadPolicy("rust-crate";
+    dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
+    panic_strategy = :unwind,
+    boundary_catches_panics = false,
+    registry = :module_local,
+    registry_key_kind = :none,
+    sets_current_lib = false,
+    finalizer_frees = true,
+    call_sites = ["src/crate_bindings.jl:344", "src/crate_bindings.jl:550",
+                  "src/crate_bindings.jl:1360"],
+    issues = [249, 250],
+    notes = "Only front door whose struct finalizers free; handle is not in " *
+            "RUST_LIBRARIES so it cannot be unloaded through the registry.")
+
+"""
+    helper_library_policy() -> LoadPolicy
+
+The ownership helper library `deps/rust_helpers`, loaded by
+`src/memory.jl:215` and `:321` into `RUST_HELPERS_LIB`.
+
+This is the one library other artifacts could legitimately need to resolve
+symbols against ([`SYMBOL_VISIBILITY_RULE`](@ref)), yet it is the one loaded
+`RTLD_LOCAL` today.  Recorded as-is; Phase A changes nothing.
+"""
+helper_library_policy() = LoadPolicy("helper-library";
+    dlopen_flags = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
+    panic_strategy = :abort,
+    boundary_catches_panics = false,
+    registry = :helper_slot,
+    registry_key_kind = :none,
+    sets_current_lib = false,
+    finalizer_frees = true,
+    call_sites = ["src/memory.jl:215", "src/memory.jl:321"],
+    issues = [250],
+    notes = "RTLD_LOCAL despite being the only library whose symbols other " *
+            "artifacts might resolve against — the visibility rule is inverted.")
+
+"""
+    cache_hit_policy() -> LoadPolicy
+
+An inline block served from the artifact cache: `load_cached_library`
+(`src/cache.jl:270`, `RTLD_LOCAL`) with registration at `src/ruststr.jl:251`.
+
+Identical source to [`inline_rustc_policy`](@ref); the pair
+`src/ruststr.jl:284` (miss) versus `src/ruststr.jl:386` (Cargo hit) is the
+concrete instance of #250 where symbol visibility depends on cache state.
+"""
+cache_hit_policy() = LoadPolicy("cache-hit";
+    dlopen_flags = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
+    panic_strategy = :abort,
+    boundary_catches_panics = false,
+    registry = :rust_libraries,
+    registry_key_kind = :content_hash,
+    sets_current_lib = true,
+    finalizer_frees = false,
+    call_sites = ["src/cache.jl:270", "src/ruststr.jl:251"],
+    issues = [250],
+    notes = "Same block as inline-rustc; whether the process-global namespace " *
+            "gains the symbols depends on whether a file was in the cache.")
+
+"""
+    generics_policy() -> LoadPolicy
+
+Monomorphized generic instantiation (`src/generics.jl:243`, registered at
+`:252` under the library *basename* rather than a content hash, and never
+touching `CURRENT_LIB`).
+"""
+generics_policy() = LoadPolicy("generics-monomorphization";
+    dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
+    panic_strategy = :abort,
+    boundary_catches_panics = false,
+    registry = :rust_libraries,
+    registry_key_kind = :lib_basename,
+    sets_current_lib = false,
+    finalizer_frees = false,
+    call_sites = ["src/generics.jl:243", "src/generics.jl:252"],
+    issues = [250],
+    notes = "Registers under a basename key, unlike every other RUST_LIBRARIES writer.")
+
+"""
+    irust_policy() -> LoadPolicy
+
+`@irust` snippet compilation (`src/ruststr.jl:822`, registered at `:837` under
+an `irust_<hash>` key together with the `IRUST_FUNCTIONS` entry).
+"""
+irust_policy() = LoadPolicy("irust";
+    dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
+    panic_strategy = :abort,
+    boundary_catches_panics = false,
+    registry = :rust_libraries,
+    registry_key_kind = :irust_hash,
+    sets_current_lib = false,
+    finalizer_frees = false,
+    call_sites = ["src/ruststr.jl:822", "src/ruststr.jl:837"],
+    issues = [250],
+    notes = "RTLD_GLOBAL for a leaf artifact; IRUST_FUNCTIONS is updated in " *
+            "the same locked block but is not part of any unload path.")
+
+"""
+    hot_reload_policy() -> LoadPolicy
+
+Hot reload of a `@rust_crate` crate (`src/hot_reload.jl:205`, re-registered at
+`:210`).  The rebuild happens outside `REGISTRY_LOCK`, and a failed rebuild
+currently leaves the registry without the previous entry (#255).
+"""
+hot_reload_policy() = LoadPolicy("hot-reload";
+    dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
+    panic_strategy = :unwind,
+    boundary_catches_panics = false,
+    registry = :rust_libraries,
+    registry_key_kind = :crate_lib_name,
+    sets_current_lib = false,
+    finalizer_frees = true,
+    call_sites = ["src/hot_reload.jl:205", "src/hot_reload.jl:210"],
+    issues = [250, 255],
+    notes = "Registration is not transactional with the rebuild, so a failed " *
+            "rebuild can leave the registry without the previous entry.")
+
+"""
+    llvm_policy() -> LoadPolicy
+
+The deprecated LLVM IR path (`src/llvmcodegen.jl:347`).  Loads `RTLD_GLOBAL`
+and does not register in `RUST_LIBRARIES` at all.  Scheduled for removal with
+#265 Phase 2; recorded here only so the inventory is complete.
+"""
+llvm_policy() = LoadPolicy("llvm-ir";
+    dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
+    panic_strategy = :abort,
+    boundary_catches_panics = false,
+    registry = :none,
+    registry_key_kind = :none,
+    sets_current_lib = false,
+    finalizer_frees = false,
+    call_sites = ["src/llvmcodegen.jl:347"],
+    issues = [250],
+    notes = "Deprecated path (#265 Phase 2); handle is never registered.")
+
+"""
+    ALL_LOAD_POLICIES
+
+Every named policy, in the order the inventory in the #277 PR body lists them.
+Used by `test/test_loadpolicy.jl` to pin down the current divergences.
+"""
+const ALL_LOAD_POLICIES = (
+    inline_rustc_policy,
+    cache_hit_policy,
+    inline_cargo_policy,
+    crate_policy,
+    helper_library_policy,
+    generics_policy,
+    irust_policy,
+    hot_reload_policy,
+    llvm_policy,
+)
+
+# ---------------------------------------------------------------------------
+# Accessors — the API Phase B call sites will use instead of open-coding.
+# ---------------------------------------------------------------------------
+
+"""
+    dlopen_flags(policy::LoadPolicy) -> UInt32
+
+The flag set to hand to `Libdl.dlopen`.
+"""
+dlopen_flags(policy::LoadPolicy) = policy.dlopen_flags
+
+"""
+    uses_global_symbols(policy::LoadPolicy) -> Bool
+
+Whether this policy publishes the artifact's symbols process-globally.
+"""
+uses_global_symbols(policy::LoadPolicy) = policy.global_symbols
+
+"""
+    rustc_panic_flags(policy::LoadPolicy) -> Vector{String}
+
+The `rustc` arguments implied by the policy's panic strategy — `["-C",
+"panic=abort"]` for `:abort`, empty for `:unwind` (rustc's default).
+Mirrors `src/compiler.jl:219`, `:381`.
+"""
+rustc_panic_flags(policy::LoadPolicy) =
+    policy.panic_strategy === :abort ? ["-C", "panic=abort"] : String[]
+
+"""
+    cargo_profile_panic_line(policy::LoadPolicy) -> Union{String, Nothing}
+
+The line the generated `[profile.release]` section needs to honour the policy's
+panic strategy, or `nothing` when the Cargo default already matches.
+`src/cargoproject.jl` emits no such line today, which is why the Cargo path
+unwinds (#244).
+"""
+cargo_profile_panic_line(policy::LoadPolicy) =
+    policy.panic_strategy === :abort ? "panic = \"abort\"" : nothing
+
+"""
+    requires_catch_unwind_boundary(policy::LoadPolicy) -> Bool
+
+Whether a generated `extern "C"` wrapper for this artifact must wrap the user
+body in `std::panic::catch_unwind` to keep a panic from crossing the FFI
+boundary.  True exactly when the artifact unwinds and the boundary does not
+already catch — i.e. on every Cargo-backed path today (#244).
+"""
+requires_catch_unwind_boundary(policy::LoadPolicy) =
+    policy.panic_strategy === :unwind && !policy.boundary_catches_panics
+
+"""
+    registers_in_rust_libraries(policy::LoadPolicy) -> Bool
+
+Whether [`register_library!`](@ref) will write into `RUST_LIBRARIES`.
+"""
+registers_in_rust_libraries(policy::LoadPolicy) = policy.registry === :rust_libraries
+
+"""
+    finalizer_frees(policy::LoadPolicy) -> Bool
+
+Whether objects produced by this artifact free their allocation on finalization
+(#249).
+"""
+finalizer_frees(policy::LoadPolicy) = policy.finalizer_frees
+
+# ---------------------------------------------------------------------------
+# Registration — the locking half of the policy (#251).
+# ---------------------------------------------------------------------------
+
+"""
+    register_library!(policy::LoadPolicy, lib_name::AbstractString,
+                      handle::Ptr{Cvoid}) -> String
+
+Record a loaded handle according to `policy`, as one transaction under
+`REGISTRY_LOCK`: the `RUST_LIBRARIES` entry, its fresh function-pointer cache
+and (when `policy.sets_current_lib`) `CURRENT_LIB[]` are installed together, so
+no other task can observe a half-registered library.
+
+Returns `lib_name`.  A no-op returning `lib_name` for policies that do not use
+`RUST_LIBRARIES` (`:module_local`, `:helper_slot`, `:none`), so a Phase B call
+site can call it unconditionally.
+
+Subsumes the seven open-coded `RUST_LIBRARIES[...] = (handle, Dict())` sites:
+`src/ruststr.jl:251`, `:291`, `:389`, `:426`, `:837`, `src/generics.jl:252`,
+`src/hot_reload.jl:210`.  Not called from `src/` yet (Phase A is additive).
+"""
+function register_library!(policy::LoadPolicy, lib_name::AbstractString, handle::Ptr{Cvoid})
+    name = String(lib_name)
+    if !registers_in_rust_libraries(policy)
+        return name
+    end
+    handle == C_NULL && throw(ArgumentError("refusing to register a NULL handle for $(name)"))
+    lock(REGISTRY_LOCK) do
+        RUST_LIBRARIES[name] = (handle, Dict{String, Ptr{Cvoid}}())
+        if policy.sets_current_lib
+            CURRENT_LIB[] = name
+        end
+    end
+    return name
+end
+
+"""
+    unregister_library!(policy::LoadPolicy, lib_name::AbstractString) -> Bool
+
+Remove the `RUST_LIBRARIES` entry and its function-pointer cache under
+`REGISTRY_LOCK`, clearing `CURRENT_LIB[]` if it pointed at `lib_name`.
+Returns whether an entry was removed.  Does not `dlclose`: Phase B decides that
+together with the unload purge described in #250.
+"""
+function unregister_library!(policy::LoadPolicy, lib_name::AbstractString)
+    name = String(lib_name)
+    registers_in_rust_libraries(policy) || return false
+    return lock(REGISTRY_LOCK) do
+        removed = haskey(RUST_LIBRARIES, name)
+        if removed
+            delete!(RUST_LIBRARIES, name)
+        end
+        if CURRENT_LIB[] == name
+            CURRENT_LIB[] = ""
+        end
+        return removed
+    end
+end
+
+function Base.show(io::IO, policy::LoadPolicy)
+    vis = policy.global_symbols ? "RTLD_GLOBAL" : "RTLD_LOCAL"
+    print(io, "LoadPolicy(", policy.name, ": ", vis,
+          ", panic=", policy.panic_strategy,
+          ", registry=", policy.registry,
+          ", finalizer_frees=", policy.finalizer_frees, ")")
+end

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -5,13 +5,15 @@
 #   1. the `dlopen` flag set (`RTLD_LOCAL` vs `RTLD_GLOBAL`)          — 12 sites
 #   2. the panic strategy of the produced artifact (`abort` vs `unwind`)
 #      and what the generated `extern "C"` boundary does about it
-#   3. whether the loaded handle is registered in `RUST_LIBRARIES`,
-#      under what kind of key, and whether `CURRENT_LIB` moves        — 7 sites
+#   3. whether the loaded handle is registered in `RUST_LIBRARIES`, under what
+#      kind of key, whether an existing entry is replaced or kept, and whether
+#      `CURRENT_LIB` moves                                            — 7 sites
 #   4. the finalizer / ownership policy of the types the artifact produces
 #
 # Because the policy lives at the call site, the same user-visible construct
-# behaves differently depending on which door it came through — or even on
-# whether the cache hit (#250).  This file introduces one record that names
+# behaves differently depending on which door it came through — an inline
+# `rust"""` block is RTLD_LOCAL without `// cargo-deps:` and RTLD_GLOBAL with
+# it (#250).  This file introduces one record that names
 # those four decisions, plus one named constructor per existing front door, so
 # that Phase B can move call sites onto the shared loader one at a time without
 # having to agree on the target policy first.
@@ -44,7 +46,10 @@ shadow one another in the process-global namespace.
 
 Note that the helper library is one of the few loaded `RTLD_LOCAL` today, and
 the leaf artifacts are mostly loaded `RTLD_GLOBAL` — i.e. current `main` has
-the rule exactly inverted.  Phase A only records this; it changes nothing.
+the rule exactly inverted.  The split among inline blocks runs along the
+dependency axis and is stable across cache states: no `// cargo-deps:` means
+`RTLD_LOCAL` on both a cache hit and a miss, `// cargo-deps:` means
+`RTLD_GLOBAL` on both.  Phase A only records this; it changes nothing.
 """
 const SYMBOL_VISIBILITY_RULE = """
 RTLD_GLOBAL is for libraries whose symbols other libraries resolve against \
@@ -58,9 +63,9 @@ handle via dlsym is RTLD_LOCAL.\
 One explicit record of the load/compile policy for a single compiled artifact.
 
 Construct one through a named constructor (see `inline_rustc_policy`,
-`inline_cargo_policy`, `crate_policy`,
-`helper_library_policy`, `cache_hit_policy`) rather than
-calling this constructor directly, so that every front door keeps a name.
+`inline_cargo_policy`, `crate_policy`, `helper_library_policy`, and the rest of
+`ALL_LOAD_POLICIES`) rather than calling this constructor directly, so that
+every front door keeps a name.
 
 # Fields
 
@@ -73,10 +78,18 @@ calling this constructor directly, so that every front door keeps a name.
   whether this artifact publishes its symbols into the process-global
   namespace.  See `SYMBOL_VISIBILITY_RULE` for when that is legitimate.
 
-- `panic_strategy::Symbol` — `:abort` or `:unwind`, the panic strategy the
-  artifact is *compiled* with.  `:abort` corresponds to `-C panic=abort`
-  (`src/compiler.jl:219`, `:381`); `:unwind` is the Cargo path, whose generated
-  `[profile.release]` sets only `opt-level`/`lto` (`src/cargoproject.jl:126-128`).
+- `panic_strategy::Symbol` — the panic strategy the artifact is *compiled*
+  with, one of:
+    * `:abort` — RustCall passes `-C panic=abort` (`src/compiler.jl:219`, `:381`);
+    * `:unwind` — RustCall controls the build and does not set a panic mode, so
+      Cargo's `unwind` default applies (the generated `[profile.release]` at
+      `src/cargoproject.jl:126-128` writes only `opt-level`/`lto`);
+    * `:crate_profile` — RustCall does **not** control the build: Cargo runs in
+      the *user's* crate, so the effective profile (the crate's own
+      `[profile.release]`, a workspace profile, `.cargo/config.toml`, or
+      `CARGO_PROFILE_RELEASE_PANIC`) decides, and `panic = "abort"` there is
+      honoured.  Unknown to Phase A, hence a separate value rather than a
+      guess.
 
 - `boundary_catches_panics::Bool` — whether the generated `extern "C"` wrapper
   is expected to wrap the user body in `std::panic::catch_unwind`.  There are
@@ -93,6 +106,14 @@ calling this constructor directly, so that every front door keeps a name.
   `:rust_libraries`: `:content_hash` (`rust_<hash>` from the inline paths),
   `:lib_basename` (generics), `:irust_hash` (`irust_<hash>`),
   `:crate_lib_name` (hot reload), or `:none`.
+
+- `registration_mode::Symbol` — `:replace` (assign unconditionally, as the
+  five `src/ruststr.jl` sites do) or `:insert_only` (keep an existing entry, as
+  `src/generics.jl:250-253` deliberately does behind `if !haskey(...)`).  The
+  distinction matters because `_unique_source_name` (`src/compiler.jl:68-72`)
+  gives every non-debug compilation the same `rust_code` basename, so the
+  generics key collides across instantiations and an unconditional assignment
+  would drop the live handle together with its function-pointer cache.
 
 - `sets_current_lib::Bool` — whether the site also moves `CURRENT_LIB[]`.
 
@@ -117,6 +138,7 @@ struct LoadPolicy
     boundary_catches_panics::Bool
     registry::Symbol
     registry_key_kind::Symbol
+    registration_mode::Symbol
     sets_current_lib::Bool
     finalizer_frees::Bool
     call_sites::Vector{String}
@@ -124,16 +146,18 @@ struct LoadPolicy
     notes::String
 end
 
-const _VALID_PANIC_STRATEGIES = (:abort, :unwind)
+const _VALID_PANIC_STRATEGIES = (:abort, :unwind, :crate_profile)
 const _VALID_REGISTRIES = (:rust_libraries, :module_local, :helper_slot, :none)
 const _VALID_KEY_KINDS = (:content_hash, :lib_basename, :irust_hash, :crate_lib_name, :none)
+const _VALID_REGISTRATION_MODES = (:replace, :insert_only)
 
 """
     LoadPolicy(name; kwargs...) -> LoadPolicy
 
 Keyword constructor with the conservative defaults Phase B should converge on:
 `RTLD_LOCAL | RTLD_NOW`, `panic=abort`, registration in `RUST_LIBRARIES` under
-a content hash, `CURRENT_LIB` untouched, and finalizers that free.
+a content hash replacing any previous entry, `CURRENT_LIB` untouched, and
+finalizers that free.
 
 Every named constructor below overrides whatever its call sites do differently.
 """
@@ -143,6 +167,7 @@ function LoadPolicy(name::AbstractString;
                     boundary_catches_panics::Bool = false,
                     registry::Symbol = :rust_libraries,
                     registry_key_kind::Symbol = :content_hash,
+                    registration_mode::Symbol = :replace,
                     sets_current_lib::Bool = false,
                     finalizer_frees::Bool = true,
                     call_sites::AbstractVector{<:AbstractString} = String[],
@@ -154,6 +179,8 @@ function LoadPolicy(name::AbstractString;
         throw(ArgumentError("invalid registry $(registry); expected one of $(_VALID_REGISTRIES)"))
     registry_key_kind in _VALID_KEY_KINDS ||
         throw(ArgumentError("invalid registry_key_kind $(registry_key_kind); expected one of $(_VALID_KEY_KINDS)"))
+    registration_mode in _VALID_REGISTRATION_MODES ||
+        throw(ArgumentError("invalid registration_mode $(registration_mode); expected one of $(_VALID_REGISTRATION_MODES)"))
     if registry !== :rust_libraries && registry_key_kind !== :none
         throw(ArgumentError("registry_key_kind must be :none unless registry is :rust_libraries"))
     end
@@ -161,7 +188,7 @@ function LoadPolicy(name::AbstractString;
     return LoadPolicy(String(name), flags,
                       (flags & UInt32(Libdl.RTLD_GLOBAL)) != 0,
                       panic_strategy, boundary_catches_panics,
-                      registry, registry_key_kind, sets_current_lib,
+                      registry, registry_key_kind, registration_mode, sets_current_lib,
                       finalizer_frees,
                       String[String(s) for s in call_sites],
                       Int[Int(i) for i in issues],
@@ -177,15 +204,17 @@ end
 """
     inline_rustc_policy() -> LoadPolicy
 
-Inline `rust\"\"\"...\"\"\"` block with no `// cargo-deps:`, compiled straight by
-`rustc` and loaded on a cache **miss**.
+Inline `rust\"\"\"...\"\"\"` block with **no** `// cargo-deps:`, compiled straight by
+`rustc`.  Covers the path on both cache states — a disk-cache hit
+(`src/cache.jl:270`, registered at `src/ruststr.jl:251`) and a cache miss
+(`src/ruststr.jl:284`, registered at `:291`) both load `RTLD_LOCAL`, so
+visibility does **not** depend on the cache.  Compiled with `-C panic=abort`
+(`src/compiler.jl:381`).
 
-Subsumes `src/ruststr.jl:284` (dlopen, `RTLD_LOCAL`) and the registration at
-`src/ruststr.jl:291`.  Compiled with `-C panic=abort` (`src/compiler.jl:381`).
-
-Diverges from `cache_hit_policy` — which is the *same block* on a cache
-hit — only in the direction of the divergence being invisible to the user
-(#250).
+The visibility divergence runs along the *dependency* axis, not the cache axis:
+this door is `RTLD_LOCAL` while `inline_cargo_policy` — the same `rust\"\"\"`
+construct that happens to declare `// cargo-deps:` — is `RTLD_GLOBAL` on both
+of its cache states (#250).
 """
 inline_rustc_policy() = LoadPolicy("inline-rustc";
     dlopen_flags = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
@@ -193,13 +222,15 @@ inline_rustc_policy() = LoadPolicy("inline-rustc";
     boundary_catches_panics = false,
     registry = :rust_libraries,
     registry_key_kind = :content_hash,
+    registration_mode = :replace,
     sets_current_lib = true,
     finalizer_frees = false,
-    call_sites = ["src/ruststr.jl:284", "src/ruststr.jl:291",
+    call_sites = ["src/cache.jl:270", "src/ruststr.jl:251",
+                  "src/ruststr.jl:284", "src/ruststr.jl:291",
                   "src/compiler.jl:381", "src/structs.jl:282-285"],
     issues = [244, 249, 250],
-    notes = "RTLD_LOCAL here but RTLD_GLOBAL for the same block on a cache " *
-            "hit (src/ruststr.jl:386) and on the Cargo path; inline #[julia] " *
+    notes = "RTLD_LOCAL on both cache states, while the same construct with " *
+            "// cargo-deps: is RTLD_GLOBAL on both of its; inline #[julia] " *
             "struct finalizers do not free.")
 
 """
@@ -208,8 +239,11 @@ inline_rustc_policy() = LoadPolicy("inline-rustc";
 Inline `rust\"\"\"...\"\"\"` block carrying `// cargo-deps:`, built through a
 generated Cargo project.
 
-Subsumes `src/ruststr.jl:419` (build) and `src/ruststr.jl:386` (Cargo cache
-hit), both `RTLD_GLOBAL`, with registration at `:426` / `:389`.
+Covers both cache states: the Cargo cache hit (`src/ruststr.jl:386`,
+registered at `:389`) and the fresh build (`:419`, registered at `:426`) both
+load `RTLD_GLOBAL`, so — as with `inline_rustc_policy` — visibility does not
+depend on the cache.  The axis along which visibility differs is whether the
+block declares `// cargo-deps:` (#250).
 
 The generated `Cargo.toml` writes only `opt-level`/`lto`
 (`src/cargoproject.jl:126-128`), so the artifact **unwinds** while the direct
@@ -239,21 +273,32 @@ and the emitted bindings file template (`src/crate_bindings.jl:1360`).
 The handle lives in a module-local `_LIB_HANDLE` `Ref`, not in `RUST_LIBRARIES`,
 so `RustCall`-level unload never sees it.  Crate structs *do* free in their
 finalizer (`src/crate_bindings.jl:550`), the opposite of inline structs (#249).
-Built by Cargo, hence `:unwind`.
+
+Panic strategy is `:crate_profile`, not `:unwind`: `build_crate_directly`
+(`src/crate_bindings.jl:914-925`) points a `CargoProject` at the user's own
+crate directory and runs Cargo there, so the effective profile is the user's —
+a `[profile.release] panic = "abort"` in their `Cargo.toml`, a workspace
+profile, `.cargo/config.toml`, or `CARGO_PROFILE_RELEASE_PANIC` are all
+honoured, and RustCall neither sets nor reads it.  Phase B must either read the
+effective profile (`cargo metadata` / `cargo config get`) or force the strategy
+explicitly on the command line before it can promise one panic policy across
+doors (#244).
 """
 crate_policy() = LoadPolicy("rust-crate";
     dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
-    panic_strategy = :unwind,
+    panic_strategy = :crate_profile,
     boundary_catches_panics = false,
     registry = :module_local,
     registry_key_kind = :none,
     sets_current_lib = false,
     finalizer_frees = true,
     call_sites = ["src/crate_bindings.jl:344", "src/crate_bindings.jl:550",
-                  "src/crate_bindings.jl:1360"],
-    issues = [249, 250],
+                  "src/crate_bindings.jl:914-925", "src/crate_bindings.jl:1360"],
+    issues = [244, 249, 250],
     notes = "Only front door whose struct finalizers free; handle is not in " *
-            "RUST_LIBRARIES so it cannot be unloaded through the registry.")
+            "RUST_LIBRARIES so it cannot be unloaded through the registry; " *
+            "and Cargo runs in the user's crate, so the panic strategy is " *
+            "whatever their effective profile says.")
 
 """
     helper_library_policy() -> LoadPolicy
@@ -290,34 +335,22 @@ helper_library_policy() = LoadPolicy("helper-library";
             "unwinds like the other Cargo-backed artifacts.")
 
 """
-    cache_hit_policy() -> LoadPolicy
-
-An inline block served from the artifact cache: `load_cached_library`
-(`src/cache.jl:270`, `RTLD_LOCAL`) with registration at `src/ruststr.jl:251`.
-
-Identical source to `inline_rustc_policy`; the pair
-`src/ruststr.jl:284` (miss) versus `src/ruststr.jl:386` (Cargo hit) is the
-concrete instance of #250 where symbol visibility depends on cache state.
-"""
-cache_hit_policy() = LoadPolicy("cache-hit";
-    dlopen_flags = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
-    panic_strategy = :abort,
-    boundary_catches_panics = false,
-    registry = :rust_libraries,
-    registry_key_kind = :content_hash,
-    sets_current_lib = true,
-    finalizer_frees = false,
-    call_sites = ["src/cache.jl:270", "src/ruststr.jl:251"],
-    issues = [250],
-    notes = "Same block as inline-rustc; whether the process-global namespace " *
-            "gains the symbols depends on whether a file was in the cache.")
-
-"""
     generics_policy() -> LoadPolicy
 
 Monomorphized generic instantiation (`src/generics.jl:243`, registered at
 `:252` under the library *basename* rather than a content hash, and never
 touching `CURRENT_LIB`).
+
+Registration mode is `:insert_only`: `src/generics.jl:250-253` writes the entry
+only `if !haskey(RUST_LIBRARIES, lib_name)`, and that guard is load-bearing.
+`_unique_source_name` (`src/compiler.jl:68-72`) returns the fixed base name
+`rust_code` whenever debug mode is off, so every instantiation compiled into
+its own temp directory yields the same `librust_code` basename — the registry
+key collides across instantiations.  Replacing the entry would swap the live
+handle and throw away the accumulated function-pointer cache that
+`src/generics.jl:267` fills, so Phase B must preserve the insert-only
+behaviour (or key these libraries by content, which is a behaviour change and
+therefore not Phase A).
 """
 generics_policy() = LoadPolicy("generics-monomorphization";
     dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
@@ -325,11 +358,14 @@ generics_policy() = LoadPolicy("generics-monomorphization";
     boundary_catches_panics = false,
     registry = :rust_libraries,
     registry_key_kind = :lib_basename,
+    registration_mode = :insert_only,
     sets_current_lib = false,
     finalizer_frees = false,
-    call_sites = ["src/generics.jl:243", "src/generics.jl:252"],
+    call_sites = ["src/compiler.jl:68-72", "src/generics.jl:243",
+                  "src/generics.jl:250-253", "src/generics.jl:267"],
     issues = [250],
-    notes = "Registers under a basename key, unlike every other RUST_LIBRARIES writer.")
+    notes = "Registers under a colliding basename key and only when absent, " *
+            "unlike every other RUST_LIBRARIES writer.")
 
 """
     irust_policy() -> LoadPolicy
@@ -356,17 +392,23 @@ irust_policy() = LoadPolicy("irust";
 Hot reload of a `@rust_crate` crate (`src/hot_reload.jl:205`, re-registered at
 `:210`).  The rebuild happens outside `REGISTRY_LOCK`, and a failed rebuild
 currently leaves the registry without the previous entry (#255).
+
+Like `crate_policy`, the panic strategy is `:crate_profile`: `rebuild_crate`
+runs `cargo build --release --manifest-path <user crate>` against their crate
+(`src/hot_reload.jl:264`), so their profile decides.
 """
 hot_reload_policy() = LoadPolicy("hot-reload";
     dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
-    panic_strategy = :unwind,
+    panic_strategy = :crate_profile,
     boundary_catches_panics = false,
     registry = :rust_libraries,
     registry_key_kind = :crate_lib_name,
+    registration_mode = :replace,
     sets_current_lib = false,
     finalizer_frees = true,
-    call_sites = ["src/hot_reload.jl:205", "src/hot_reload.jl:210"],
-    issues = [250, 255],
+    call_sites = ["src/hot_reload.jl:205", "src/hot_reload.jl:210",
+                  "src/hot_reload.jl:264"],
+    issues = [244, 250, 255],
     notes = "Registration is not transactional with the rebuild, so a failed " *
             "rebuild can leave the registry without the previous entry.")
 
@@ -397,7 +439,6 @@ Used by `test/test_loadpolicy.jl` to pin down the current divergences.
 """
 const ALL_LOAD_POLICIES = (
     inline_rustc_policy,
-    cache_hit_policy,
     inline_cargo_policy,
     crate_policy,
     helper_library_policy,
@@ -429,11 +470,15 @@ uses_global_symbols(policy::LoadPolicy) = policy.global_symbols
     rustc_panic_flags(policy::LoadPolicy) -> Vector{String}
 
 The `rustc` arguments implied by the policy's panic strategy — `["-C",
-"panic=abort"]` for `:abort`, empty for `:unwind` (rustc's default).
+"panic=abort"]` for `:abort`, empty for `:unwind` (rustc's default), and
+`missing` for `:crate_profile`, where the build is Cargo's inside the user's
+crate and RustCall does not drive `rustc` at all.
 Mirrors `src/compiler.jl:219`, `:381`.
 """
-rustc_panic_flags(policy::LoadPolicy) =
-    policy.panic_strategy === :abort ? ["-C", "panic=abort"] : String[]
+function rustc_panic_flags(policy::LoadPolicy)
+    policy.panic_strategy === :crate_profile && return missing
+    return policy.panic_strategy === :abort ? ["-C", "panic=abort"] : String[]
+end
 
 """
     cargo_profile_panic_line(policy::LoadPolicy) -> Union{String, Nothing}
@@ -442,20 +487,49 @@ The line the generated `[profile.release]` section needs to honour the policy's
 panic strategy, or `nothing` when the Cargo default already matches.
 `src/cargoproject.jl` emits no such line today, which is why the Cargo path
 unwinds (#244).
+
+Returns `missing` for `:crate_profile`: RustCall generates no `Cargo.toml` for
+those doors — the manifest is the user's — so there is no line for it to write,
+and Phase B has to read the effective profile (`cargo metadata` /
+`cargo config get`) or force the strategy on the command line instead.
 """
-cargo_profile_panic_line(policy::LoadPolicy) =
-    policy.panic_strategy === :abort ? "panic = \"abort\"" : nothing
+function cargo_profile_panic_line(policy::LoadPolicy)
+    policy.panic_strategy === :crate_profile && return missing
+    return policy.panic_strategy === :abort ? "panic = \"abort\"" : nothing
+end
 
 """
     requires_catch_unwind_boundary(policy::LoadPolicy) -> Bool
 
 Whether a generated `extern "C"` wrapper for this artifact must wrap the user
 body in `std::panic::catch_unwind` to keep a panic from crossing the FFI
-boundary.  True exactly when the artifact unwinds and the boundary does not
-already catch — i.e. on every Cargo-backed path today (#244).
+boundary.  `true` exactly when the artifact unwinds and the boundary does not
+already catch — i.e. on every path RustCall builds with Cargo today (#244).
+
+Returns **`missing`** for `:crate_profile`: whether those artifacts unwind is
+decided by the user's Cargo profile, which Phase A does not read.  Callers that
+need a decision rather than a fact should use `must_assume_unwind`, which
+resolves the unknown conservatively.
 """
-requires_catch_unwind_boundary(policy::LoadPolicy) =
-    policy.panic_strategy === :unwind && !policy.boundary_catches_panics
+function requires_catch_unwind_boundary(policy::LoadPolicy)
+    policy.boundary_catches_panics && return false
+    policy.panic_strategy === :crate_profile && return missing
+    return policy.panic_strategy === :unwind
+end
+
+"""
+    must_assume_unwind(policy::LoadPolicy) -> Bool
+
+The conservative resolution of `requires_catch_unwind_boundary`: `true` unless
+the artifact is known to abort or the boundary already catches.  An unknown
+(`:crate_profile`) strategy resolves to `true`, because a boundary that catches
+a panic that cannot happen is merely redundant, while a missing boundary on an
+unwinding artifact is undefined behaviour (#244).
+"""
+function must_assume_unwind(policy::LoadPolicy)
+    policy.boundary_catches_panics && return false
+    return policy.panic_strategy !== :abort
+end
 
 """
     registers_in_rust_libraries(policy::LoadPolicy) -> Bool
@@ -485,6 +559,12 @@ Record a loaded handle according to `policy`, as one transaction under
 and (when `policy.sets_current_lib`) `CURRENT_LIB[]` are installed together, so
 no other task can observe a half-registered library.
 
+`policy.registration_mode` decides what happens when the key is already taken:
+`:replace` overwrites the entry (what the five `src/ruststr.jl` sites do),
+`:insert_only` leaves the existing handle and its function-pointer cache
+untouched (what `src/generics.jl:250-253` does behind `if !haskey(...)`, which
+matters because the generics key collides — see `generics_policy`).
+
 Returns `lib_name`.  A no-op returning `lib_name` for policies that do not use
 `RUST_LIBRARIES` (`:module_local`, `:helper_slot`, `:none`), so a Phase B call
 site can call it unconditionally.
@@ -500,6 +580,10 @@ function register_library!(policy::LoadPolicy, lib_name::AbstractString, handle:
     end
     handle == C_NULL && throw(ArgumentError("refusing to register a NULL handle for $(name)"))
     lock(REGISTRY_LOCK) do
+        if policy.registration_mode === :insert_only && haskey(RUST_LIBRARIES, name)
+            @debug "register_library!: keeping the existing entry" lib_name=name policy=policy.name
+            return
+        end
         RUST_LIBRARIES[name] = (handle, Dict{String, Ptr{Cvoid}}())
         if policy.sets_current_lib
             CURRENT_LIB[] = name
@@ -536,5 +620,6 @@ function Base.show(io::IO, policy::LoadPolicy)
     print(io, "LoadPolicy(", policy.name, ": ", vis,
           ", panic=", policy.panic_strategy,
           ", registry=", policy.registry,
+          "/", policy.registration_mode,
           ", finalizer_frees=", policy.finalizer_frees, ")")
 end

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -63,7 +63,7 @@ handle via dlsym is RTLD_LOCAL.\
 One explicit record of the load/compile policy for a single compiled artifact.
 
 Construct one through a named constructor (see `inline_rustc_policy`,
-`inline_cargo_policy`, `crate_policy`, `helper_library_policy`, and the rest of
+`inline_cargo_policy`, `crate_direct_policy`, `helper_library_policy`, and the rest of
 `ALL_LOAD_POLICIES`) rather than calling this constructor directly, so that
 every front door keeps a name.
 
@@ -282,40 +282,74 @@ inline_cargo_policy() = LoadPolicy("inline-cargo";
             "and loads RTLD_GLOBAL where the rustc path loads RTLD_LOCAL.")
 
 """
-    crate_policy() -> LoadPolicy
+    crate_direct_policy() -> LoadPolicy
 
-`@rust_crate` bindings, both the in-memory module (`src/crate_bindings.jl:344`)
-and the emitted bindings file template (`src/crate_bindings.jl:1360`).
+`@rust_crate` for a crate that already declares `crate-type = ["cdylib"]`, so
+RustCall builds it in place: `src/crate_bindings.jl:852` calls
+`build_crate_directly`, which points a `CargoProject` at `info.path` and runs
+Cargo there (`:914-925`).  The Cargo root is then the **user's** manifest, so
+their `[profile.release] panic = "abort"`, a workspace profile,
+`.cargo/config.toml` or `CARGO_PROFILE_RELEASE_PANIC` all decide — hence
+`:crate_profile`, which `effective_panic_strategy` deliberately leaves
+unresolved.  Phase B must read the effective profile (`cargo metadata` /
+`cargo config get`) or force the strategy explicitly (#244).
 
-The handle lives in a module-local `_LIB_HANDLE` `Ref`, not in `RUST_LIBRARIES`,
-so `RustCall`-level unload never sees it.  Crate structs *do* free in their
-finalizer (`src/crate_bindings.jl:550`), the opposite of inline structs (#249).
-
-Panic strategy is `:crate_profile`, not `:unwind`: `build_crate_directly`
-(`src/crate_bindings.jl:914-925`) points a `CargoProject` at the user's own
-crate directory and runs Cargo there, so the effective profile is the user's —
-a `[profile.release] panic = "abort"` in their `Cargo.toml`, a workspace
-profile, `.cargo/config.toml`, or `CARGO_PROFILE_RELEASE_PANIC` are all
-honoured, and RustCall neither sets nor reads it.  Phase B must either read the
-effective profile (`cargo metadata` / `cargo config get`) or force the strategy
-explicitly on the command line before it can promise one panic policy across
-doors (#244).
+Loading and ownership are shared with `crate_wrapper_policy`: the handle lives
+in a module-local `_LIB_HANDLE` `Ref` (`src/crate_bindings.jl:344`, and the
+emitted bindings-file template at `:1360`), not in `RUST_LIBRARIES`, so
+`RustCall`-level unload never sees it; crate structs *do* free in their
+finalizer (`:550`), the opposite of inline structs (#249).
 """
-crate_policy() = LoadPolicy("rust-crate";
+crate_direct_policy() = LoadPolicy("rust-crate-direct";
     dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
     panic_strategy = :crate_profile,
+    cargo_profile = :release,
     boundary_catches_panics = false,
     registry = :module_local,
     registry_key_kind = :none,
     sets_current_lib = false,
     finalizer_frees = true,
     call_sites = ["src/crate_bindings.jl:344", "src/crate_bindings.jl:550",
-                  "src/crate_bindings.jl:914-925", "src/crate_bindings.jl:1360"],
+                  "src/crate_bindings.jl:852", "src/crate_bindings.jl:914-925",
+                  "src/crate_bindings.jl:1360"],
     issues = [244, 249, 250],
-    notes = "Only front door whose struct finalizers free; handle is not in " *
-            "RUST_LIBRARIES so it cannot be unloaded through the registry; " *
-            "and Cargo runs in the user's crate, so the panic strategy is " *
-            "whatever their effective profile says.")
+    notes = "Cargo runs with the user's manifest as the root, so the panic " *
+            "strategy is whatever their effective profile says; struct " *
+            "finalizers free, and the handle is not in RUST_LIBRARIES.")
+
+"""
+    crate_wrapper_policy() -> LoadPolicy
+
+`@rust_crate` for a crate without `cdylib`, where RustCall generates a wrapper
+crate around it and builds *that* (`src/crate_bindings.jl:854-868`).  The Cargo
+root is then RustCall's own generated manifest, whose `[profile.release]` sets
+only `opt-level`/`lto` (`src/crate_bindings.jl:266-269`) and pins no `panic` —
+so this door is `:cargo_default`, exactly like `inline_cargo_policy`: Cargo's
+release default unless `CARGO_PROFILE_RELEASE_PANIC` is set in the inherited
+environment.  Resolve with `effective_panic_strategy`; Phase B should pin
+`panic` in the generated wrapper manifest.
+
+The two `@rust_crate` build paths therefore have different panic semantics for
+the same user-visible macro, chosen by `crate_has_cdylib` (#244).  Everything
+else — `RTLD_GLOBAL`, the module-local handle, freeing finalizers — matches
+`crate_direct_policy`.
+"""
+crate_wrapper_policy() = LoadPolicy("rust-crate-wrapper";
+    dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
+    panic_strategy = :cargo_default,
+    cargo_profile = :release,
+    boundary_catches_panics = false,
+    registry = :module_local,
+    registry_key_kind = :none,
+    sets_current_lib = false,
+    finalizer_frees = true,
+    call_sites = ["src/crate_bindings.jl:266-269", "src/crate_bindings.jl:344",
+                  "src/crate_bindings.jl:550", "src/crate_bindings.jl:854-868",
+                  "src/crate_bindings.jl:1360"],
+    issues = [244, 249, 250],
+    notes = "RustCall's generated wrapper manifest is the Cargo root and pins " *
+            "no panic, so this @rust_crate path takes Cargo's default while " *
+            "the direct-cdylib path takes the user's profile.")
 
 """
     helper_library_policy() -> LoadPolicy
@@ -413,7 +447,7 @@ Hot reload of a `@rust_crate` crate (`src/hot_reload.jl:205`, re-registered at
 `:210`).  The rebuild happens outside `REGISTRY_LOCK`, and a failed rebuild
 currently leaves the registry without the previous entry (#255).
 
-Like `crate_policy`, the panic strategy is `:crate_profile`: `rebuild_crate`
+Like `crate_direct_policy`, the panic strategy is `:crate_profile`: `rebuild_crate`
 runs `cargo build --release --manifest-path <user crate>` against their crate
 (`src/hot_reload.jl:264`), so their profile decides.
 """
@@ -460,7 +494,8 @@ Used by `test/test_loadpolicy.jl` to pin down the current divergences.
 const ALL_LOAD_POLICIES = (
     inline_rustc_policy,
     inline_cargo_policy,
-    crate_policy,
+    crate_direct_policy,
+    crate_wrapper_policy,
     helper_library_policy,
     generics_policy,
     irust_policy,
@@ -536,23 +571,42 @@ cargo_panic_env_var(policy::LoadPolicy) =
 
 """
     effective_panic_strategy(policy::LoadPolicy; env = ENV) -> Symbol
+    effective_panic_strategy(policy::LoadPolicy, snapshot_env) -> Symbol
 
 Resolve `policy.panic_strategy` against the environment a build would inherit.
 
 - `:abort` and `:unwind` are pinned by RustCall and returned unchanged.
 - `:cargo_default` is resolved by reading `cargo_panic_env_var(policy)` out of
-  `env`: `"abort"` gives `:abort`, `"unwind"` gives `:unwind`, and anything
-  else — unset, empty, unrecognised — gives `:unwind`, Cargo's default for the
-  `release` profile.  Both doors that carry `:cargo_default` run Cargo without
-  `setenv` (`src/cargobuild.jl:25-67`, `deps/build.jl:97-98`), so the Julia
-  process environment reaches the build and `CARGO_PROFILE_RELEASE_PANIC=abort`
-  really does change the artifact.
+  the environment: `"abort"` gives `:abort`, `"unwind"` gives `:unwind`, and
+  anything else — unset, empty, unrecognised — gives `:unwind`, Cargo's default
+  for the `release` profile.  Both doors that carry `:cargo_default` run Cargo
+  without `setenv` (`src/cargobuild.jl:25-67`, `deps/build.jl:97-98`), so the
+  Julia process environment reaches the build and
+  `CARGO_PROFILE_RELEASE_PANIC=abort` really does change the artifact.
 - `:crate_profile` is returned unchanged: the environment is only one of the
   inputs there, and the user's manifest — which Phase A does not read — can
-  pin `panic` and win over the default (though not over the environment
-  variable).  Still unknowable without reading it.
+  pin `panic`.  Still unknowable without reading it.
 
-Pass `env` explicitly to reason about a build other than this process's.
+# Which environment
+
+**The `env = ENV` default answers for an artifact built in *this* process, and
+only for that.**  A cached or reloaded artifact was built under the environment
+that was live at *build* time, which may differ from the current one, so
+resolving it against `ENV` can report the opposite strategy from what the `.so`
+on disk actually does.  For those, the caller MUST pass the environment
+captured at build time — PR #272 records it on `RustBlockSnapshot.cargo_env` as
+serialized `KEY=VALUE` text, one entry per line — using the second method:
+
+    effective_panic_strategy(policy, snapshot.cargo_env)
+
+which accepts that text (parsed by `parse_cargo_env_snapshot`) or any
+`AbstractDict`.  Never resolve a cached artifact against the live `ENV`.
+
+The related cache-*identity* problem — the Cargo cache key at
+`src/ruststr.jl:380-386` not covering the panic setting, so two artifacts built
+under different `CARGO_PROFILE_*` values share a key — is closed by #272 adding
+the `CARGO_PROFILE_` allowlist to `_cargo_block_identity`; the structural fix is
+tracked in #278.  Phase A only models the resolution, not the key.
 """
 function effective_panic_strategy(policy::LoadPolicy; env = ENV)
     policy.panic_strategy === :cargo_default || return policy.panic_strategy
@@ -560,6 +614,37 @@ function effective_panic_strategy(policy::LoadPolicy; env = ENV)
     value = lowercase(strip(String(raw)))
     value == "abort" && return :abort
     return :unwind
+end
+
+effective_panic_strategy(policy::LoadPolicy, snapshot_env::Union{AbstractDict, AbstractString}) =
+    effective_panic_strategy(policy; env = _as_env(snapshot_env))
+
+"""
+    parse_cargo_env_snapshot(text::AbstractString) -> Dict{String, String}
+
+Parse a serialized build-time environment snapshot — one `KEY=VALUE` per line,
+the shape PR #272 stores in `RustBlockSnapshot.cargo_env` — into a dictionary
+suitable as the `env` of `effective_panic_strategy`.
+
+Blank lines and lines without `=` are skipped; the value keeps everything after
+the first `=`, so `KEY=a=b` yields `"a=b"`.  Surrounding whitespace is trimmed
+from the key only, since a value's whitespace can be significant.
+"""
+_as_env(env::AbstractDict) = env
+_as_env(env::AbstractString) = parse_cargo_env_snapshot(env)
+
+function parse_cargo_env_snapshot(text::AbstractString)
+    out = Dict{String, String}()
+    for line in eachsplit(text, '\n')
+        entry = strip(line)
+        isempty(entry) && continue
+        sep = findfirst(isequal('='), entry)
+        sep === nothing && continue
+        key = strip(entry[1:prevind(entry, sep)])
+        isempty(key) && continue
+        out[String(key)] = String(entry[nextind(entry, sep):end])
+    end
+    return out
 end
 
 """
@@ -584,6 +669,11 @@ function requires_catch_unwind_boundary(policy::LoadPolicy; env = ENV)
     return strategy === :unwind
 end
 
+# Same build-time-snapshot contract as effective_panic_strategy: pass the
+# captured environment for a cached or reloaded artifact, never the live ENV.
+requires_catch_unwind_boundary(policy::LoadPolicy, snapshot_env::Union{AbstractDict, AbstractString}) =
+    requires_catch_unwind_boundary(policy; env = _as_env(snapshot_env))
+
 """
     must_assume_unwind(policy::LoadPolicy; env = ENV) -> Bool
 
@@ -597,6 +687,9 @@ function must_assume_unwind(policy::LoadPolicy; env = ENV)
     policy.boundary_catches_panics && return false
     return effective_panic_strategy(policy; env) !== :abort
 end
+
+must_assume_unwind(policy::LoadPolicy, snapshot_env::Union{AbstractDict, AbstractString}) =
+    must_assume_unwind(policy; env = _as_env(snapshot_env))
 
 """
     registers_in_rust_libraries(policy::LoadPolicy) -> Bool

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -81,9 +81,16 @@ every front door keeps a name.
 - `panic_strategy::Symbol` — the panic strategy the artifact is *compiled*
   with, one of:
     * `:abort` — RustCall passes `-C panic=abort` (`src/compiler.jl:219`, `:381`);
-    * `:unwind` — RustCall controls the build and does not set a panic mode, so
-      Cargo's `unwind` default applies (the generated `[profile.release]` at
-      `src/cargoproject.jl:126-128` writes only `opt-level`/`lto`);
+    * `:unwind` — the artifact is pinned to unwinding;
+    * `:cargo_default` — RustCall drives Cargo but pins nothing: the generated
+      `[profile.release]` writes only `opt-level`/`lto`
+      (`src/cargoproject.jl:126-128`), and the helper library has no profile
+      section at all, so the result is *Cargo's default for the profile,
+      subject to `CARGO_PROFILE_<PROFILE>_PANIC` from the environment*.
+      `build_cargo_project` (`src/cargobuild.jl:25-67`) and `deps/build.jl`
+      both `run` Cargo without `setenv`, so the Julia process environment is
+      inherited and `CARGO_PROFILE_RELEASE_PANIC=abort` silently produces an
+      aborting artifact.  Resolve it with `effective_panic_strategy`;
     * `:crate_profile` — RustCall does **not** control the build: Cargo runs in
       the *user's* crate, so the effective profile (the crate's own
       `[profile.release]`, a workspace profile, `.cargo/config.toml`, or
@@ -135,6 +142,7 @@ struct LoadPolicy
     dlopen_flags::UInt32
     global_symbols::Bool
     panic_strategy::Symbol
+    cargo_profile::Symbol
     boundary_catches_panics::Bool
     registry::Symbol
     registry_key_kind::Symbol
@@ -146,7 +154,7 @@ struct LoadPolicy
     notes::String
 end
 
-const _VALID_PANIC_STRATEGIES = (:abort, :unwind, :crate_profile)
+const _VALID_PANIC_STRATEGIES = (:abort, :unwind, :cargo_default, :crate_profile)
 const _VALID_REGISTRIES = (:rust_libraries, :module_local, :helper_slot, :none)
 const _VALID_KEY_KINDS = (:content_hash, :lib_basename, :irust_hash, :crate_lib_name, :none)
 const _VALID_REGISTRATION_MODES = (:replace, :insert_only)
@@ -164,6 +172,7 @@ Every named constructor below overrides whatever its call sites do differently.
 function LoadPolicy(name::AbstractString;
                     dlopen_flags::Integer = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
                     panic_strategy::Symbol = :abort,
+                    cargo_profile::Symbol = :release,
                     boundary_catches_panics::Bool = false,
                     registry::Symbol = :rust_libraries,
                     registry_key_kind::Symbol = :content_hash,
@@ -187,7 +196,7 @@ function LoadPolicy(name::AbstractString;
     flags = UInt32(dlopen_flags)
     return LoadPolicy(String(name), flags,
                       (flags & UInt32(Libdl.RTLD_GLOBAL)) != 0,
-                      panic_strategy, boundary_catches_panics,
+                      panic_strategy, cargo_profile, boundary_catches_panics,
                       registry, registry_key_kind, registration_mode, sets_current_lib,
                       finalizer_frees,
                       String[String(s) for s in call_sites],
@@ -246,23 +255,31 @@ depend on the cache.  The axis along which visibility differs is whether the
 block declares `// cargo-deps:` (#250).
 
 The generated `Cargo.toml` writes only `opt-level`/`lto`
-(`src/cargoproject.jl:126-128`), so the artifact **unwinds** while the direct
-`rustc` path aborts — and no boundary catches the unwind (#244).
+(`src/cargoproject.jl:126-128`) and never pins `panic`, so the strategy is
+`:cargo_default`: Cargo's release default (`unwind`) *unless*
+`CARGO_PROFILE_RELEASE_PANIC` is set in the Julia process, which
+`build_cargo_project` inherits (`src/cargobuild.jl:25-67` runs Cargo with no
+`setenv`).  Either way the direct `rustc` path aborts and this one may not, and
+no boundary catches an unwind (#244).  Use `effective_panic_strategy` to
+resolve it; Phase B should pin `panic` in the generated manifest.
 """
 inline_cargo_policy() = LoadPolicy("inline-cargo";
     dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW,
-    panic_strategy = :unwind,
+    panic_strategy = :cargo_default,
+    cargo_profile = :release,
     boundary_catches_panics = false,
     registry = :rust_libraries,
     registry_key_kind = :content_hash,
     sets_current_lib = true,
     finalizer_frees = false,
     call_sites = ["src/ruststr.jl:386", "src/ruststr.jl:389",
-                  "src/ruststr.jl:419", "src/ruststr.jl:426",
+                  "src/ruststr.jl:409", "src/ruststr.jl:419",
+                  "src/ruststr.jl:426", "src/cargobuild.jl:25-67",
                   "src/cargoproject.jl:126-128"],
     issues = [244, 250],
-    notes = "Cargo path unwinds while the rustc path aborts, and loads " *
-            "RTLD_GLOBAL where the rustc path loads RTLD_LOCAL.")
+    notes = "Cargo path takes Cargo's release default (unwind, or abort under " *
+            "CARGO_PROFILE_RELEASE_PANIC) while the rustc path always aborts, " *
+            "and loads RTLD_GLOBAL where the rustc path loads RTLD_LOCAL.")
 
 """
     crate_policy() -> LoadPolicy
@@ -310,17 +327,19 @@ This is the one library other artifacts could legitimately need to resolve
 symbols against (`SYMBOL_VISIBILITY_RULE`), yet it is the one loaded
 `RTLD_LOCAL` today.  Recorded as-is; Phase A changes nothing.
 
-Panic strategy is `:unwind`, not `:abort`: the helper library is built by
+Panic strategy is `:cargo_default`, not `:abort`: the helper library is built by
 `deps/build.jl:97-98` with a plain `cargo build --release --manifest-path ...`,
 and `deps/rust_helpers/Cargo.toml` (9 lines, `[package]`/`[lib]`/`[dependencies]`
 only) declares no `[profile.release]` and therefore no `panic` key, so Cargo's
-`unwind` default applies.  Together with the two Cargo-backed inline paths and
-`@rust_crate`, that makes the helper library a fourth unwinding artifact with no
-`catch_unwind` boundary (#244).
+release default (`unwind`) applies — unless `CARGO_PROFILE_RELEASE_PANIC` is set
+in the environment `Pkg.build` inherits, in which case the same source produces
+an aborting artifact.  Either way no `catch_unwind` boundary contains it (#244);
+`effective_panic_strategy` resolves the value.
 """
 helper_library_policy() = LoadPolicy("helper-library";
     dlopen_flags = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
-    panic_strategy = :unwind,
+    panic_strategy = :cargo_default,
+    cargo_profile = :release,
     boundary_catches_panics = false,
     registry = :helper_slot,
     registry_key_kind = :none,
@@ -332,7 +351,8 @@ helper_library_policy() = LoadPolicy("helper-library";
     notes = "RTLD_LOCAL despite being the only library whose symbols other " *
             "artifacts might resolve against — the visibility rule is " *
             "inverted; and built by plain `cargo build --release`, so it " *
-            "unwinds like the other Cargo-backed artifacts.")
+            "takes Cargo's release default like the other Cargo-backed " *
+            "artifacts, environment overrides included.")
 
 """
     generics_policy() -> LoadPolicy
@@ -471,12 +491,12 @@ uses_global_symbols(policy::LoadPolicy) = policy.global_symbols
 
 The `rustc` arguments implied by the policy's panic strategy — `["-C",
 "panic=abort"]` for `:abort`, empty for `:unwind` (rustc's default), and
-`missing` for `:crate_profile`, where the build is Cargo's inside the user's
-crate and RustCall does not drive `rustc` at all.
+`missing` for `:cargo_default` and `:crate_profile`, where Cargo drives the
+build and RustCall does not invoke `rustc` itself.
 Mirrors `src/compiler.jl:219`, `:381`.
 """
 function rustc_panic_flags(policy::LoadPolicy)
-    policy.panic_strategy === :crate_profile && return missing
+    policy.panic_strategy in (:crate_profile, :cargo_default) && return missing
     return policy.panic_strategy === :abort ? ["-C", "panic=abort"] : String[]
 end
 
@@ -488,6 +508,11 @@ panic strategy, or `nothing` when the Cargo default already matches.
 `src/cargoproject.jl` emits no such line today, which is why the Cargo path
 unwinds (#244).
 
+Returns `nothing` for `:cargo_default`, which is precisely today's bug: RustCall
+writes the manifest and pins nothing, leaving the strategy to Cargo's default
+and to `CARGO_PROFILE_<PROFILE>_PANIC`.  Phase B should emit a line here so the
+environment cannot change the policy silently.
+
 Returns `missing` for `:crate_profile`: RustCall generates no `Cargo.toml` for
 those doors — the manifest is the user's — so there is no line for it to write,
 and Phase B has to read the effective profile (`cargo metadata` /
@@ -495,30 +520,72 @@ and Phase B has to read the effective profile (`cargo metadata` /
 """
 function cargo_profile_panic_line(policy::LoadPolicy)
     policy.panic_strategy === :crate_profile && return missing
+    policy.panic_strategy === :cargo_default && return nothing
     return policy.panic_strategy === :abort ? "panic = \"abort\"" : nothing
 end
 
 """
-    requires_catch_unwind_boundary(policy::LoadPolicy) -> Bool
+    cargo_panic_env_var(policy::LoadPolicy) -> String
+
+The `CARGO_PROFILE_<PROFILE>_PANIC` variable that overrides this policy's panic
+strategy, derived from `policy.cargo_profile` — `CARGO_PROFILE_RELEASE_PANIC`
+for every Cargo-backed door today.
+"""
+cargo_panic_env_var(policy::LoadPolicy) =
+    "CARGO_PROFILE_$(uppercase(String(policy.cargo_profile)))_PANIC"
+
+"""
+    effective_panic_strategy(policy::LoadPolicy; env = ENV) -> Symbol
+
+Resolve `policy.panic_strategy` against the environment a build would inherit.
+
+- `:abort` and `:unwind` are pinned by RustCall and returned unchanged.
+- `:cargo_default` is resolved by reading `cargo_panic_env_var(policy)` out of
+  `env`: `"abort"` gives `:abort`, `"unwind"` gives `:unwind`, and anything
+  else — unset, empty, unrecognised — gives `:unwind`, Cargo's default for the
+  `release` profile.  Both doors that carry `:cargo_default` run Cargo without
+  `setenv` (`src/cargobuild.jl:25-67`, `deps/build.jl:97-98`), so the Julia
+  process environment reaches the build and `CARGO_PROFILE_RELEASE_PANIC=abort`
+  really does change the artifact.
+- `:crate_profile` is returned unchanged: the environment is only one of the
+  inputs there, and the user's manifest — which Phase A does not read — can
+  pin `panic` and win over the default (though not over the environment
+  variable).  Still unknowable without reading it.
+
+Pass `env` explicitly to reason about a build other than this process's.
+"""
+function effective_panic_strategy(policy::LoadPolicy; env = ENV)
+    policy.panic_strategy === :cargo_default || return policy.panic_strategy
+    raw = get(env, cargo_panic_env_var(policy), "")
+    value = lowercase(strip(String(raw)))
+    value == "abort" && return :abort
+    return :unwind
+end
+
+"""
+    requires_catch_unwind_boundary(policy::LoadPolicy; env = ENV) -> Union{Bool, Missing}
 
 Whether a generated `extern "C"` wrapper for this artifact must wrap the user
 body in `std::panic::catch_unwind` to keep a panic from crossing the FFI
 boundary.  `true` exactly when the artifact unwinds and the boundary does not
-already catch — i.e. on every path RustCall builds with Cargo today (#244).
+already catch — which, with no `CARGO_PROFILE_RELEASE_PANIC` set, is every path
+RustCall builds with Cargo today (#244).
 
-Returns **`missing`** for `:crate_profile`: whether those artifacts unwind is
-decided by the user's Cargo profile, which Phase A does not read.  Callers that
+Routes through `effective_panic_strategy`, so a `:cargo_default` policy answers
+`false` under `CARGO_PROFILE_RELEASE_PANIC=abort`.  Returns **`missing`** for
+`:crate_profile`, whose answer depends on the user's manifest.  Callers that
 need a decision rather than a fact should use `must_assume_unwind`, which
 resolves the unknown conservatively.
 """
-function requires_catch_unwind_boundary(policy::LoadPolicy)
+function requires_catch_unwind_boundary(policy::LoadPolicy; env = ENV)
     policy.boundary_catches_panics && return false
-    policy.panic_strategy === :crate_profile && return missing
-    return policy.panic_strategy === :unwind
+    strategy = effective_panic_strategy(policy; env)
+    strategy === :crate_profile && return missing
+    return strategy === :unwind
 end
 
 """
-    must_assume_unwind(policy::LoadPolicy) -> Bool
+    must_assume_unwind(policy::LoadPolicy; env = ENV) -> Bool
 
 The conservative resolution of `requires_catch_unwind_boundary`: `true` unless
 the artifact is known to abort or the boundary already catches.  An unknown
@@ -526,9 +593,9 @@ the artifact is known to abort or the boundary already catches.  An unknown
 a panic that cannot happen is merely redundant, while a missing boundary on an
 unwinding artifact is undefined behaviour (#244).
 """
-function must_assume_unwind(policy::LoadPolicy)
+function must_assume_unwind(policy::LoadPolicy; env = ENV)
     policy.boundary_catches_panics && return false
-    return policy.panic_strategy !== :abort
+    return effective_panic_strategy(policy; env) !== :abort
 end
 
 """

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -57,9 +57,9 @@ handle via dlsym is RTLD_LOCAL.\
 
 One explicit record of the load/compile policy for a single compiled artifact.
 
-Construct one through a named constructor (see [`inline_rustc_policy`](@ref),
-[`inline_cargo_policy`](@ref), [`crate_policy`](@ref),
-[`helper_library_policy`](@ref), [`cache_hit_policy`](@ref)) rather than
+Construct one through a named constructor (see `inline_rustc_policy`,
+`inline_cargo_policy`, `crate_policy`,
+`helper_library_policy`, `cache_hit_policy`) rather than
 calling this constructor directly, so that every front door keeps a name.
 
 # Fields
@@ -71,7 +71,7 @@ calling this constructor directly, so that every front door keeps a name.
 
 - `global_symbols::Bool` — whether the flag set includes `RTLD_GLOBAL`, i.e.
   whether this artifact publishes its symbols into the process-global
-  namespace.  See [`SYMBOL_VISIBILITY_RULE`](@ref) for when that is legitimate.
+  namespace.  See `SYMBOL_VISIBILITY_RULE` for when that is legitimate.
 
 - `panic_strategy::Symbol` — `:abort` or `:unwind`, the panic strategy the
   artifact is *compiled* with.  `:abort` corresponds to `-C panic=abort`
@@ -183,7 +183,7 @@ Inline `rust\"\"\"...\"\"\"` block with no `// cargo-deps:`, compiled straight b
 Subsumes `src/ruststr.jl:284` (dlopen, `RTLD_LOCAL`) and the registration at
 `src/ruststr.jl:291`.  Compiled with `-C panic=abort` (`src/compiler.jl:381`).
 
-Diverges from [`cache_hit_policy`](@ref) — which is the *same block* on a cache
+Diverges from `cache_hit_policy` — which is the *same block* on a cache
 hit — only in the direction of the divergence being invisible to the user
 (#250).
 """
@@ -262,21 +262,32 @@ The ownership helper library `deps/rust_helpers`, loaded by
 `src/memory.jl:215` and `:321` into `RUST_HELPERS_LIB`.
 
 This is the one library other artifacts could legitimately need to resolve
-symbols against ([`SYMBOL_VISIBILITY_RULE`](@ref)), yet it is the one loaded
+symbols against (`SYMBOL_VISIBILITY_RULE`), yet it is the one loaded
 `RTLD_LOCAL` today.  Recorded as-is; Phase A changes nothing.
+
+Panic strategy is `:unwind`, not `:abort`: the helper library is built by
+`deps/build.jl:97-98` with a plain `cargo build --release --manifest-path ...`,
+and `deps/rust_helpers/Cargo.toml` (9 lines, `[package]`/`[lib]`/`[dependencies]`
+only) declares no `[profile.release]` and therefore no `panic` key, so Cargo's
+`unwind` default applies.  Together with the two Cargo-backed inline paths and
+`@rust_crate`, that makes the helper library a fourth unwinding artifact with no
+`catch_unwind` boundary (#244).
 """
 helper_library_policy() = LoadPolicy("helper-library";
     dlopen_flags = Libdl.RTLD_LOCAL | Libdl.RTLD_NOW,
-    panic_strategy = :abort,
+    panic_strategy = :unwind,
     boundary_catches_panics = false,
     registry = :helper_slot,
     registry_key_kind = :none,
     sets_current_lib = false,
     finalizer_frees = true,
-    call_sites = ["src/memory.jl:215", "src/memory.jl:321"],
-    issues = [250],
+    call_sites = ["src/memory.jl:215", "src/memory.jl:321",
+                  "deps/build.jl:97-98", "deps/rust_helpers/Cargo.toml"],
+    issues = [244, 250],
     notes = "RTLD_LOCAL despite being the only library whose symbols other " *
-            "artifacts might resolve against — the visibility rule is inverted.")
+            "artifacts might resolve against — the visibility rule is " *
+            "inverted; and built by plain `cargo build --release`, so it " *
+            "unwinds like the other Cargo-backed artifacts.")
 
 """
     cache_hit_policy() -> LoadPolicy
@@ -284,7 +295,7 @@ helper_library_policy() = LoadPolicy("helper-library";
 An inline block served from the artifact cache: `load_cached_library`
 (`src/cache.jl:270`, `RTLD_LOCAL`) with registration at `src/ruststr.jl:251`.
 
-Identical source to [`inline_rustc_policy`](@ref); the pair
+Identical source to `inline_rustc_policy`; the pair
 `src/ruststr.jl:284` (miss) versus `src/ruststr.jl:386` (Cargo hit) is the
 concrete instance of #250 where symbol visibility depends on cache state.
 """
@@ -449,7 +460,7 @@ requires_catch_unwind_boundary(policy::LoadPolicy) =
 """
     registers_in_rust_libraries(policy::LoadPolicy) -> Bool
 
-Whether [`register_library!`](@ref) will write into `RUST_LIBRARIES`.
+Whether `register_library!` will write into `RUST_LIBRARIES`.
 """
 registers_in_rust_libraries(policy::LoadPolicy) = policy.registry === :rust_libraries
 

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -143,6 +143,20 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test RustCall.inline_rustc_policy().panic_strategy === :abort
         @test RustCall.inline_cargo_policy().panic_strategy === :unwind
         @test RustCall.crate_policy().panic_strategy === :unwind
+
+        # Fourth unwinding path: the ownership helper library. deps/build.jl
+        # builds it with a plain `cargo build --release` and
+        # deps/rust_helpers/Cargo.toml declares no [profile.release] / panic
+        # key, so Cargo's unwind default applies (#244).
+        repo_root = dirname(_SRC_DIR)
+        build_jl = read(joinpath(repo_root, "deps", "build.jl"), String)
+        helpers_toml = read(joinpath(repo_root, "deps", "rust_helpers", "Cargo.toml"), String)
+        @test occursin("build --release --manifest-path", build_jl)
+        @test !occursin("panic", build_jl)
+        @test !occursin("panic", helpers_toml)
+        @test !occursin("[profile", helpers_toml)
+        @test RustCall.helper_library_policy().panic_strategy === :unwind
+        @test RustCall.requires_catch_unwind_boundary(RustCall.helper_library_policy())
         # The two inline doors disagree, which is exactly what #244 asks to fix.
         @test RustCall.inline_rustc_policy().panic_strategy !==
               RustCall.inline_cargo_policy().panic_strategy

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -28,6 +28,7 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test p.dlopen_flags == UInt32(Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
         @test !RustCall.uses_global_symbols(p)
         @test p.panic_strategy === :abort
+        @test p.cargo_profile === :release
         @test RustCall.registers_in_rust_libraries(p)
         @test p.registry_key_kind === :content_hash
         @test p.registration_mode === :replace
@@ -62,12 +63,46 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
                                 boundary_catches_panics = true))
         @test RustCall.must_assume_unwind(unwind)
         @test !RustCall.must_assume_unwind(abort)
+        @test RustCall.effective_panic_strategy(abort) === :abort
+        @test RustCall.effective_panic_strategy(unwind) === :unwind
+
+        # :cargo_default — RustCall drives Cargo but pins no `panic`, so the
+        # result is Cargo's profile default AND the CARGO_PROFILE_<P>_PANIC
+        # environment override, which the build inherits (#244).
+        cd_policy = RustCall.LoadPolicy("cd"; panic_strategy = :cargo_default)
+        @test RustCall.cargo_panic_env_var(cd_policy) == "CARGO_PROFILE_RELEASE_PANIC"
+        @test RustCall.effective_panic_strategy(cd_policy; env = Dict()) === :unwind
+        @test RustCall.effective_panic_strategy(
+            cd_policy; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "abort")) === :abort
+        @test RustCall.effective_panic_strategy(
+            cd_policy; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "unwind")) === :unwind
+        @test RustCall.effective_panic_strategy(
+            cd_policy; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "")) === :unwind
+        @test RustCall.requires_catch_unwind_boundary(cd_policy; env = Dict())
+        @test !RustCall.requires_catch_unwind_boundary(
+            cd_policy; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "abort"))
+        @test RustCall.must_assume_unwind(cd_policy; env = Dict())
+        @test !RustCall.must_assume_unwind(
+            cd_policy; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "abort"))
+        @test RustCall.rustc_panic_flags(cd_policy) === missing
+        # The manifest pins nothing today — that is the bug Phase B fixes.
+        @test RustCall.cargo_profile_panic_line(cd_policy) === nothing
+
+        # A profile other than release picks the matching variable.
+        dbg = RustCall.LoadPolicy("dbg"; panic_strategy = :cargo_default,
+                                  cargo_profile = :dev)
+        @test RustCall.cargo_panic_env_var(dbg) == "CARGO_PROFILE_DEV_PANIC"
+        @test RustCall.effective_panic_strategy(
+            dbg; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "abort")) === :unwind
 
         # :crate_profile — RustCall does not control the build, so the answer
         # is unknown rather than a guess. Phase B must read the effective
         # profile (`cargo metadata` / `cargo config get`) or force it (#244).
         crate = RustCall.LoadPolicy("c"; panic_strategy = :crate_profile)
         @test crate.panic_strategy === :crate_profile
+        # Unchanged by the environment: the user's manifest can still pin it.
+        @test RustCall.effective_panic_strategy(
+            crate; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "abort")) === :crate_profile
         @test RustCall.rustc_panic_flags(crate) === missing
         @test RustCall.cargo_profile_panic_line(crate) === missing
         @test RustCall.requires_catch_unwind_boundary(crate) === missing
@@ -187,7 +222,31 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test isempty(catch_unwind_hits)
 
         @test RustCall.inline_rustc_policy().panic_strategy === :abort
-        @test RustCall.inline_cargo_policy().panic_strategy === :unwind
+
+        # The two Cargo-backed doors RustCall itself drives pin no `panic`, so
+        # they take Cargo's release default — and the CARGO_PROFILE_RELEASE_PANIC
+        # override, because neither build calls setenv: src/cargobuild.jl runs
+        # `cargo build` with the inherited environment, as does deps/build.jl.
+        # Same source, different artifact depending on the caller's env (#244).
+        @test !occursin("setenv", _src("cargobuild.jl"))
+        for policy in (RustCall.inline_cargo_policy(), RustCall.helper_library_policy())
+            @test policy.panic_strategy === :cargo_default
+            @test policy.cargo_profile === :release
+            @test RustCall.cargo_panic_env_var(policy) == "CARGO_PROFILE_RELEASE_PANIC"
+            @test RustCall.effective_panic_strategy(policy; env = Dict()) === :unwind
+            @test RustCall.effective_panic_strategy(
+                policy; env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "abort")) === :abort
+            @test RustCall.must_assume_unwind(policy; env = Dict())
+        end
+        # ...while the direct-rustc door pins -C panic=abort and is unaffected.
+        @test RustCall.effective_panic_strategy(
+            RustCall.inline_rustc_policy();
+            env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "unwind")) === :abort
+        @test !RustCall.must_assume_unwind(
+            RustCall.inline_rustc_policy();
+            env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "unwind"))
+        # Both cargo-backed doors really do build --release.
+        @test occursin("release=true", _src("ruststr.jl"))
 
         # @rust_crate and hot reload run Cargo in the USER's crate
         # (src/crate_bindings.jl:914-925, src/hot_reload.jl:264), so a
@@ -214,12 +273,16 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test !occursin("panic", build_jl)
         @test !occursin("panic", helpers_toml)
         @test !occursin("[profile", helpers_toml)
-        @test RustCall.helper_library_policy().panic_strategy === :unwind
-        @test RustCall.requires_catch_unwind_boundary(RustCall.helper_library_policy())
+        @test RustCall.helper_library_policy().panic_strategy === :cargo_default
+        @test RustCall.requires_catch_unwind_boundary(
+            RustCall.helper_library_policy(); env = Dict())
         # The two inline doors disagree, which is exactly what #244 asks to fix.
-        @test RustCall.inline_rustc_policy().panic_strategy !==
-              RustCall.inline_cargo_policy().panic_strategy
-        @test RustCall.requires_catch_unwind_boundary(RustCall.inline_cargo_policy())
+        @test RustCall.effective_panic_strategy(RustCall.inline_rustc_policy();
+                                                env = Dict()) !==
+              RustCall.effective_panic_strategy(RustCall.inline_cargo_policy();
+                                                env = Dict())
+        @test RustCall.requires_catch_unwind_boundary(
+            RustCall.inline_cargo_policy(); env = Dict())
         @test !RustCall.requires_catch_unwind_boundary(RustCall.inline_rustc_policy())
     end
 

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -1,0 +1,257 @@
+# Tests for the explicit load/compile policy object (issue #277, Phase A).
+#
+# Two halves:
+#
+#   1. the policy record and its named constructors, and
+#   2. the *current divergences* between the front doors, asserted against the
+#      shipped sources.  Phase A migrates no call site, so these tests pass on
+#      today's `main`; when Phase B moves a door onto the shared loader, the
+#      corresponding assertion here must be updated in the same PR.  That is
+#      the point: the inconsistency is pinned down instead of implicit.
+
+using Test
+using RustCall
+using Libdl
+
+const _SRC_DIR = joinpath(dirname(dirname(pathof(RustCall))), "src")
+
+_src(name) = read(joinpath(_SRC_DIR, name), String)
+
+"""Number of non-overlapping occurrences of `needle` in the source of `name`."""
+_count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
+
+@testset "LoadPolicy" begin
+
+    @testset "record and defaults" begin
+        p = RustCall.LoadPolicy("example")
+        @test p.name == "example"
+        @test p.dlopen_flags == UInt32(Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+        @test !RustCall.uses_global_symbols(p)
+        @test p.panic_strategy === :abort
+        @test RustCall.registers_in_rust_libraries(p)
+        @test p.registry_key_kind === :content_hash
+        @test !p.sets_current_lib
+        @test RustCall.finalizer_frees(p)
+        @test RustCall.dlopen_flags(p) == p.dlopen_flags
+        @test occursin("LoadPolicy(example", sprint(show, p))
+
+        g = RustCall.LoadPolicy("g"; dlopen_flags = Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW)
+        @test RustCall.uses_global_symbols(g)
+
+        @test_throws ArgumentError RustCall.LoadPolicy("bad"; panic_strategy = :terminate)
+        @test_throws ArgumentError RustCall.LoadPolicy("bad"; registry = :somewhere)
+        @test_throws ArgumentError RustCall.LoadPolicy("bad"; registry_key_kind = :nope)
+        # A non-RUST_LIBRARIES registry must not carry a RUST_LIBRARIES key kind.
+        @test_throws ArgumentError RustCall.LoadPolicy("bad"; registry = :helper_slot,
+                                                      registry_key_kind = :content_hash)
+    end
+
+    @testset "panic accessors" begin
+        abort = RustCall.LoadPolicy("a"; panic_strategy = :abort)
+        unwind = RustCall.LoadPolicy("u"; panic_strategy = :unwind)
+        @test RustCall.rustc_panic_flags(abort) == ["-C", "panic=abort"]
+        @test isempty(RustCall.rustc_panic_flags(unwind))
+        @test RustCall.cargo_profile_panic_line(abort) == "panic = \"abort\""
+        @test RustCall.cargo_profile_panic_line(unwind) === nothing
+        @test !RustCall.requires_catch_unwind_boundary(abort)
+        @test RustCall.requires_catch_unwind_boundary(unwind)
+        @test !RustCall.requires_catch_unwind_boundary(
+            RustCall.LoadPolicy("u2"; panic_strategy = :unwind,
+                                boundary_catches_panics = true))
+    end
+
+    @testset "named constructors cover every front door" begin
+        @test length(RustCall.ALL_LOAD_POLICIES) == 9
+        names = String[]
+        for ctor in RustCall.ALL_LOAD_POLICIES
+            p = ctor()
+            @test p isa RustCall.LoadPolicy
+            @test !isempty(p.name)
+            @test !isempty(p.call_sites)      # every policy names what it subsumes
+            @test !isempty(p.issues)
+            push!(names, p.name)
+        end
+        @test length(unique(names)) == length(names)
+        # The five doors Phase B swaps over first.
+        @test Set(["inline-rustc", "inline-cargo", "rust-crate",
+                   "helper-library", "cache-hit"]) ⊆ Set(names)
+    end
+
+    # -----------------------------------------------------------------
+    # Divergence 1: dlopen flags (#250)
+    #
+    # The same inline block gets RTLD_LOCAL on a cache miss and RTLD_GLOBAL on
+    # the Cargo path / Cargo cache hit, so whether its symbols enter the
+    # process-global namespace depends on which door and on cache state.
+    # -----------------------------------------------------------------
+    @testset "divergence: dlopen flags (#250)" begin
+        local_sites = 0
+        global_sites = 0
+        for file in readdir(_SRC_DIR)
+            endswith(file, ".jl") || continue
+            file == "loadpolicy.jl" && continue
+            src = _src(file)
+            local_sites += count(_ -> true, eachmatch(r"dlopen\([^)]*RTLD_LOCAL", src))
+            global_sites += count(_ -> true, eachmatch(r"dlopen\([^)]*RTLD_GLOBAL", src))
+        end
+        # Current main: 4 local, 8 global, 12 total. Phase B collapses these
+        # into a single loader; update these numbers as doors move over.
+        @test local_sites == 4
+        @test global_sites == 8
+        @test local_sites + global_sites == 12
+
+        # The pair that makes the bug user-visible: cache-miss vs Cargo path.
+        @test !RustCall.uses_global_symbols(RustCall.inline_rustc_policy())
+        @test RustCall.uses_global_symbols(RustCall.inline_cargo_policy())
+        @test !RustCall.uses_global_symbols(RustCall.cache_hit_policy())
+        # ...and the rule is inverted: the helper library, the one library
+        # other artifacts could resolve against, is the LOCAL one.
+        @test !RustCall.uses_global_symbols(RustCall.helper_library_policy())
+        @test RustCall.uses_global_symbols(RustCall.crate_policy())
+        @test occursin("RTLD_GLOBAL", RustCall.SYMBOL_VISIBILITY_RULE)
+    end
+
+    # -----------------------------------------------------------------
+    # Divergence 2: panic strategy and the missing boundary (#244)
+    #
+    # `-C panic=abort` is passed on the direct-rustc path only; the generated
+    # Cargo project sets no panic mode, and there is no catch_unwind anywhere,
+    # so a panic crossing extern "C" on the Cargo path is undefined behaviour.
+    # -----------------------------------------------------------------
+    @testset "divergence: panic strategy (#244)" begin
+        @test _count_in("compiler.jl", r"panic=abort") == 2
+        @test !occursin("panic", _src("cargoproject.jl"))
+
+        repo = dirname(_SRC_DIR)
+        catch_unwind_hits = String[]
+        for root in (joinpath(repo, "src"), joinpath(repo, "deps"))
+            isdir(root) || continue
+            for (dir, _, files) in walkdir(root)
+                occursin(Base.Filesystem.path_separator * "target" *
+                         Base.Filesystem.path_separator, dir * Base.Filesystem.path_separator) && continue
+                for f in files
+                    (endswith(f, ".jl") || endswith(f, ".rs")) || continue
+                    f == "loadpolicy.jl" && continue   # this file only names the fix
+                    path = joinpath(dir, f)
+                    occursin("catch_unwind", read(path, String)) && push!(catch_unwind_hits, path)
+                end
+            end
+        end
+        # No FFI boundary contains a panic today (#244).
+        @test isempty(catch_unwind_hits)
+
+        @test RustCall.inline_rustc_policy().panic_strategy === :abort
+        @test RustCall.inline_cargo_policy().panic_strategy === :unwind
+        @test RustCall.crate_policy().panic_strategy === :unwind
+        # The two inline doors disagree, which is exactly what #244 asks to fix.
+        @test RustCall.inline_rustc_policy().panic_strategy !==
+              RustCall.inline_cargo_policy().panic_strategy
+        @test RustCall.requires_catch_unwind_boundary(RustCall.inline_cargo_policy())
+        @test !RustCall.requires_catch_unwind_boundary(RustCall.inline_rustc_policy())
+    end
+
+    # -----------------------------------------------------------------
+    # Divergence 3: registration in RUST_LIBRARIES (#250, #251, #255)
+    # -----------------------------------------------------------------
+    @testset "divergence: registration sites (#250, #255)" begin
+        writes = 0
+        for file in readdir(_SRC_DIR)
+            endswith(file, ".jl") || continue
+            file == "loadpolicy.jl" && continue
+            writes += count(_ -> true,
+                            eachmatch(r"RUST_LIBRARIES\[[^\]]*\]\s*=", _src(file)))
+        end
+        # Seven open-coded registration sites on current main.
+        @test writes == 7
+
+        # Each site decides for itself whether CURRENT_LIB moves and what the
+        # key looks like; the policies record that disagreement.
+        @test RustCall.inline_rustc_policy().sets_current_lib
+        @test RustCall.cache_hit_policy().sets_current_lib
+        @test RustCall.inline_cargo_policy().sets_current_lib
+        @test !RustCall.generics_policy().sets_current_lib
+        @test !RustCall.irust_policy().sets_current_lib
+        @test !RustCall.hot_reload_policy().sets_current_lib
+
+        @test RustCall.generics_policy().registry_key_kind === :lib_basename
+        @test RustCall.irust_policy().registry_key_kind === :irust_hash
+        @test RustCall.hot_reload_policy().registry_key_kind === :crate_lib_name
+        @test RustCall.inline_rustc_policy().registry_key_kind === :content_hash
+
+        # Two doors bypass RUST_LIBRARIES entirely, so registry-level unload
+        # cannot see them (#250).
+        @test !RustCall.registers_in_rust_libraries(RustCall.crate_policy())
+        @test !RustCall.registers_in_rust_libraries(RustCall.helper_library_policy())
+        @test !RustCall.registers_in_rust_libraries(RustCall.llvm_policy())
+
+        # The hot-reload rebuild happens outside REGISTRY_LOCK (#255).
+        @test occursin("outside REGISTRY_LOCK", _src("hot_reload.jl"))
+    end
+
+    @testset "register_library! is a locked transaction" begin
+        policy = RustCall.LoadPolicy("test-registration"; sets_current_lib = true)
+        name = "loadpolicy_test_lib_$(getpid())"
+        handle = Ptr{Cvoid}(UInt(0xdead0000))   # never dlsym'd; registry bookkeeping only
+        previous = RustCall.CURRENT_LIB[]
+        try
+            @test RustCall.register_library!(policy, name, handle) == name
+            entry = lock(RustCall.REGISTRY_LOCK) do
+                RustCall.RUST_LIBRARIES[name]
+            end
+            @test entry[1] == handle
+            @test isempty(entry[2])                     # fresh function-pointer cache
+            @test RustCall.CURRENT_LIB[] == name
+            @test RustCall.unregister_library!(policy, name)
+            @test !haskey(RustCall.RUST_LIBRARIES, name)
+            @test RustCall.CURRENT_LIB[] == ""
+            @test !RustCall.unregister_library!(policy, name)  # idempotent
+            @test_throws ArgumentError RustCall.register_library!(policy, name, C_NULL)
+
+            # Policies that do not use RUST_LIBRARIES are a no-op, so a Phase B
+            # call site may call register_library! unconditionally.
+            @test RustCall.register_library!(RustCall.crate_policy(), name, handle) == name
+            @test !haskey(RustCall.RUST_LIBRARIES, name)
+            @test !RustCall.unregister_library!(RustCall.crate_policy(), name)
+        finally
+            lock(RustCall.REGISTRY_LOCK) do
+                delete!(RustCall.RUST_LIBRARIES, name)
+            end
+            RustCall.CURRENT_LIB[] = previous
+        end
+    end
+
+    # -----------------------------------------------------------------
+    # Divergence 4: finalizer / ownership policy (#249, #252)
+    #
+    # Inline #[julia] struct objects never free ("Temporarily disabled free to
+    # diagnose segfault"); @rust_crate struct objects call <Name>_free.
+    # Same user-visible construct, opposite lifetime semantics.
+    # -----------------------------------------------------------------
+    @testset "divergence: finalizers (#249, #252)" begin
+        structs_src = _src("structs.jl")
+        @test _count_in("structs.jl", r"Finalizer: skipped free") == 2
+        @test occursin("Temporarily disabled free", structs_src)
+
+        crate_src = _src("crate_bindings.jl")
+        @test occursin("_free", crate_src)
+        @test occursin("finalizer(obj)", crate_src)
+
+        @test !RustCall.finalizer_frees(RustCall.inline_rustc_policy())
+        @test !RustCall.finalizer_frees(RustCall.cache_hit_policy())
+        @test !RustCall.finalizer_frees(RustCall.inline_cargo_policy())
+        @test RustCall.finalizer_frees(RustCall.crate_policy())
+        @test RustCall.finalizer_frees(RustCall.inline_rustc_policy()) !==
+              RustCall.finalizer_frees(RustCall.crate_policy())
+    end
+
+    @testset "Phase A is additive: no call site migrated yet" begin
+        # loadpolicy.jl is included but nothing in src/ uses it yet.
+        for file in readdir(_SRC_DIR)
+            endswith(file, ".jl") || continue
+            file in ("loadpolicy.jl", "RustCall.jl") && continue
+            src = _src(file)
+            @test !occursin("LoadPolicy", src)
+            @test !occursin("register_library!", src)
+        end
+    end
+end

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -30,6 +30,7 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test p.panic_strategy === :abort
         @test RustCall.registers_in_rust_libraries(p)
         @test p.registry_key_kind === :content_hash
+        @test p.registration_mode === :replace
         @test !p.sets_current_lib
         @test RustCall.finalizer_frees(p)
         @test RustCall.dlopen_flags(p) == p.dlopen_flags
@@ -41,6 +42,7 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test_throws ArgumentError RustCall.LoadPolicy("bad"; panic_strategy = :terminate)
         @test_throws ArgumentError RustCall.LoadPolicy("bad"; registry = :somewhere)
         @test_throws ArgumentError RustCall.LoadPolicy("bad"; registry_key_kind = :nope)
+        @test_throws ArgumentError RustCall.LoadPolicy("bad"; registration_mode = :upsert)
         # A non-RUST_LIBRARIES registry must not carry a RUST_LIBRARIES key kind.
         @test_throws ArgumentError RustCall.LoadPolicy("bad"; registry = :helper_slot,
                                                       registry_key_kind = :content_hash)
@@ -58,10 +60,29 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test !RustCall.requires_catch_unwind_boundary(
             RustCall.LoadPolicy("u2"; panic_strategy = :unwind,
                                 boundary_catches_panics = true))
+        @test RustCall.must_assume_unwind(unwind)
+        @test !RustCall.must_assume_unwind(abort)
+
+        # :crate_profile — RustCall does not control the build, so the answer
+        # is unknown rather than a guess. Phase B must read the effective
+        # profile (`cargo metadata` / `cargo config get`) or force it (#244).
+        crate = RustCall.LoadPolicy("c"; panic_strategy = :crate_profile)
+        @test crate.panic_strategy === :crate_profile
+        @test RustCall.rustc_panic_flags(crate) === missing
+        @test RustCall.cargo_profile_panic_line(crate) === missing
+        @test RustCall.requires_catch_unwind_boundary(crate) === missing
+        # ...resolved conservatively: assume it can unwind.
+        @test RustCall.must_assume_unwind(crate)
+        @test !RustCall.must_assume_unwind(
+            RustCall.LoadPolicy("c2"; panic_strategy = :crate_profile,
+                                boundary_catches_panics = true))
+        @test RustCall.requires_catch_unwind_boundary(
+            RustCall.LoadPolicy("c3"; panic_strategy = :crate_profile,
+                                boundary_catches_panics = true)) === false
     end
 
     @testset "named constructors cover every front door" begin
-        @test length(RustCall.ALL_LOAD_POLICIES) == 9
+        @test length(RustCall.ALL_LOAD_POLICIES) == 8
         names = String[]
         for ctor in RustCall.ALL_LOAD_POLICIES
             p = ctor()
@@ -72,17 +93,25 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
             push!(names, p.name)
         end
         @test length(unique(names)) == length(names)
-        # The five doors Phase B swaps over first.
+        # The doors Phase B swaps over first. There is deliberately no
+        # separate "cache hit" policy: the cache state does not change any of
+        # the four decisions (see the #250 testset below).
         @test Set(["inline-rustc", "inline-cargo", "rust-crate",
-                   "helper-library", "cache-hit"]) ⊆ Set(names)
+                   "helper-library"]) ⊆ Set(names)
+        @test !("cache-hit" in names)
+        @test !isdefined(RustCall, :cache_hit_policy)
     end
 
     # -----------------------------------------------------------------
     # Divergence 1: dlopen flags (#250)
     #
-    # The same inline block gets RTLD_LOCAL on a cache miss and RTLD_GLOBAL on
-    # the Cargo path / Cargo cache hit, so whether its symbols enter the
-    # process-global namespace depends on which door and on cache state.
+    # The axis is whether the block declares `// cargo-deps:`, NOT the cache
+    # state: a dependency-free inline block is RTLD_LOCAL on both a disk-cache
+    # hit (src/cache.jl:270) and a miss (src/ruststr.jl:284), while a
+    # Cargo-backed block is RTLD_GLOBAL on both its cache hit
+    # (src/ruststr.jl:386) and its fresh build (:419). So the same
+    # user-visible construct publishes its symbols process-globally or not
+    # depending only on whether it happens to name a dependency.
     # -----------------------------------------------------------------
     @testset "divergence: dlopen flags (#250)" begin
         local_sites = 0
@@ -100,10 +129,27 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test global_sites == 8
         @test local_sites + global_sites == 12
 
-        # The pair that makes the bug user-visible: cache-miss vs Cargo path.
-        @test !RustCall.uses_global_symbols(RustCall.inline_rustc_policy())
-        @test RustCall.uses_global_symbols(RustCall.inline_cargo_policy())
-        @test !RustCall.uses_global_symbols(RustCall.cache_hit_policy())
+        # Cache state does not change the flags. The dependency-free door
+        # loads RTLD_LOCAL from both the cache and a fresh compile: cache.jl
+        # has a RTLD_LOCAL dlopen and no RTLD_GLOBAL one at all.
+        cache_src = _src("cache.jl")
+        @test occursin(r"dlopen\([^)]*RTLD_LOCAL", cache_src)
+        @test !occursin(r"dlopen\([^)]*RTLD_GLOBAL", cache_src)
+        # ruststr.jl: exactly one RTLD_LOCAL (the dependency-free cache miss)
+        # and three RTLD_GLOBAL (Cargo cache hit, Cargo build, @irust).
+        ruststr_src = _src("ruststr.jl")
+        @test count(_ -> true, eachmatch(r"dlopen\([^)]*RTLD_LOCAL", ruststr_src)) == 1
+        @test count(_ -> true, eachmatch(r"dlopen\([^)]*RTLD_GLOBAL", ruststr_src)) == 3
+
+        # One policy per axis value, each covering both cache states.
+        rustc_policy = RustCall.inline_rustc_policy()
+        cargo_policy = RustCall.inline_cargo_policy()
+        @test !RustCall.uses_global_symbols(rustc_policy)
+        @test RustCall.uses_global_symbols(cargo_policy)
+        @test "src/cache.jl:270" in rustc_policy.call_sites      # cache hit
+        @test "src/ruststr.jl:284" in rustc_policy.call_sites    # cache miss
+        @test "src/ruststr.jl:386" in cargo_policy.call_sites    # cache hit
+        @test "src/ruststr.jl:419" in cargo_policy.call_sites    # fresh build
         # ...and the rule is inverted: the helper library, the one library
         # other artifacts could resolve against, is the LOCAL one.
         @test !RustCall.uses_global_symbols(RustCall.helper_library_policy())
@@ -142,7 +188,20 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
 
         @test RustCall.inline_rustc_policy().panic_strategy === :abort
         @test RustCall.inline_cargo_policy().panic_strategy === :unwind
-        @test RustCall.crate_policy().panic_strategy === :unwind
+
+        # @rust_crate and hot reload run Cargo in the USER's crate
+        # (src/crate_bindings.jl:914-925, src/hot_reload.jl:264), so a
+        # `[profile.release] panic = "abort"` there is honoured and RustCall
+        # cannot claim a strategy. Recorded as :crate_profile, resolved
+        # conservatively by must_assume_unwind (#244).
+        @test occursin("build_cargo_project(project, release=release)",
+                       _src("crate_bindings.jl"))
+        @test occursin("cargo build --release --manifest-path", _src("hot_reload.jl"))
+        @test RustCall.crate_policy().panic_strategy === :crate_profile
+        @test RustCall.hot_reload_policy().panic_strategy === :crate_profile
+        @test RustCall.requires_catch_unwind_boundary(RustCall.crate_policy()) === missing
+        @test RustCall.must_assume_unwind(RustCall.crate_policy())
+        @test RustCall.must_assume_unwind(RustCall.hot_reload_policy())
 
         # Fourth unwinding path: the ownership helper library. deps/build.jl
         # builds it with a plain `cargo build --release` and
@@ -181,7 +240,6 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         # Each site decides for itself whether CURRENT_LIB moves and what the
         # key looks like; the policies record that disagreement.
         @test RustCall.inline_rustc_policy().sets_current_lib
-        @test RustCall.cache_hit_policy().sets_current_lib
         @test RustCall.inline_cargo_policy().sets_current_lib
         @test !RustCall.generics_policy().sets_current_lib
         @test !RustCall.irust_policy().sets_current_lib
@@ -200,6 +258,21 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
 
         # The hot-reload rebuild happens outside REGISTRY_LOCK (#255).
         @test occursin("outside REGISTRY_LOCK", _src("hot_reload.jl"))
+
+        # Generics registers only when the key is absent, and that guard is
+        # load-bearing: _unique_source_name returns the fixed base name
+        # "rust_code" outside debug mode (src/compiler.jl:68-72), so every
+        # instantiation collides on the same librust_code basename. An
+        # unconditional assignment would swap the live handle and discard the
+        # function-pointer cache filled at src/generics.jl:267 (#250).
+        @test occursin("return \"rust_code\"", _src("compiler.jl"))
+        @test occursin("if !haskey(RUST_LIBRARIES, lib_name)", _src("generics.jl"))
+        @test RustCall.generics_policy().registration_mode === :insert_only
+        for ctor in RustCall.ALL_LOAD_POLICIES
+            p = ctor()
+            p.name == "generics-monomorphization" && continue
+            @test p.registration_mode === :replace
+        end
     end
 
     @testset "register_library! is a locked transaction" begin
@@ -226,6 +299,35 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
             @test RustCall.register_library!(RustCall.crate_policy(), name, handle) == name
             @test !haskey(RustCall.RUST_LIBRARIES, name)
             @test !RustCall.unregister_library!(RustCall.crate_policy(), name)
+
+            # :insert_only keeps the existing handle and its function-pointer
+            # cache; :replace overwrites both (#250, src/generics.jl:250-253).
+            insert_only = RustCall.LoadPolicy("test-insert-only";
+                                              registration_mode = :insert_only)
+            other = Ptr{Cvoid}(UInt(0xbeef0000))
+            RustCall.register_library!(policy, name, handle)
+            lock(RustCall.REGISTRY_LOCK) do
+                RustCall.RUST_LIBRARIES[name][2]["cached_symbol"] = handle
+            end
+            RustCall.register_library!(insert_only, name, other)
+            kept = lock(RustCall.REGISTRY_LOCK) do
+                RustCall.RUST_LIBRARIES[name]
+            end
+            @test kept[1] == handle                       # existing handle kept
+            @test haskey(kept[2], "cached_symbol")        # and its symbol cache
+
+            RustCall.register_library!(policy, name, other)   # :replace
+            replaced = lock(RustCall.REGISTRY_LOCK) do
+                RustCall.RUST_LIBRARIES[name]
+            end
+            @test replaced[1] == other
+            @test isempty(replaced[2])
+            RustCall.unregister_library!(policy, name)
+
+            # :insert_only on an absent key still inserts.
+            @test RustCall.register_library!(insert_only, name, other) == name
+            @test lock(() -> RustCall.RUST_LIBRARIES[name][1], RustCall.REGISTRY_LOCK) == other
+            RustCall.unregister_library!(insert_only, name)
         finally
             lock(RustCall.REGISTRY_LOCK) do
                 delete!(RustCall.RUST_LIBRARIES, name)
@@ -251,7 +353,6 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         @test occursin("finalizer(obj)", crate_src)
 
         @test !RustCall.finalizer_frees(RustCall.inline_rustc_policy())
-        @test !RustCall.finalizer_frees(RustCall.cache_hit_policy())
         @test !RustCall.finalizer_frees(RustCall.inline_cargo_policy())
         @test RustCall.finalizer_frees(RustCall.crate_policy())
         @test RustCall.finalizer_frees(RustCall.inline_rustc_policy()) !==

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -117,7 +117,7 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
     end
 
     @testset "named constructors cover every front door" begin
-        @test length(RustCall.ALL_LOAD_POLICIES) == 8
+        @test length(RustCall.ALL_LOAD_POLICIES) == 9
         names = String[]
         for ctor in RustCall.ALL_LOAD_POLICIES
             p = ctor()
@@ -131,8 +131,8 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         # The doors Phase B swaps over first. There is deliberately no
         # separate "cache hit" policy: the cache state does not change any of
         # the four decisions (see the #250 testset below).
-        @test Set(["inline-rustc", "inline-cargo", "rust-crate",
-                   "helper-library"]) ⊆ Set(names)
+        @test Set(["inline-rustc", "inline-cargo", "rust-crate-direct",
+                   "rust-crate-wrapper", "helper-library"]) ⊆ Set(names)
         @test !("cache-hit" in names)
         @test !isdefined(RustCall, :cache_hit_policy)
     end
@@ -188,7 +188,8 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         # ...and the rule is inverted: the helper library, the one library
         # other artifacts could resolve against, is the LOCAL one.
         @test !RustCall.uses_global_symbols(RustCall.helper_library_policy())
-        @test RustCall.uses_global_symbols(RustCall.crate_policy())
+        @test RustCall.uses_global_symbols(RustCall.crate_direct_policy())
+        @test RustCall.uses_global_symbols(RustCall.crate_wrapper_policy())
         @test occursin("RTLD_GLOBAL", RustCall.SYMBOL_VISIBILITY_RULE)
     end
 
@@ -248,19 +249,41 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
         # Both cargo-backed doors really do build --release.
         @test occursin("release=true", _src("ruststr.jl"))
 
-        # @rust_crate and hot reload run Cargo in the USER's crate
-        # (src/crate_bindings.jl:914-925, src/hot_reload.jl:264), so a
-        # `[profile.release] panic = "abort"` there is honoured and RustCall
-        # cannot claim a strategy. Recorded as :crate_profile, resolved
-        # conservatively by must_assume_unwind (#244).
-        @test occursin("build_cargo_project(project, release=release)",
-                       _src("crate_bindings.jl"))
+        # @rust_crate has TWO build paths with different panic semantics,
+        # chosen by crate_has_cdylib: the direct build runs Cargo with the
+        # USER's manifest as the root (src/crate_bindings.jl:852, :914-925), so
+        # their [profile.release] wins -> :crate_profile; the wrapper build
+        # (:854-868) makes RustCall's generated manifest the root, and that one
+        # sets only opt-level/lto (:266-269) -> :cargo_default. Hot reload
+        # rebuilds the user's manifest (src/hot_reload.jl:264) -> :crate_profile.
+        crate_src = _src("crate_bindings.jl")
+        @test occursin("build_cargo_project(project, release=release)", crate_src)
+        @test occursin("build_cargo_project(wrapper_project, release=build_release)", crate_src)
+        @test occursin("\"[profile.release]\"", crate_src)
+        @test !occursin("panic", crate_src)
         @test occursin("cargo build --release --manifest-path", _src("hot_reload.jl"))
-        @test RustCall.crate_policy().panic_strategy === :crate_profile
+
+        @test RustCall.crate_direct_policy().panic_strategy === :crate_profile
+        @test RustCall.crate_wrapper_policy().panic_strategy === :cargo_default
         @test RustCall.hot_reload_policy().panic_strategy === :crate_profile
-        @test RustCall.requires_catch_unwind_boundary(RustCall.crate_policy()) === missing
-        @test RustCall.must_assume_unwind(RustCall.crate_policy())
+        @test RustCall.requires_catch_unwind_boundary(
+            RustCall.crate_direct_policy()) === missing
+        @test RustCall.requires_catch_unwind_boundary(
+            RustCall.crate_wrapper_policy(); env = Dict()) === true
+        @test RustCall.effective_panic_strategy(
+            RustCall.crate_wrapper_policy();
+            env = Dict("CARGO_PROFILE_RELEASE_PANIC" => "abort")) === :abort
+        @test RustCall.must_assume_unwind(RustCall.crate_direct_policy())
         @test RustCall.must_assume_unwind(RustCall.hot_reload_policy())
+        # The two @rust_crate doors disagree with each other (#244).
+        @test RustCall.crate_direct_policy().panic_strategy !==
+              RustCall.crate_wrapper_policy().panic_strategy
+        # Everything except the panic strategy is shared between them.
+        for f in (:dlopen_flags, :registry, :registry_key_kind, :registration_mode,
+                  :sets_current_lib, :finalizer_frees)
+            @test getfield(RustCall.crate_direct_policy(), f) ==
+                  getfield(RustCall.crate_wrapper_policy(), f)
+        end
 
         # Fourth unwinding path: the ownership helper library. deps/build.jl
         # builds it with a plain `cargo build --release` and
@@ -315,7 +338,8 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
 
         # Two doors bypass RUST_LIBRARIES entirely, so registry-level unload
         # cannot see them (#250).
-        @test !RustCall.registers_in_rust_libraries(RustCall.crate_policy())
+        @test !RustCall.registers_in_rust_libraries(RustCall.crate_direct_policy())
+        @test !RustCall.registers_in_rust_libraries(RustCall.crate_wrapper_policy())
         @test !RustCall.registers_in_rust_libraries(RustCall.helper_library_policy())
         @test !RustCall.registers_in_rust_libraries(RustCall.llvm_policy())
 
@@ -359,9 +383,9 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
 
             # Policies that do not use RUST_LIBRARIES are a no-op, so a Phase B
             # call site may call register_library! unconditionally.
-            @test RustCall.register_library!(RustCall.crate_policy(), name, handle) == name
+            @test RustCall.register_library!(RustCall.crate_direct_policy(), name, handle) == name
             @test !haskey(RustCall.RUST_LIBRARIES, name)
-            @test !RustCall.unregister_library!(RustCall.crate_policy(), name)
+            @test !RustCall.unregister_library!(RustCall.crate_direct_policy(), name)
 
             # :insert_only keeps the existing handle and its function-pointer
             # cache; :replace overwrites both (#250, src/generics.jl:250-253).
@@ -417,9 +441,10 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
 
         @test !RustCall.finalizer_frees(RustCall.inline_rustc_policy())
         @test !RustCall.finalizer_frees(RustCall.inline_cargo_policy())
-        @test RustCall.finalizer_frees(RustCall.crate_policy())
+        @test RustCall.finalizer_frees(RustCall.crate_direct_policy())
+        @test RustCall.finalizer_frees(RustCall.crate_wrapper_policy())
         @test RustCall.finalizer_frees(RustCall.inline_rustc_policy()) !==
-              RustCall.finalizer_frees(RustCall.crate_policy())
+              RustCall.finalizer_frees(RustCall.crate_direct_policy())
     end
 
     @testset "Phase A is additive: no call site migrated yet" begin


### PR DESCRIPTION
Phase A of #277. **Strictly additive: no call site has been migrated yet.** Nothing in `src/` calls the new code, no observable behaviour changes, and the only edit to an existing source file is the one `include("loadpolicy.jl")` line in `src/RustCall.jl`.

## What this adds

- **`src/loadpolicy.jl`** — one `LoadPolicy` record naming the four decisions that are currently open-coded at every front door:
  - the `dlopen` flag set, plus `SYMBOL_VISIBILITY_RULE`: `RTLD_GLOBAL` only for libraries whose symbols other libraries resolve against (the ownership helper library); every leaf artifact reached through its own handle via `dlsym` is `RTLD_LOCAL`. Current `main` has this rule inverted. Visibility is **stable across cache states** and splits on whether the block declares `// cargo-deps:`.
  - the panic strategy of the artifact — `:abort` (pinned by RustCall), `:unwind` (pinned), `:cargo_default` (RustCall drives Cargo but pins no `panic`, so Cargo's profile default applies *and* `CARGO_PROFILE_<PROFILE>_PANIC` from the inherited environment can flip it), or `:crate_profile` (Cargo runs in the user's crate, their manifest decides) — plus the Cargo profile in use, and whether the generated `extern "C"` boundary catches unwinds. Accessors: `rustc_panic_flags`, `cargo_profile_panic_line`, `cargo_panic_env_var`, `effective_panic_strategy(policy; env = ENV)`, `requires_catch_unwind_boundary` (`missing` for `:crate_profile`) and the conservative `must_assume_unwind`.
  - whether the handle is registered in `RUST_LIBRARIES`, under what key kind (`:content_hash`, `:lib_basename`, `:irust_hash`, `:crate_lib_name`), whether an existing entry is replaced or kept (`registration_mode`), and whether `CURRENT_LIB` moves.
  - the finalizer / ownership policy of the types the artifact produces.

  Named constructors for every door that exists today — `inline_rustc_policy`, `inline_cargo_policy`, `crate_direct_policy`, `crate_wrapper_policy`, `helper_library_policy`, `generics_policy`, `irust_policy`, `hot_reload_policy`, `llvm_policy` — each reproducing today's behaviour and documenting the call sites it will subsume and the issue its divergence causes. `register_library!` / `unregister_library!` do registration as one transaction under `REGISTRY_LOCK` (#251). Everything internal; no new `export`.

- **`test/test_loadpolicy.jl`** — tests the constructors and, for each of the four decisions, **documents the current divergence as a test** against the shipped sources, with the causing issue named in a comment. When Phase B migrates a door, the corresponding assertion has to be updated in the same PR. The file is picked up by `ParallelTestRunner`'s discovery in `test/runtests.jl`, so `runtests.jl` needs no edit.

## Inventory: 12 `dlopen` sites

| # | Site | Flags | Front door | Policy constructor |
| --- | --- | --- | --- | --- |
| 1 | `src/cache.jl:270` | `RTLD_LOCAL \| RTLD_NOW` | `load_cached_library` (dependency-free inline block, cache hit) | `inline_rustc_policy` |
| 2 | `src/ruststr.jl:284` | `RTLD_LOCAL \| RTLD_NOW` | dependency-free inline block, direct rustc, cache miss | `inline_rustc_policy` |
| 3 | `src/ruststr.jl:386` | `RTLD_GLOBAL \| RTLD_NOW` | inline `rust"""` with `// cargo-deps:`, Cargo cache hit | `inline_cargo_policy` |
| 4 | `src/ruststr.jl:419` | `RTLD_GLOBAL \| RTLD_NOW` | inline `rust"""` with `// cargo-deps:`, freshly built | `inline_cargo_policy` |
| 5 | `src/ruststr.jl:822` | `RTLD_GLOBAL \| RTLD_NOW` | `@irust` snippet | `irust_policy` |
| 6 | `src/memory.jl:215` | `RTLD_LOCAL \| RTLD_NOW` | `load_rust_helpers_lib` (explicit) | `helper_library_policy` |
| 7 | `src/memory.jl:321` | `RTLD_LOCAL \| RTLD_NOW` | helper library auto-load | `helper_library_policy` |
| 8 | `src/crate_bindings.jl:344` | `RTLD_GLOBAL \| RTLD_NOW` | `@rust_crate` in-memory module `__init__` | `crate_direct_policy` / `crate_wrapper_policy` |
| 9 | `src/crate_bindings.jl:1360` | `RTLD_GLOBAL \| RTLD_NOW` | emitted bindings-file template | `crate_direct_policy` / `crate_wrapper_policy` |
| 10 | `src/generics.jl:243` | `RTLD_GLOBAL \| RTLD_NOW` | monomorphized generic instantiation | `generics_policy` |
| 11 | `src/hot_reload.jl:205` | `RTLD_GLOBAL \| RTLD_NOW` | hot reload of a crate | `hot_reload_policy` |
| 12 | `src/llvmcodegen.jl:347` | `RTLD_GLOBAL \| RTLD_NOW` | deprecated LLVM IR path (#265) | `llvm_policy` |

4 `RTLD_LOCAL`, 8 `RTLD_GLOBAL`. The divergence axis is **whether the block declares `// cargo-deps:`**, not the cache state: sites 1 and 2 (hit and miss of the dependency-free door) are both `RTLD_LOCAL`, sites 3 and 4 (hit and fresh build of the Cargo door) are both `RTLD_GLOBAL`. So the same user-visible `rust"""` construct publishes its symbols process-globally or not depending only on whether it happens to name a dependency (#250).

## Inventory: 7 `RUST_LIBRARIES` write sites

| # | Site | Key kind | `CURRENT_LIB` | Also writes | Notes |
| --- | --- | --- | --- | --- | --- |
| 1 | `src/ruststr.jl:251` | `rust_<content hash>` | set | — | dependency-free inline block, cache hit; replaces |
| 2 | `src/ruststr.jl:291` | `rust_<content hash>` | set | — | dependency-free inline block, cache miss; replaces |
| 3 | `src/ruststr.jl:389` | `rust_<content hash>` | set | — | Cargo cache hit |
| 4 | `src/ruststr.jl:426` | `rust_<content hash>` | set | — | Cargo build |
| 5 | `src/ruststr.jl:837` | `irust_<hash>` | not set | `IRUST_FUNCTIONS` | `@irust` |
| 6 | `src/generics.jl:252` | library **basename** | not set | function-pointer cache at `:267` | **insert-only** (`if !haskey(...)`), and load-bearing: `_unique_source_name` (`src/compiler.jl:68-72`) gives every non-debug compilation the same `rust_code` basename, so the key collides and replacing would drop the live handle and its symbol cache |
| 7 | `src/hot_reload.jl:210` | crate `lib_name` | not set | — | rebuild happens outside `REGISTRY_LOCK`; a failed rebuild can leave the previous entry gone (#255) |

Not in `RUST_LIBRARIES` at all: the `@rust_crate` module-local `_LIB_HANDLE` (sites 8/9 above), the helper library's `RUST_HELPERS_LIB` (6/7), and the LLVM path (12) — so registry-level unload cannot see them (#250).

## Other divergences recorded

- **Panic strategy**, four distinct cases: `-C panic=abort` at `src/compiler.jl:219`, `:381` (direct rustc) only; RustCall-generated Cargo projects and the ownership helper library are `:cargo_default` — `src/cargoproject.jl:126-128` writes only `opt-level`/`lto` and `deps/rust_helpers/Cargo.toml` has no `[profile.release]` at all, and since neither `build_cargo_project` (`src/cargobuild.jl:25-67`) nor `deps/build.jl:97-98` passes `setenv`, `CARGO_PROFILE_RELEASE_PANIC=abort` in the Julia process silently makes both abort (`effective_panic_strategy(policy; env)` resolves this — and for a cached or reloaded artifact the caller must pass the build-time snapshot, `effective_panic_strategy(policy, snapshot.cargo_env)`, never the live `ENV`; the matching cache-key gap at `src/ruststr.jl:380-386` is closed by #272's `CARGO_PROFILE_` allowlist, structural fix in #278); `@rust_crate` splits in two, chosen by `crate_has_cdylib`: the direct build (`src/crate_bindings.jl:852`, `:914-925`) and hot reload (`src/hot_reload.jl:264`) run Cargo with the **user's** manifest as the root, so their profile decides — `:crate_profile`, with `requires_catch_unwind_boundary` returning `missing` and `must_assume_unwind` resolving it conservatively — while the generated wrapper crate (`:854-868`, manifest at `:266-269`) is RustCall's own and is therefore `:cargo_default` like the inline Cargo door. `catch_unwind` appears nowhere in `src/` or `deps/`, so a panic crossing `extern "C"` on any non-aborting path is UB (#244).
- **Finalizers**: inline `#[julia]` structs never free (`src/structs.jl:157-159`, `:282-285`, "Temporarily disabled free to diagnose segfault"), `@rust_crate` structs call `<Name>_free` (`src/crate_bindings.jl:550`) — opposite lifetime semantics for the same construct (#249, #252).

## Testing

`bash scripts/lint_interpolation.sh src` and `bash scripts/lint_rust_syntax_regex.sh src` pass. Full `Pkg.test()` passes on this branch (1710 parallel + 270 serial assertions), with `RUSTCALL_EXTRACT` pointed at a freshly built `rustcall-extract`.

Part of #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
