### PR TITLE
Single source of truth for the FFI type contract (#276, Phase A)

### DIFF
--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -35,6 +35,7 @@ const REGISTRY_LOCK = ReentrantLock()
 # Include submodules in order of dependency
 include("types.jl")
 include("typetranslation.jl")
+include("ffi_contract.jl")
 include("compiler.jl")
 include("llvmintegration.jl")
 include("codegen.jl")

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -325,17 +325,22 @@ const FFI_PRIMITIVE_PATH_PREFIXES = ("core::primitive::", "std::primitive::")
 
 The table key for a Rust type spelling: whitespace trimmed, and a
 `core::primitive::` / `std::primitive::` qualifier stripped so that
-`core::primitive::i32` resolves like `i32`.
+`core::primitive::i32` resolves like `i32`. A leading `::` (the rooted form
+`::core::primitive::i32`, which `type_to_string` preserves) is stripped first.
 
 Only those two prefixes are stripped; see [`FFI_PRIMITIVE_PATH_PREFIXES`] for
-why an arbitrary `mycrate::i32` is not normalized even though
+why an arbitrary `mycrate::i32` — rooted or not — is not normalized even though
 `rustcall_core` accepts it.
 """
 function ffi_normalize_spelling(rust_type::AbstractString)
     key = String(strip(rust_type))
+    # A rooted path (`::core::primitive::i32`) names the same type as the
+    # unrooted one; only the primitive prefixes below act on it, so an
+    # unrecognised rooted path is returned untouched and still fails closed.
+    rooted = startswith(key, "::") ? key[3:end] : key
     for prefix in FFI_PRIMITIVE_PATH_PREFIXES
-        if startswith(key, prefix)
-            tail = key[(length(prefix) + 1):end]
+        if startswith(rooted, prefix)
+            tail = rooted[(length(prefix) + 1):end]
             # Only a bare final segment: `core::primitive::i32`, never
             # `core::primitive::foo::bar`.
             occursin("::", tail) && return key
@@ -610,13 +615,24 @@ c.ownership    # :transferred_to_julia
 c.free_symbol  # "Point_free"
 ```
 
-Declaring `:owned_by_rust` or `:transferred_to_julia` without naming a
-`free_symbol` (directly, or via `owner` for the string convention) is an
-`ArgumentError`: an owned value with no way to release it is the shape of #246
-and #249, and the contract refuses to record it.
+# The free-symbol invariant
 
-`owner` is the function or struct name the wrapper belongs to; when given, an
-`:owned_by_rust` string return carries its [`ffi_free_symbol`](@ref).
+A contract whose ownership is one of [`FFI_OWNERSHIP_NEEDS_FREE`] **always**
+names the `free_symbol` that releases the value; an owned value with no way to
+free it is the shape of #246 and #249 and is never recorded. Concretely:
+
+* declaring `:owned_by_rust` / `:transferred_to_julia` without a `free_symbol`
+  is an `ArgumentError`;
+* a *derived* owned return with no symbol available (a lowered `String` return
+  where the caller named no owner) reports `:unknown` ownership rather than an
+  unfreeable `:owned_by_rust`.
+
+`owner` is the function or struct name the wrapper belongs to. It supplies only
+the **string** release convention (`<owner>_free_rust_string`,
+`deps/rustcall_core/src/codegen.rs:633`), so it stands in for `free_symbol` only
+on a lowered owned-string return (`:ptr_len_cap`). For a pointer return — where
+the releasing symbol is whatever the crate exports, e.g. `Point_free` — it does
+not apply and `free_symbol` must be given.
 
 ```julia
 c = RustCall.ffi_return_contract("String"; abi = "string", owner = "shout")
@@ -631,6 +647,9 @@ function ffi_return_contract(rust_type::AbstractString; abi::AbstractString = ""
                              owner::Union{Nothing, AbstractString} = nothing,
                              ownership::Union{Nothing, Symbol} = nothing,
                              free_symbol::Union{Nothing, AbstractString} = nothing)
+    ownership === nothing || ownership in FFI_OWNERSHIP_KINDS || throw(ArgumentError(
+        "unknown ownership :$ownership for $rust_type; " *
+        "expected one of $(FFI_OWNERSHIP_KINDS)"))
     return _ffi_contract(rust_type, :return, abi, owner, ownership, free_symbol)
 end
 
@@ -655,7 +674,8 @@ function _ffi_contract(rust_type::AbstractString, direction::Symbol, abi::Abstra
     key = ffi_normalize_spelling(rust_type)
     override = ffi_manifest_abi_kind(abi, direction)
     entry = ffi_lookup(key)
-    stated = _ffi_check_stated_ownership(key, stated_ownership, stated_free_symbol, owner)
+    stated = (stated_ownership,
+              stated_free_symbol === nothing ? nothing : String(stated_free_symbol))
 
     if entry === nothing
         override === nothing && return _ffi_unknown_contract(key, direction)
@@ -692,20 +712,15 @@ _ffi_unknown_contract(key, direction) = FFIContract(
     copy(_FFI_UNKNOWN_SLOTS), Any, :unknown, nothing, false,
 )
 
-# An explicitly stated ownership must be a known tag, and one that implies a
-# release must name the symbol that performs it.
-function _ffi_check_stated_ownership(key, ownership, free_symbol, owner)
-    if ownership !== nothing
-        ownership in FFI_OWNERSHIP_KINDS || throw(ArgumentError(
-            "unknown ownership :$ownership for $key; expected one of $(FFI_OWNERSHIP_KINDS)"))
-        if ownership === :owned_by_rust || ownership === :transferred_to_julia
-            free_symbol === nothing && owner === nothing && throw(ArgumentError(
-                "ownership :$ownership for $key requires a free_symbol (or an owner): " *
-                "an owned value with no way to release it cannot be recorded"))
-        end
-    end
-    return (ownership, free_symbol === nothing ? nothing : String(free_symbol))
-end
+"""
+    FFI_OWNERSHIP_NEEDS_FREE
+
+The ownership tags that oblige someone to release the value. The contract keeps
+the invariant that a position tagged with one of these **always** names the
+`free_symbol` that performs the release — an owned value with no way to free it
+is the shape of #246 and #249, and is refused rather than recorded.
+"""
+const FFI_OWNERSHIP_NEEDS_FREE = (:owned_by_rust, :transferred_to_julia)
 
 # Turn an ABI kind into the ccall slots / aggregate / layout for one position.
 function _ffi_positional(key, direction, kind, surface, ownership, owner,
@@ -727,9 +742,30 @@ function _ffi_positional(key, direction, kind, surface, ownership, owner,
     # A stated ownership wins over the derived one: the consumer has metadata
     # the spelling does not carry (a constructor's `Box::into_raw`, say).
     final_ownership = stated_ownership === nothing ? ownership : stated_ownership
-    derived_free = final_ownership === :owned_by_rust && owner !== nothing ?
+
+    # `owner` only names the *string* release convention
+    # (`<owner>_free_rust_string`, deps/rustcall_core/src/codegen.rs:633), so it
+    # may stand in for `free_symbol` only where that convention applies: the
+    # lowered owned-string return. Every other owned value must name its own
+    # symbol explicitly.
+    derived_free = owner !== nothing && kind === :ptr_len_cap && direction === :return ?
         ffi_free_symbol(owner) : nothing
     free_symbol = stated_free_symbol === nothing ? derived_free : stated_free_symbol
+
+    if final_ownership in FFI_OWNERSHIP_NEEDS_FREE && free_symbol === nothing
+        if stated_ownership === nothing
+            # Derived, not asserted: the ABI says the value is owned but nobody
+            # named the releasing symbol. Fail closed rather than hand back an
+            # owned value a consumer cannot free (#246, #249).
+            final_ownership = :unknown
+        else
+            throw(ArgumentError(
+                "ownership :$stated_ownership for $key requires an explicit free_symbol" *
+                (kind === :ptr_len_cap ? " (or an owner, for the string convention)" : "") *
+                ": an owned value with no way to release it cannot be recorded"))
+        end
+    end
+
     return FFIContract(key, direction, kind, slots, aggregate, layout, surface,
                        final_ownership, free_symbol, true)
 end

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -77,13 +77,32 @@ Who owns the memory a C slot refers to, and therefore who must release it.
 | `:none`                | nothing is owned; the value is a scalar passed by value |
 | `:borrowed`            | the pointee belongs to the other side and is only valid for the duration of the call |
 | `:owned_by_julia`      | Julia allocated the buffer; Julia frees it, and must keep it rooted (`GC.@preserve`) across the call |
-| `:owned_by_rust`       | Rust allocated the buffer; Julia must hand it back through `free_symbol` (#246) |
-| `:transferred_to_julia`| ownership moved to Julia, which frees it with its own allocator |
+| `:owned_by_rust`       | Rust allocated it; Julia releases it **within the call** by calling `free_symbol` (#246) |
+| `:transferred_to_julia`| the *responsibility* to release moved to Julia, which **must** do so by calling `free_symbol` — never through Julia's allocator |
 | `:unknown`             | the contract does not say — callers must fail rather than assume |
 
-`:owned_by_rust` is the tag whose missing `free_symbol` is the root of #246
-(leaked `String` returns) and #249 (the drop symbol picked from the Julia-side
-type tag instead of from the library that allocated the value).
+# `:owned_by_rust` vs `:transferred_to_julia`
+
+The release **mechanism is identical**: both call the Rust export named by
+`free_symbol`, so the Rust destructor runs on the allocator that allocated the
+value. Julia never frees Rust memory itself — not with `Libc.free`, not with its
+own GC. Freeing a `Box::into_raw` handle any other way skips `Drop` and, once a
+crate installs a `#[global_allocator]`, corrupts the heap (#249).
+
+What differs is **when**, and therefore who holds the pointer:
+
+* `:owned_by_rust` — the value does not outlive the call. The wrapper copies it
+  into Julia memory and calls `free_symbol` before returning, as
+  `_call_rust_owned_string` already does in a `finally`
+  (`src/structs.jl:511-523`). Julia never stores the raw pointer.
+* `:transferred_to_julia` — the value outlives the call. Julia keeps the handle
+  (a `Box::into_raw` pointer inside a struct wrapper, `codegen.rs:386-392`) and
+  is responsible for calling `free_symbol` later, from a finalizer.
+
+Both are in [`FFI_OWNERSHIP_NEEDS_FREE`], so both always name that symbol. A
+missing `free_symbol` on either is the root of #246 (leaked `String` returns)
+and #249 (the drop symbol picked from the Julia-side type tag instead of from
+the library that allocated the value).
 """
 const FFI_OWNERSHIP_KINDS =
     (:none, :borrowed, :owned_by_julia, :owned_by_rust, :transferred_to_julia, :unknown)
@@ -100,10 +119,13 @@ One row of the contract: what a Rust type spelling means at the boundary.
   leading pointer slot; use [`ffi_argument_contract`](@ref) /
   [`ffi_return_contract`](@ref) for the full slot list.
 - `surface_type::Type` — the type a Julia caller sees.
-- `julia_symbol::Symbol` — how the surface type is *spelled* in generated code.
-  Kept separate from `surface_type` because Julia aliases erase spellings:
-  `Cvoid === Nothing` and `Csize_t === UInt64`, and the existing generators emit
-  `:Cvoid` / `:Csize_t`.
+- `julia_expr::Union{Symbol,Expr}` — how the surface type is *spelled* in
+  generated code, as a Julia AST fragment ready to splice with `\$`: a `Symbol`
+  for a plain name (`:Int32`, `:Cvoid`, `:RustString`) and an `Expr` for a
+  parametric one (`:(Ptr{Ptr{Int32}})`). Kept separate from `surface_type`
+  because Julia aliases erase spellings: `Cvoid === Nothing` and
+  `Csize_t === UInt64`, and the existing generators emit `:Cvoid` / `:Csize_t`.
+  Evaluating it in the `RustCall` module yields `surface_type`.
 - `abi::Symbol` — one of [`FFI_ABI_KINDS`], the ABI when the type appears as a
   plain by-value argument or return.
 - `ownership::Symbol` — one of [`FFI_OWNERSHIP_KINDS`].
@@ -113,7 +135,7 @@ struct FFIType
     rust::String
     ccall_type::Type
     surface_type::Type
-    julia_symbol::Symbol
+    julia_expr::Union{Symbol, Expr}
     abi::Symbol
     ownership::Symbol
     note::String
@@ -175,8 +197,8 @@ end
 # The table
 # ============================================================================
 
-_ffi_row(rust, ccall_type, surface_type, julia_symbol, abi, ownership, note = "") =
-    FFIType(rust, ccall_type, surface_type, julia_symbol, abi, ownership, note)
+_ffi_row(rust, ccall_type, surface_type, julia_expr, abi, ownership, note = "") =
+    FFIType(rust, ccall_type, surface_type, julia_expr, abi, ownership, note)
 
 _ffi_scalar(rust, T, sym = Symbol(T)) = _ffi_row(rust, T, T, sym, :by_value, :none)
 
@@ -284,7 +306,7 @@ end
 #     must hand back to the library that allocated it, and `"str"` is a borrowed
 #     `(ptr, len)` view.
 #
-# The `surface_type` / `julia_symbol` columns stay meaningful regardless: they
+# The `surface_type` / `julia_expr` columns stay meaningful regardless: they
 # describe the Julia-visible type, not the calling convention.
 _ffi_register!(FFIType(
     "String", Ptr{UInt8}, RustString, :RustString, :unknown, :unknown,
@@ -401,7 +423,7 @@ function _ffi_pointer_row(key::AbstractString, pointee::AbstractString)
     # rejects as non-FFI anyway (`types.rs:104`). So the default is `:unknown`,
     # and a consumer that has the metadata states it: see
     # [`ffi_return_contract`](@ref)'s `ownership` / `free_symbol` keywords.
-    return FFIType(String(key), T, T, Symbol(T), :pointer, :unknown, note)
+    return FFIType(String(key), T, T, ffi_type_expr(T), :pointer, :unknown, note)
 end
 
 """
@@ -444,10 +466,24 @@ function ffi_surface_type(rust_type::AbstractString)
 end
 
 """
-    ffi_julia_symbol(rust_type::AbstractString) -> Union{Symbol, Nothing}
+    ffi_julia_symbol(rust_type::AbstractString) -> Union{Symbol, Expr, Nothing}
 
-How the surface type should be *spelled* in generated code (`:Cvoid`,
-`:Csize_t`, ...), or `nothing` when the type is unknown.
+How the surface type should be *spelled* in generated code, as a Julia AST
+fragment, or `nothing` when the type is unknown.
+
+A plain name comes back as a `Symbol` (`:Cvoid`, `:Csize_t`, `:RustString`); a
+parametric one comes back as an `Expr` (`:(Ptr{Ptr{Int32}})`), never as a
+`Symbol` of its printed form — `Symbol("Ptr{Int32}")` would splice into
+generated code as `var"Ptr{Int32}"`, an undefined binding. Both forms can be
+interpolated into a quote directly:
+
+```julia
+T = RustCall.ffi_julia_symbol("*const *mut i32")   # :(Ptr{Ptr{Int32}})
+:(x::\$T)
+```
+
+Use [`ffi_julia_type`](@ref) when you want the `Type` itself rather than its
+spelling.
 
 This is the replacement for `_rust_type_to_julia_type_symbol`
 (`src/julia_functions.jl:220`) and `rust_to_julia_type_sym`
@@ -456,7 +492,40 @@ types, while this answers `nothing` so the caller can fail closed.
 """
 function ffi_julia_symbol(rust_type::AbstractString)
     entry = ffi_lookup(rust_type)
-    return entry === nothing ? nothing : entry.julia_symbol
+    return entry === nothing ? nothing : entry.julia_expr
+end
+
+"""
+    ffi_julia_type(rust_type::AbstractString) -> Union{Type, Nothing}
+
+The `Type` that [`ffi_julia_symbol`](@ref)'s expression names — the surface type
+as a value, for callers that want to compare types without `eval`. `nothing`
+when the type is unknown.
+
+```julia
+RustCall.ffi_julia_type("*const *mut i32") === Ptr{Ptr{Int32}}
+```
+"""
+ffi_julia_type(rust_type::AbstractString) = ffi_surface_type(rust_type)
+
+"""
+    ffi_type_expr(T::Type) -> Union{Symbol, Expr}
+
+Render a Julia type as an AST fragment that names it: `:Int32`, `:Cvoid`,
+`:(Ptr{Ptr{Int32}})`. Parametric `Ptr`s are rendered recursively so the result
+is always valid Julia, never a `Symbol` of a printed type.
+
+`Cvoid` is spelled `:Cvoid` rather than `:Nothing`, matching what the existing
+generators emit.
+"""
+function ffi_type_expr(T::Type)
+    T === Cvoid && return :Cvoid
+    if T <: Ptr && T !== Ptr && isconcretetype(T)
+        return Expr(:curly, :Ptr, ffi_type_expr(eltype(T)))
+    end
+    # `nameof`, not `Symbol(T)`: the latter renders a module-qualified string for
+    # types outside `Base`, which is not a `Symbol` any generated code can use.
+    return T isa DataType ? nameof(T) : Symbol(T)
 end
 
 """

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -51,9 +51,15 @@ The C ABI forms a Rust value can take when it crosses the boundary.
 | `:void`          | none                                 | the Rust unit type `()` |
 | `:by_value`      | one, the scalar itself               | primitives, `#[repr(C)]` aggregates |
 | `:pointer`       | one, `Ptr{T}`                        | raw pointers, opaque handles |
-| `:ptr_len`       | two, `Ptr{UInt8}` + `Csize_t`        | `&str` and `&[T]` slices |
-| `:ptr_len_cap`   | three, `Ptr{UInt8}` + 2 × `Csize_t`  | an owned Rust `String` / `Vec<T>` buffer |
+| `:ptr_len`       | `Ptr{UInt8}` + `Csize_t`             | `&str` and `&[T]` slices |
+| `:ptr_len_cap`   | `Ptr{UInt8}` + 2 × `Csize_t`         | an owned Rust `String` / `Vec<T>` buffer |
 | `:unknown`       | undefined                            | the type is not in the contract |
+
+The two multi-word kinds reach a `ccall` differently depending on direction:
+as **separate argument slots** in argument position, and as **one `#[repr(C)]`
+aggregate** (`CRustStr` / `CRustString`) in return position, since a `ccall` has
+exactly one return type. [`FFIContract`](@ref) records both — `ccall_types` for
+the calling convention, `layout` for the word list.
 
 `:unknown` exists so that callers can *fail closed* (issue #276 acceptance
 criterion 2) rather than fall back to a guess the way
@@ -124,14 +130,31 @@ for the manifest `abi` column.
 - `rust_type::String` — the Rust spelling this was resolved from.
 - `direction::Symbol` — `:argument` or `:return`.
 - `abi::Symbol` — the resolved [`FFI_ABI_KINDS`] entry.
-- `ccall_types::Vector{Type}` — the C slots, in order. Empty for a `:void`
-  return; one entry for `:by_value` / `:pointer`; two for `:ptr_len`; three for
-  `:ptr_len_cap`.
+- `ccall_types::Vector{Type}` — **what this position contributes to a `ccall`
+  signature**, which is direction-dependent for the multi-word ABIs:
+  * `:void` return — empty;
+  * `:by_value` / `:pointer` — one entry;
+  * `:ptr_len` / `:ptr_len_cap` as an *argument* — the two or three separate
+    argument slots the wrapper takes;
+  * `:ptr_len` / `:ptr_len_cap` as a *return* — exactly one entry, the
+    `#[repr(C)]` aggregate the wrapper returns, because a `ccall` has one
+    return type. See `aggregate_type`.
+- `aggregate_type::Union{Nothing,Type}` — the single `#[repr(C)]` struct the C
+  value *is*, when this position passes an aggregate. Set for `:ptr_len` /
+  `:ptr_len_cap` in return position (`CRustStr` / `CRustString`, matching
+  `<fn>_RustCallBorrowedString` / `<fn>_RustCallOwnedString` emitted by
+  `deps/rustcall_core/src/codegen.rs:837-863`), `nothing` otherwise — arguments
+  are expanded into separate slots, not passed as an aggregate.
+- `layout::Vector{Type}` — the C field layout of the value, in order, for the
+  multi-word ABIs (`[Ptr{UInt8}, Csize_t]` / `[Ptr{UInt8}, Csize_t, Csize_t]`).
+  Direction-independent: it describes the value, not the calling convention.
+  Empty for the single-word ABIs.
 - `surface_type::Type` — the Julia type the user sees at this position.
 - `ownership::Symbol` — one of [`FFI_OWNERSHIP_KINDS`].
 - `free_symbol::Union{Nothing,String}` — for `:owned_by_rust`, the name of the
-  symbol that releases the value, or `nothing` when the contract cannot name it
-  yet (it is per-function: `<fn>_free_rust_string`, see #242/#246).
+  symbol that releases the value. The name is per-owner
+  (`<fn|Struct>_free_rust_string`, `deps/rustcall_core/src/codegen.rs:633`), so
+  it is filled in only when the caller passes `owner`; `nothing` otherwise.
 - `known::Bool` — `false` when the Rust spelling is not in the contract. A
   caller that must fail closed checks this instead of inspecting the fallback.
 """
@@ -140,6 +163,8 @@ struct FFIContract
     direction::Symbol
     abi::Symbol
     ccall_types::Vector{Type}
+    aggregate_type::Union{Nothing, Type}
+    layout::Vector{Type}
     surface_type::Type
     ownership::Symbol
     free_symbol::Union{Nothing, String}
@@ -264,23 +289,62 @@ _ffi_register!(FFIType(
 const _FFI_PTR_CONST_PREFIX = "*const "
 const _FFI_PTR_MUT_PREFIX = "*mut "
 
+# The only path prefixes under which a trailing primitive segment is guaranteed
+# to *be* that primitive. `rustcall_core::types::is_ffi_compatible_type`
+# (`deps/rustcall_core/src/types.rs:85`) is laxer: it matches on `last_ident`
+# alone, so it also accepts `mycrate::i32`, where `i32` may be a user type
+# alias with a completely different layout. The contract deliberately does not
+# follow it that far — an unqualified last segment is not evidence — so
+# `mycrate::i32` stays unknown and fails closed. That gap is a recorded
+# divergence in `test/test_ffi_contract.jl`, and closing it needs the extractor
+# to resolve the path (#270), not a wider guess here.
+const FFI_PRIMITIVE_PATH_PREFIXES = ("core::primitive::", "std::primitive::")
+
+"""
+    ffi_normalize_spelling(rust_type::AbstractString) -> String
+
+The table key for a Rust type spelling: whitespace trimmed, and a
+`core::primitive::` / `std::primitive::` qualifier stripped so that
+`core::primitive::i32` resolves like `i32`.
+
+Only those two prefixes are stripped; see [`FFI_PRIMITIVE_PATH_PREFIXES`] for
+why an arbitrary `mycrate::i32` is not normalized even though
+`rustcall_core` accepts it.
+"""
+function ffi_normalize_spelling(rust_type::AbstractString)
+    key = String(strip(rust_type))
+    for prefix in FFI_PRIMITIVE_PATH_PREFIXES
+        if startswith(key, prefix)
+            tail = key[(length(prefix) + 1):end]
+            # Only a bare final segment: `core::primitive::i32`, never
+            # `core::primitive::foo::bar`.
+            occursin("::", tail) && return key
+            return tail
+        end
+    end
+    return key
+end
+
 """
     ffi_lookup(rust_type::AbstractString) -> Union{FFIType, Nothing}
 
 The contract row for a Rust type spelling, or `nothing` when the contract does
-not cover it. Leading and trailing whitespace is ignored.
+not cover it. The spelling is normalized with [`ffi_normalize_spelling`](@ref)
+first, so `core::primitive::u8` resolves like `u8`.
 
 Raw pointer spellings (`*const T`, `*mut T`) are synthesised on demand: they map
-to `Ptr{J}` where `J` is the pointee's Julia type, and to `Ptr{Cvoid}` when the
-pointee is not itself in the contract (an opaque handle). This mirrors
-`rustcall_core`'s `Type::Ptr => true` (`deps/rustcall_core/src/types.rs:91`),
-which accepts every pointer wholesale.
+to `Ptr{J}` where `J` is the pointee's Julia type. The pointee is resolved
+*recursively* through `ffi_lookup`, so `*const *mut i32` is `Ptr{Ptr{Int32}}`;
+only a pointee the contract genuinely cannot map (an opaque handle, or a
+multi-word type like `String` that has no single-word C form) degrades to
+`Ptr{Cvoid}`. This mirrors `rustcall_core`'s `Type::Ptr => true`
+(`deps/rustcall_core/src/types.rs:91`), which accepts every pointer wholesale.
 
 `nothing` is the fail-closed answer. Callers must not substitute a default for
 it; that is the guess this file exists to remove (#245 item 1).
 """
 function ffi_lookup(rust_type::AbstractString)
-    key = strip(rust_type)
+    key = ffi_normalize_spelling(rust_type)
     entry = get(FFI_TYPE_TABLE, key, nothing)
     entry === nothing || return entry
     return _ffi_pointer_row(key)
@@ -296,8 +360,9 @@ function _ffi_pointer_row(key::AbstractString)
 end
 
 function _ffi_pointer_row(key::AbstractString, pointee::AbstractString)
-    inner = get(FFI_TYPE_TABLE, pointee, nothing)
-    T = if inner === nothing || inner.abi != :by_value
+    # Recursive: the pointee may itself be a pointer spelling.
+    inner = ffi_lookup(pointee)
+    T = if inner === nothing || !(inner.abi === :by_value || inner.abi === :pointer)
         Ptr{Cvoid}
     else
         Ptr{inner.ccall_type}
@@ -405,9 +470,13 @@ end
 """
     ffi_slots(abi::Symbol) -> Vector{Type}
 
-The C slots an ABI kind occupies, for the pointer-carrying kinds. Scalar and
-pointer kinds depend on the concrete type and are filled in by
+The C field layout of a multi-word ABI kind, in order. Direction-independent:
+it describes the value, not the calling convention. For how those words reach a
+`ccall` — separate argument slots, or one aggregate return type — see
 [`ffi_argument_contract`](@ref) / [`ffi_return_contract`](@ref).
+
+Scalar and pointer kinds depend on the concrete type and have no fixed layout
+here.
 """
 function ffi_slots(abi::Symbol)
     if abi === :ptr_len
@@ -421,9 +490,38 @@ function ffi_slots(abi::Symbol)
 end
 
 """
+    ffi_aggregate_type(abi::Symbol) -> Union{Type, Nothing}
+
+The `#[repr(C)]` struct a multi-word ABI kind is returned as: `CRustStr` for
+`:ptr_len`, `CRustString` for `:ptr_len_cap`, `nothing` for every single-word
+kind.
+
+These mirror the `<fn>_RustCallBorrowedString { ptr, len }` and
+`<fn>_RustCallOwnedString { ptr, len, cap }` helpers the wrapper generator emits
+(`deps/rustcall_core/src/codegen.rs:837-863`) and that `_call_rust_owned_string`
+/ `_call_rust_borrowed_string` already receive (`src/structs.jl:511-528`).
+"""
+function ffi_aggregate_type(abi::Symbol)
+    abi === :ptr_len && return CRustStr
+    abi === :ptr_len_cap && return CRustString
+    return nothing
+end
+
+"""
+    ffi_free_symbol(owner::AbstractString) -> String
+
+The name of the symbol that releases an `:owned_by_rust` string produced by
+`owner` (a function or struct name): `<owner>_free_rust_string`, matching
+`deps/rustcall_core/src/codegen.rs:633`.
+"""
+ffi_free_symbol(owner::AbstractString) = string(owner, "_free_rust_string")
+
+"""
     ffi_argument_contract(rust_type; abi = "") -> FFIContract
 
-The contract for one argument position.
+The contract for one argument position. Multi-word values are **expanded into
+separate argument slots** here, because that is how the generated wrapper takes
+them.
 
 `abi` is the manifest `Arg.abi` column (PR #274); when non-empty it overrides
 the ABI derived from the Rust spelling, which is what makes the manifest
@@ -433,57 +531,76 @@ raise rather than substitute a default.
 
 ```julia
 c = RustCall.ffi_argument_contract("&str")
-c.ccall_types   # Type[Ptr{UInt8}, Csize_t]
-c.ownership     # :owned_by_julia  (Julia's buffer, rooted for the call)
+c.ccall_types     # Type[Ptr{UInt8}, Csize_t]  — two argument slots
+c.aggregate_type  # nothing
+c.ownership       # :owned_by_julia  (Julia's buffer, rooted for the call)
 ```
 """
 function ffi_argument_contract(rust_type::AbstractString; abi::AbstractString = "")
-    return _ffi_contract(rust_type, :argument, abi)
+    return _ffi_contract(rust_type, :argument, abi, nothing)
 end
 
 """
-    ffi_return_contract(rust_type; abi = "") -> FFIContract
+    ffi_return_contract(rust_type; abi = "", owner = nothing) -> FFIContract
 
 The contract for the return position. `abi` is the manifest `Method.return_abi`
 column (PR #274). See [`ffi_argument_contract`](@ref).
 
+A `ccall` has exactly one return type, so a multi-word value is **not** expanded
+here: `ccall_types` holds the single `#[repr(C)]` aggregate the wrapper returns
+(also available as `aggregate_type`), and `layout` holds its fields.
+
+`owner` is the function or struct name the wrapper belongs to; when given, an
+`:owned_by_rust` return also carries its [`ffi_free_symbol`](@ref).
+
 ```julia
-c = RustCall.ffi_return_contract("String")
-c.abi           # :ptr_len_cap
-c.ownership     # :owned_by_rust — Julia must free it through the owning library (#246)
+c = RustCall.ffi_return_contract("String"; owner = "shout")
+c.abi             # :ptr_len_cap
+c.ccall_types     # Type[CRustString]  — one return type
+c.layout          # Type[Ptr{UInt8}, Csize_t, Csize_t]
+c.ownership       # :owned_by_rust — Julia must free it through the owning library (#246)
+c.free_symbol     # "shout_free_rust_string"
 ```
 """
-function ffi_return_contract(rust_type::AbstractString; abi::AbstractString = "")
-    return _ffi_contract(rust_type, :return, abi)
+function ffi_return_contract(rust_type::AbstractString; abi::AbstractString = "",
+                             owner::Union{Nothing, AbstractString} = nothing)
+    return _ffi_contract(rust_type, :return, abi, owner)
 end
 
-function _ffi_contract(rust_type::AbstractString, direction::Symbol, abi::AbstractString)
+"""
+    ffi_return_ccall_type(rust_type; abi = "") -> Union{Type, Nothing}
+
+The single Julia type to put in the return slot of a `ccall` for this Rust type,
+or `nothing` when the contract does not cover it (`Cvoid` for `()`).
+"""
+function ffi_return_ccall_type(rust_type::AbstractString; abi::AbstractString = "")
+    c = ffi_return_contract(rust_type; abi = abi)
+    c.known || return nothing
+    c.abi === :void && return Cvoid
+    return only(c.ccall_types)
+end
+
+function _ffi_contract(rust_type::AbstractString, direction::Symbol, abi::AbstractString,
+                       owner::Union{Nothing, AbstractString})
     _ffi_check_direction(direction)
-    key = String(strip(rust_type))
+    key = ffi_normalize_spelling(rust_type)
     override = ffi_manifest_abi_kind(abi, direction)
     entry = ffi_lookup(key)
 
     if entry === nothing
         override === nothing && return FFIContract(
-            key, direction, :unknown, copy(_FFI_UNKNOWN_SLOTS), Any, :unknown, nothing, false,
+            key, direction, :unknown, copy(_FFI_UNKNOWN_SLOTS), nothing,
+            copy(_FFI_UNKNOWN_SLOTS), Any, :unknown, nothing, false,
         )
         # The manifest named the ABI even though the spelling is unknown to the
         # table: the manifest wins, which is the whole point of #270.
-        return FFIContract(
-            key, direction, override, ffi_slots(override),
-            direction === :argument ? String : (override === :ptr_len_cap ? RustString : RustStr),
-            _ffi_ownership_for(override, direction), nothing, true,
-        )
+        ownership = _ffi_ownership_for(override, direction)
+        surface = direction === :argument ? String :
+            (override === :ptr_len_cap ? RustString : RustStr)
+        return _ffi_positional(key, direction, override, surface, ownership, owner)
     end
 
     kind = override === nothing ? _ffi_directional_abi(entry, direction) : override
-    slots = if kind === :void
-        Type[]
-    elseif kind === :by_value || kind === :pointer
-        Type[entry.ccall_type]
-    else
-        ffi_slots(kind)
-    end
     ownership = if entry.abi === :by_value || entry.abi === :void || entry.abi === :pointer
         # Scalars own nothing; for a raw pointer the contract cannot know who
         # owns the pointee, so it stays `:borrowed` and the caller must say.
@@ -493,7 +610,28 @@ function _ffi_contract(rust_type::AbstractString, direction::Symbol, abi::Abstra
     end
     surface = direction === :argument && (kind === :ptr_len || kind === :ptr_len_cap) ?
         String : entry.surface_type
-    return FFIContract(key, direction, kind, slots, surface, ownership, nothing, true)
+    return _ffi_positional(key, direction, kind, surface, ownership, owner, entry.ccall_type)
+end
+
+# Turn an ABI kind into the ccall slots / aggregate / layout for one position.
+function _ffi_positional(key, direction, kind, surface, ownership, owner,
+                         scalar_type::Union{Nothing, Type} = nothing)
+    layout = kind === :ptr_len || kind === :ptr_len_cap ? ffi_slots(kind) : Type[]
+    aggregate = direction === :return ? ffi_aggregate_type(kind) : nothing
+    slots = if kind === :void
+        Type[]
+    elseif kind === :by_value || kind === :pointer
+        Type[scalar_type === nothing ? Ptr{Cvoid} : scalar_type]
+    elseif aggregate !== nothing
+        # One return type, not N words: `ccall` has a single return slot.
+        Type[aggregate]
+    else
+        copy(layout)
+    end
+    free_symbol = ownership === :owned_by_rust && owner !== nothing ?
+        ffi_free_symbol(owner) : nothing
+    return FFIContract(key, direction, kind, slots, aggregate, layout, surface,
+                       ownership, free_symbol, true)
 end
 
 # `String` and `&str` are `(ptr, len)` in argument position regardless of which
@@ -520,7 +658,7 @@ A one-line human-readable rendering of a contract, for error messages and for
 the documentation of the supported-type matrix (#245 item 4).
 """
 function ffi_describe(rust_type::AbstractString; direction::Symbol = :return, abi::AbstractString = "")
-    c = _ffi_contract(rust_type, direction, abi)
+    c = _ffi_contract(rust_type, direction, abi, nothing)
     c.known || return "$(c.rust_type): not in the FFI contract"
     slots = isempty(c.ccall_types) ? "no slots" : join(string.(c.ccall_types), ", ")
     return "$(c.rust_type) [$(c.direction)]: abi=$(c.abi), slots=($slots), surface=$(c.surface_type), ownership=$(c.ownership)"

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -254,31 +254,51 @@ for (rust, T, sym) in (
 end
 
 # -- Strings -----------------------------------------------------------------
-# The ABI is direction-dependent, which is exactly what the flat tables cannot
-# express and why #246 exists:
+# **The spelling does not determine the ABI. Only the manifest does.**
 #
-#   * as an argument, both `String` and `&str` arrive as `(ptr, len)` bytes —
-#     Julia owns the buffer and must keep it rooted for the call; the Rust
-#     wrapper copies (`String`) or borrows (`&str`).
-#   * as a return, `String` is an owned `(ptr, len, cap)` buffer that Julia must
-#     hand back to the library that allocated it, and `&str` is a borrowed
+# On `main`, string lowering is not uniform across wrapper flavours:
+#
+#   * `transform_simple_function` (`deps/rustcall_core/src/codegen.rs:53-58`)
+#     only marks a free `#[julia] fn ... -> String` signature `extern "C"` — the
+#     Rust types are forwarded as written, with no `(ptr, len)` pair and no
+#     `CRustString`;
+#   * `generate_method_wrapper_crate` (`:378`, `:414`, `:443`) likewise forwards
+#     the original argument and return types;
+#   * only `inline_method_wrapper` (`:774-863`) actually lowers strings, into
+#     `(ptr, len)` arguments and a `<fn>_RustCallOwnedString` /
+#     `<fn>_RustCallBorrowedString` return.
+#
+# PR #274 makes the lowering uniform *and* records it in the manifest as
+# `Arg.abi` / `Method.return_abi`. So the rule that is correct both before and
+# after #274 is: **the manifest `abi` column is the only authority on whether
+# lowering happened.** These rows therefore carry `:unknown` — a bare `String`
+# spelling with `abi == ""` fails closed rather than describing a lowering the
+# wrapper may not have performed. `abi = "string"` / `"str"` selects the lowered
+# form, and only then does the contract name the slots, the aggregate and the
+# ownership:
+#
+#   * as an argument, both arrive as `(ptr, len)` bytes — Julia owns the buffer
+#     and must keep it rooted for the call; the wrapper copies (`String`) or
+#     borrows (`&str`);
+#   * as a return, `"string"` is an owned `(ptr, len, cap)` buffer that Julia
+#     must hand back to the library that allocated it, and `"str"` is a borrowed
 #     `(ptr, len)` view.
 #
-# The rows below carry the *return* ABI; [`ffi_argument_contract`](@ref)
-# rewrites them for the argument direction.
+# The `surface_type` / `julia_symbol` columns stay meaningful regardless: they
+# describe the Julia-visible type, not the calling convention.
 _ffi_register!(FFIType(
-    "String", Ptr{UInt8}, RustString, :RustString, :ptr_len_cap, :owned_by_rust,
-    "Owned Rust buffer: (ptr, len, cap). Never a Cstring — see #246.",
+    "String", Ptr{UInt8}, RustString, :RustString, :unknown, :unknown,
+    "Owned Rust buffer, never a Cstring (#246) — but only the manifest abi column says whether the wrapper lowered it.",
 ))
 _ffi_register!(FFIType(
-    "&str", Ptr{UInt8}, RustStr, :RustStr, :ptr_len, :borrowed,
-    "Fat pointer (ptr, len) borrowed from the callee; copy before the borrow ends.",
+    "&str", Ptr{UInt8}, RustStr, :RustStr, :unknown, :unknown,
+    "Fat pointer (ptr, len) when lowered; the manifest abi column says whether it was.",
 ))
 # Bare `str` is unsized and cannot cross the boundary by value; the existing
 # `RUST_TO_JULIA_TYPE_MAP` maps it to `Cstring`, which is recorded here so the
-# divergence tests can see it, but the contract treats it as a borrowed view.
+# divergence tests can see it.
 _ffi_register!(FFIType(
-    "str", Ptr{UInt8}, RustStr, :RustStr, :ptr_len, :borrowed,
+    "str", Ptr{UInt8}, RustStr, :RustStr, :unknown, :unknown,
     "Unsized; only ever reachable behind a reference. RUST_TO_JULIA_TYPE_MAP says Cstring.",
 ))
 
@@ -368,26 +388,44 @@ function _ffi_pointer_row(key::AbstractString, pointee::AbstractString)
         Ptr{inner.ccall_type}
     end
     note = inner === nothing ? "Opaque pointee: the contract does not know $(pointee)." : ""
-    return FFIType(String(key), T, T, Symbol(T), :pointer, :borrowed, note)
+    # Ownership of a raw pointer is NOT derivable from the spelling. A generated
+    # constructor returns `Box::into_raw` (`deps/rustcall_core/src/codegen.rs:386-392`),
+    # which Julia owns and must free, while another `*mut T` may be a pointer
+    # into memory Rust keeps. `:borrowed` — valid only for the duration of the
+    # call — is reserved for `&T` / `&mut T` references, which `rustcall_core`
+    # rejects as non-FFI anyway (`types.rs:104`). So the default is `:unknown`,
+    # and a consumer that has the metadata states it: see
+    # [`ffi_return_contract`](@ref)'s `ownership` / `free_symbol` keywords.
+    return FFIType(String(key), T, T, Symbol(T), :pointer, :unknown, note)
 end
 
 """
     ffi_known(rust_type::AbstractString) -> Bool
 
-Whether the contract covers this Rust type spelling.
+Whether the contract has a row for this Rust type spelling.
+
+Note that a row is not by itself enough to build a call: the string rows carry
+`abi === :unknown` because the spelling does not say whether the wrapper lowered
+them (see the Strings section above). Use
+[`ffi_argument_contract`](@ref) / [`ffi_return_contract`](@ref), whose `known`
+field answers the question a call site actually asks — "can I build this
+position?" — and is `false` for a string spelling without a manifest `abi`.
 """
 ffi_known(rust_type::AbstractString) = ffi_lookup(rust_type) !== nothing
 
 """
     ffi_ccall_type(rust_type::AbstractString) -> Union{Type, Nothing}
 
-The Julia type of the leading C slot, or `nothing` when the type is unknown.
-For multi-slot ABIs use [`ffi_argument_contract`](@ref) /
-[`ffi_return_contract`](@ref), whose `ccall_types` lists every slot.
+The Julia type of the single C slot this Rust type occupies, or `nothing` when
+the contract cannot say — either because the type is unknown, or because the
+spelling alone does not determine its ABI (the string rows). For multi-word
+ABIs use [`ffi_argument_contract`](@ref) / [`ffi_return_contract`](@ref).
 """
 function ffi_ccall_type(rust_type::AbstractString)
     entry = ffi_lookup(rust_type)
-    return entry === nothing ? nothing : entry.ccall_type
+    entry === nothing && return nothing
+    entry.abi === :unknown && return nothing
+    return entry.ccall_type
 end
 
 """
@@ -525,23 +563,28 @@ them.
 
 `abi` is the manifest `Arg.abi` column (PR #274); when non-empty it overrides
 the ABI derived from the Rust spelling, which is what makes the manifest
-normative (#270). When the Rust type is unknown the returned contract has
-`known = false`, empty `ccall_types` and `:unknown` ownership — callers must
-raise rather than substitute a default.
+normative (#270). It is also the *only* thing that selects the lowered string
+form: `ffi_argument_contract("String")` is unknown, `abi = "string"` makes it
+`:ptr_len`.
+
+When the position cannot be described the returned contract has `known = false`,
+empty `ccall_types` and `:unknown` ownership — callers must raise rather than
+substitute a default.
 
 ```julia
-c = RustCall.ffi_argument_contract("&str")
+c = RustCall.ffi_argument_contract("&str"; abi = "str")
 c.ccall_types     # Type[Ptr{UInt8}, Csize_t]  — two argument slots
 c.aggregate_type  # nothing
 c.ownership       # :owned_by_julia  (Julia's buffer, rooted for the call)
 ```
 """
 function ffi_argument_contract(rust_type::AbstractString; abi::AbstractString = "")
-    return _ffi_contract(rust_type, :argument, abi, nothing)
+    return _ffi_contract(rust_type, :argument, abi, nothing, nothing, nothing)
 end
 
 """
-    ffi_return_contract(rust_type; abi = "", owner = nothing) -> FFIContract
+    ffi_return_contract(rust_type; abi = "", owner = nothing,
+                        ownership = nothing, free_symbol = nothing) -> FFIContract
 
 The contract for the return position. `abi` is the manifest `Method.return_abi`
 column (PR #274). See [`ffi_argument_contract`](@ref).
@@ -550,11 +593,33 @@ A `ccall` has exactly one return type, so a multi-word value is **not** expanded
 here: `ccall_types` holds the single `#[repr(C)]` aggregate the wrapper returns
 (also available as `aggregate_type`), and `layout` holds its fields.
 
-`owner` is the function or struct name the wrapper belongs to; when given, an
-`:owned_by_rust` return also carries its [`ffi_free_symbol`](@ref).
+# Stating ownership the spelling cannot express
+
+A raw-pointer return defaults to `:unknown` ownership, because the spelling does
+not say: a generated constructor returns `Box::into_raw`
+(`deps/rustcall_core/src/codegen.rs:386-392`), which Julia owns and must free,
+while another `*mut T` may point into memory Rust keeps. A consumer that *has*
+the metadata states it with `ownership` (and, where a release is required, the
+`free_symbol` that performs it):
 
 ```julia
-c = RustCall.ffi_return_contract("String"; owner = "shout")
+c = RustCall.ffi_return_contract("*mut Point";
+                                 ownership = :transferred_to_julia,
+                                 free_symbol = "Point_free")
+c.ownership    # :transferred_to_julia
+c.free_symbol  # "Point_free"
+```
+
+Declaring `:owned_by_rust` or `:transferred_to_julia` without naming a
+`free_symbol` (directly, or via `owner` for the string convention) is an
+`ArgumentError`: an owned value with no way to release it is the shape of #246
+and #249, and the contract refuses to record it.
+
+`owner` is the function or struct name the wrapper belongs to; when given, an
+`:owned_by_rust` string return carries its [`ffi_free_symbol`](@ref).
+
+```julia
+c = RustCall.ffi_return_contract("String"; abi = "string", owner = "shout")
 c.abi             # :ptr_len_cap
 c.ccall_types     # Type[CRustString]  — one return type
 c.layout          # Type[Ptr{UInt8}, Csize_t, Csize_t]
@@ -563,15 +628,17 @@ c.free_symbol     # "shout_free_rust_string"
 ```
 """
 function ffi_return_contract(rust_type::AbstractString; abi::AbstractString = "",
-                             owner::Union{Nothing, AbstractString} = nothing)
-    return _ffi_contract(rust_type, :return, abi, owner)
+                             owner::Union{Nothing, AbstractString} = nothing,
+                             ownership::Union{Nothing, Symbol} = nothing,
+                             free_symbol::Union{Nothing, AbstractString} = nothing)
+    return _ffi_contract(rust_type, :return, abi, owner, ownership, free_symbol)
 end
 
 """
     ffi_return_ccall_type(rust_type; abi = "") -> Union{Type, Nothing}
 
 The single Julia type to put in the return slot of a `ccall` for this Rust type,
-or `nothing` when the contract does not cover it (`Cvoid` for `()`).
+or `nothing` when the contract cannot describe the position (`Cvoid` for `()`).
 """
 function ffi_return_ccall_type(rust_type::AbstractString; abi::AbstractString = "")
     c = ffi_return_contract(rust_type; abi = abi)
@@ -581,41 +648,70 @@ function ffi_return_ccall_type(rust_type::AbstractString; abi::AbstractString = 
 end
 
 function _ffi_contract(rust_type::AbstractString, direction::Symbol, abi::AbstractString,
-                       owner::Union{Nothing, AbstractString})
+                       owner::Union{Nothing, AbstractString},
+                       stated_ownership::Union{Nothing, Symbol},
+                       stated_free_symbol::Union{Nothing, AbstractString})
     _ffi_check_direction(direction)
     key = ffi_normalize_spelling(rust_type)
     override = ffi_manifest_abi_kind(abi, direction)
     entry = ffi_lookup(key)
+    stated = _ffi_check_stated_ownership(key, stated_ownership, stated_free_symbol, owner)
 
     if entry === nothing
-        override === nothing && return FFIContract(
-            key, direction, :unknown, copy(_FFI_UNKNOWN_SLOTS), nothing,
-            copy(_FFI_UNKNOWN_SLOTS), Any, :unknown, nothing, false,
-        )
+        override === nothing && return _ffi_unknown_contract(key, direction)
         # The manifest named the ABI even though the spelling is unknown to the
         # table: the manifest wins, which is the whole point of #270.
         ownership = _ffi_ownership_for(override, direction)
         surface = direction === :argument ? String :
             (override === :ptr_len_cap ? RustString : RustStr)
-        return _ffi_positional(key, direction, override, surface, ownership, owner)
+        return _ffi_positional(key, direction, override, surface, ownership, owner,
+                               nothing, stated...)
     end
 
     kind = override === nothing ? _ffi_directional_abi(entry, direction) : override
+    # No manifest column and a spelling whose ABI it does not determine (the
+    # string rows): fail closed instead of describing a lowering the wrapper may
+    # never have performed.
+    kind === :unknown && return _ffi_unknown_contract(key, direction)
+
     ownership = if entry.abi === :by_value || entry.abi === :void || entry.abi === :pointer
         # Scalars own nothing; for a raw pointer the contract cannot know who
-        # owns the pointee, so it stays `:borrowed` and the caller must say.
+        # owns the pointee, so it stays `:unknown` until a consumer states it.
         entry.ownership
     else
         _ffi_ownership_for(kind, direction)
     end
     surface = direction === :argument && (kind === :ptr_len || kind === :ptr_len_cap) ?
         String : entry.surface_type
-    return _ffi_positional(key, direction, kind, surface, ownership, owner, entry.ccall_type)
+    return _ffi_positional(key, direction, kind, surface, ownership, owner,
+                           entry.ccall_type, stated...)
+end
+
+_ffi_unknown_contract(key, direction) = FFIContract(
+    key, direction, :unknown, copy(_FFI_UNKNOWN_SLOTS), nothing,
+    copy(_FFI_UNKNOWN_SLOTS), Any, :unknown, nothing, false,
+)
+
+# An explicitly stated ownership must be a known tag, and one that implies a
+# release must name the symbol that performs it.
+function _ffi_check_stated_ownership(key, ownership, free_symbol, owner)
+    if ownership !== nothing
+        ownership in FFI_OWNERSHIP_KINDS || throw(ArgumentError(
+            "unknown ownership :$ownership for $key; expected one of $(FFI_OWNERSHIP_KINDS)"))
+        if ownership === :owned_by_rust || ownership === :transferred_to_julia
+            free_symbol === nothing && owner === nothing && throw(ArgumentError(
+                "ownership :$ownership for $key requires a free_symbol (or an owner): " *
+                "an owned value with no way to release it cannot be recorded"))
+        end
+    end
+    return (ownership, free_symbol === nothing ? nothing : String(free_symbol))
 end
 
 # Turn an ABI kind into the ccall slots / aggregate / layout for one position.
 function _ffi_positional(key, direction, kind, surface, ownership, owner,
-                         scalar_type::Union{Nothing, Type} = nothing)
+                         scalar_type::Union{Nothing, Type} = nothing,
+                         stated_ownership::Union{Nothing, Symbol} = nothing,
+                         stated_free_symbol::Union{Nothing, String} = nothing)
     layout = kind === :ptr_len || kind === :ptr_len_cap ? ffi_slots(kind) : Type[]
     aggregate = direction === :return ? ffi_aggregate_type(kind) : nothing
     slots = if kind === :void
@@ -628,14 +724,20 @@ function _ffi_positional(key, direction, kind, surface, ownership, owner,
     else
         copy(layout)
     end
-    free_symbol = ownership === :owned_by_rust && owner !== nothing ?
+    # A stated ownership wins over the derived one: the consumer has metadata
+    # the spelling does not carry (a constructor's `Box::into_raw`, say).
+    final_ownership = stated_ownership === nothing ? ownership : stated_ownership
+    derived_free = final_ownership === :owned_by_rust && owner !== nothing ?
         ffi_free_symbol(owner) : nothing
+    free_symbol = stated_free_symbol === nothing ? derived_free : stated_free_symbol
     return FFIContract(key, direction, kind, slots, aggregate, layout, surface,
-                       ownership, free_symbol, true)
+                       final_ownership, free_symbol, true)
 end
 
-# `String` and `&str` are `(ptr, len)` in argument position regardless of which
-# of the two they are: the wrapper copies for `String` and borrows for `&str`.
+# When the manifest says `"string"` for an argument, the wrapper takes the words
+# as `(ptr, len)` — `ffi_manifest_abi_kind` already resolves that. This only
+# handles the (now unreachable for strings) case of a table row whose own ABI is
+# `:ptr_len_cap`, kept so future owned-aggregate rows behave consistently.
 function _ffi_directional_abi(entry::FFIType, direction::Symbol)
     if direction === :argument && entry.abi === :ptr_len_cap
         return :ptr_len
@@ -648,7 +750,11 @@ function _ffi_ownership_for(kind::Symbol, direction::Symbol)
     kind === :by_value && return :none
     direction === :argument && return :owned_by_julia
     kind === :ptr_len_cap && return :owned_by_rust
-    return :borrowed
+    # A lowered `&str` return: a view into memory Rust keeps, valid only for as
+    # long as the callee guarantees. This is the one place `:borrowed` is
+    # derived — a raw pointer never is.
+    kind === :ptr_len && return :borrowed
+    return :unknown
 end
 
 """
@@ -658,7 +764,7 @@ A one-line human-readable rendering of a contract, for error messages and for
 the documentation of the supported-type matrix (#245 item 4).
 """
 function ffi_describe(rust_type::AbstractString; direction::Symbol = :return, abi::AbstractString = "")
-    c = _ffi_contract(rust_type, direction, abi, nothing)
+    c = _ffi_contract(rust_type, direction, abi, nothing, nothing, nothing)
     c.known || return "$(c.rust_type): not in the FFI contract"
     slots = isempty(c.ccall_types) ? "no slots" : join(string.(c.ccall_types), ", ")
     return "$(c.rust_type) [$(c.direction)]: abi=$(c.abi), slots=($slots), surface=$(c.surface_type), ownership=$(c.ownership)"

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -1,0 +1,527 @@
+# The FFI type contract: single source of truth (issue #276, Phase A)
+#
+# RustCall currently decides "what does this Rust type mean at the C boundary?"
+# in five independent places, each with its own table and its own domain:
+#
+#   | table                                                    | knows                          |
+#   | -------------------------------------------------------- | ------------------------------ |
+#   | `is_ffi_compatible_type` / `is_non_ffi_type`             | `PRIMITIVES` + `Type::Ptr`     |
+#   | (`deps/rustcall_core/src/types.rs:85,104`)               |                                |
+#   | `_rust_type_to_julia_conversion_type`                    | 13 primitives                  |
+#   | (`src/julia_functions.jl:193`)                           |                                |
+#   | `_rust_type_to_julia_type_symbol`                        | the same 13 plus `()`          |
+#   | (`src/julia_functions.jl:220`)                           |                                |
+#   | `_RUST_PRIMITIVE_TO_JULIA` (`src/ruststr.jl:519`)        | 13 primitives plus `()`        |
+#   | `rust_to_julia_type_sym` (`src/structs.jl:665`)          | 8 primitives, `String`, `&str` |
+#
+# (`RUST_TO_JULIA_TYPE_MAP` in `src/typetranslation.jl` is a sixth, wider one.)
+#
+# This file is the *one* table those five are meant to collapse into. It also
+# makes explicit two things the manifest leaves implicit today:
+#
+#   * the **C ABI form** of a value — by value, behind a pointer, as a
+#     `(ptr, len)` pair, as a `(ptr, len, cap)` triple, ...
+#   * **ownership** — who is responsible for releasing the memory a C slot
+#     points at, and through which symbol.
+#
+# Phase A is strictly additive: nothing here is wired into a call site yet, and
+# no existing behaviour changes. `test/test_ffi_contract.jl` enumerates, as
+# executable documentation, every point where the five tables disagree with
+# this one. Phase B migrates the call sites; those tests then become the
+# regression tests for #245, #246 and #249.
+#
+# Forward compatibility with the `abi` manifest column (#270, PR #274): the
+# extractor is growing an `Arg.abi` / `Method.return_abi` string column whose
+# values are `""` (as written), `"string"` and `"str"`. Every entry point here
+# accepts that column verbatim as the `abi` keyword and lets it override the
+# ABI derived from the Rust type spelling, so wiring the manifest column in
+# later is a parameter pass, not a rewrite.
+
+# ============================================================================
+# Vocabulary
+# ============================================================================
+
+"""
+    FFI_ABI_KINDS
+
+The C ABI forms a Rust value can take when it crosses the boundary.
+
+| kind             | C slots                              | notes |
+| ---------------- | ------------------------------------ | ----- |
+| `:void`          | none                                 | the Rust unit type `()` |
+| `:by_value`      | one, the scalar itself               | primitives, `#[repr(C)]` aggregates |
+| `:pointer`       | one, `Ptr{T}`                        | raw pointers, opaque handles |
+| `:ptr_len`       | two, `Ptr{UInt8}` + `Csize_t`        | `&str` and `&[T]` slices |
+| `:ptr_len_cap`   | three, `Ptr{UInt8}` + 2 × `Csize_t`  | an owned Rust `String` / `Vec<T>` buffer |
+| `:unknown`       | undefined                            | the type is not in the contract |
+
+`:unknown` exists so that callers can *fail closed* (issue #276 acceptance
+criterion 2) rather than fall back to a guess the way
+`call_rust_function_infer` (`src/codegen.jl:304`) does today.
+"""
+const FFI_ABI_KINDS = (:void, :by_value, :pointer, :ptr_len, :ptr_len_cap, :unknown)
+
+"""
+    FFI_OWNERSHIP_KINDS
+
+Who owns the memory a C slot refers to, and therefore who must release it.
+
+| kind                   | meaning |
+| ---------------------- | ------- |
+| `:none`                | nothing is owned; the value is a scalar passed by value |
+| `:borrowed`            | the pointee belongs to the other side and is only valid for the duration of the call |
+| `:owned_by_julia`      | Julia allocated the buffer; Julia frees it, and must keep it rooted (`GC.@preserve`) across the call |
+| `:owned_by_rust`       | Rust allocated the buffer; Julia must hand it back through `free_symbol` (#246) |
+| `:transferred_to_julia`| ownership moved to Julia, which frees it with its own allocator |
+| `:unknown`             | the contract does not say — callers must fail rather than assume |
+
+`:owned_by_rust` is the tag whose missing `free_symbol` is the root of #246
+(leaked `String` returns) and #249 (the drop symbol picked from the Julia-side
+type tag instead of from the library that allocated the value).
+"""
+const FFI_OWNERSHIP_KINDS =
+    (:none, :borrowed, :owned_by_julia, :owned_by_rust, :transferred_to_julia, :unknown)
+
+"""
+    FFIType
+
+One row of the contract: what a Rust type spelling means at the boundary.
+
+# Fields
+- `rust::String` — the canonical Rust spelling (`"i32"`, `"String"`, `"&str"`, `"()"`).
+- `ccall_type::Type` — the Julia type of the single C slot in the *by value*
+  form. For multi-slot ABIs (`:ptr_len`, `:ptr_len_cap`) this is the type of the
+  leading pointer slot; use [`ffi_argument_contract`](@ref) /
+  [`ffi_return_contract`](@ref) for the full slot list.
+- `surface_type::Type` — the type a Julia caller sees.
+- `julia_symbol::Symbol` — how the surface type is *spelled* in generated code.
+  Kept separate from `surface_type` because Julia aliases erase spellings:
+  `Cvoid === Nothing` and `Csize_t === UInt64`, and the existing generators emit
+  `:Cvoid` / `:Csize_t`.
+- `abi::Symbol` — one of [`FFI_ABI_KINDS`], the ABI when the type appears as a
+  plain by-value argument or return.
+- `ownership::Symbol` — one of [`FFI_OWNERSHIP_KINDS`].
+- `note::String` — why this row is the way it is, when that is not obvious.
+"""
+struct FFIType
+    rust::String
+    ccall_type::Type
+    surface_type::Type
+    julia_symbol::Symbol
+    abi::Symbol
+    ownership::Symbol
+    note::String
+end
+
+"""
+    FFIContract
+
+The contract for one *position* — a single argument, or the return value — of a
+function, i.e. an [`FFIType`](@ref) resolved for a direction and (optionally)
+for the manifest `abi` column.
+
+# Fields
+- `rust_type::String` — the Rust spelling this was resolved from.
+- `direction::Symbol` — `:argument` or `:return`.
+- `abi::Symbol` — the resolved [`FFI_ABI_KINDS`] entry.
+- `ccall_types::Vector{Type}` — the C slots, in order. Empty for a `:void`
+  return; one entry for `:by_value` / `:pointer`; two for `:ptr_len`; three for
+  `:ptr_len_cap`.
+- `surface_type::Type` — the Julia type the user sees at this position.
+- `ownership::Symbol` — one of [`FFI_OWNERSHIP_KINDS`].
+- `free_symbol::Union{Nothing,String}` — for `:owned_by_rust`, the name of the
+  symbol that releases the value, or `nothing` when the contract cannot name it
+  yet (it is per-function: `<fn>_free_rust_string`, see #242/#246).
+- `known::Bool` — `false` when the Rust spelling is not in the contract. A
+  caller that must fail closed checks this instead of inspecting the fallback.
+"""
+struct FFIContract
+    rust_type::String
+    direction::Symbol
+    abi::Symbol
+    ccall_types::Vector{Type}
+    surface_type::Type
+    ownership::Symbol
+    free_symbol::Union{Nothing, String}
+    known::Bool
+end
+
+# ============================================================================
+# The table
+# ============================================================================
+
+_ffi_row(rust, ccall_type, surface_type, julia_symbol, abi, ownership, note = "") =
+    FFIType(rust, ccall_type, surface_type, julia_symbol, abi, ownership, note)
+
+_ffi_scalar(rust, T, sym = Symbol(T)) = _ffi_row(rust, T, T, sym, :by_value, :none)
+
+"""
+    FFI_TYPE_TABLE :: Dict{String, FFIType}
+
+The single source of truth: Rust type spelling → [`FFIType`](@ref).
+
+Built by merging the domains of the five existing tables (see the header of
+this file). Every spelling accepted by *any* of them is present here, so a type
+that one layer accepts can no longer be silently mistranslated by the next
+(#245 item 2). Spellings the contract deliberately refuses are absent, and
+[`ffi_lookup`](@ref) returns `nothing` for them.
+"""
+const FFI_TYPE_TABLE = Dict{String, FFIType}()
+
+function _ffi_register!(entry::FFIType)
+    FFI_TYPE_TABLE[entry.rust] = entry
+    return entry
+end
+
+# -- Rust primitives ---------------------------------------------------------
+# The `PRIMITIVES` list of `deps/rustcall_core/src/types.rs:12` in full. The
+# Julia-side tables stop at 13 of them; `i128`, `u128` and `char` are accepted
+# by the Rust side and map to `:Any` on the Julia side today (#245 item 2).
+for (rust, T) in (
+    ("i8", Int8),
+    ("i16", Int16),
+    ("i32", Int32),
+    ("i64", Int64),
+    ("i128", Int128),
+    ("u8", UInt8),
+    ("u16", UInt16),
+    ("u32", UInt32),
+    ("u64", UInt64),
+    ("u128", UInt128),
+    ("f32", Float32),
+    ("f64", Float64),
+    ("bool", Bool),
+)
+    _ffi_register!(_ffi_scalar(rust, T))
+end
+
+# `usize` / `isize` are spelled with the C aliases because that is what the
+# generated code emits; `Csize_t === UInt64` and `Cssize_t === Int64` on every
+# platform RustCall supports, so this agrees with `RUST_TO_JULIA_TYPE_MAP`'s
+# `UInt` / `Int` as a *type* while differing as a *spelling*.
+_ffi_register!(_ffi_scalar("usize", Csize_t, :Csize_t))
+_ffi_register!(_ffi_scalar("isize", Cssize_t, :Cssize_t))
+
+# Rust `char` is a 4-byte Unicode scalar value. Julia's `Char` is also 4 bytes
+# but stores UTF-8 code units left-aligned, so the bit patterns differ: the C
+# slot must be `UInt32` and the surface value converted, never reinterpreted.
+_ffi_register!(FFIType(
+    "char", UInt32, Char, :Char, :by_value, :none,
+    "Rust char is a code point; Julia Char is left-aligned UTF-8. Convert, do not reinterpret.",
+))
+
+# -- The unit type -----------------------------------------------------------
+_ffi_register!(FFIType("()", Cvoid, Cvoid, :Cvoid, :void, :none, ""))
+
+# -- `std::os::raw` aliases (from `RUST_TO_JULIA_TYPE_MAP`) ------------------
+for (rust, T, sym) in (
+    ("c_char", Cchar, :Cchar),
+    ("c_int", Cint, :Cint),
+    ("c_uint", Cuint, :Cuint),
+    ("c_long", Clong, :Clong),
+    ("c_ulong", Culong, :Culong),
+    ("c_longlong", Clonglong, :Clonglong),
+    ("c_ulonglong", Culonglong, :Culonglong),
+    ("c_float", Cfloat, :Cfloat),
+    ("c_double", Cdouble, :Cdouble),
+)
+    _ffi_register!(_ffi_scalar(rust, T, sym))
+end
+
+# -- Strings -----------------------------------------------------------------
+# The ABI is direction-dependent, which is exactly what the flat tables cannot
+# express and why #246 exists:
+#
+#   * as an argument, both `String` and `&str` arrive as `(ptr, len)` bytes —
+#     Julia owns the buffer and must keep it rooted for the call; the Rust
+#     wrapper copies (`String`) or borrows (`&str`).
+#   * as a return, `String` is an owned `(ptr, len, cap)` buffer that Julia must
+#     hand back to the library that allocated it, and `&str` is a borrowed
+#     `(ptr, len)` view.
+#
+# The rows below carry the *return* ABI; [`ffi_argument_contract`](@ref)
+# rewrites them for the argument direction.
+_ffi_register!(FFIType(
+    "String", Ptr{UInt8}, RustString, :RustString, :ptr_len_cap, :owned_by_rust,
+    "Owned Rust buffer: (ptr, len, cap). Never a Cstring — see #246.",
+))
+_ffi_register!(FFIType(
+    "&str", Ptr{UInt8}, RustStr, :RustStr, :ptr_len, :borrowed,
+    "Fat pointer (ptr, len) borrowed from the callee; copy before the borrow ends.",
+))
+# Bare `str` is unsized and cannot cross the boundary by value; the existing
+# `RUST_TO_JULIA_TYPE_MAP` maps it to `Cstring`, which is recorded here so the
+# divergence tests can see it, but the contract treats it as a borrowed view.
+_ffi_register!(FFIType(
+    "str", Ptr{UInt8}, RustStr, :RustStr, :ptr_len, :borrowed,
+    "Unsized; only ever reachable behind a reference. RUST_TO_JULIA_TYPE_MAP says Cstring.",
+))
+
+# ============================================================================
+# Lookup
+# ============================================================================
+
+const _FFI_PTR_CONST_PREFIX = "*const "
+const _FFI_PTR_MUT_PREFIX = "*mut "
+
+"""
+    ffi_lookup(rust_type::AbstractString) -> Union{FFIType, Nothing}
+
+The contract row for a Rust type spelling, or `nothing` when the contract does
+not cover it. Leading and trailing whitespace is ignored.
+
+Raw pointer spellings (`*const T`, `*mut T`) are synthesised on demand: they map
+to `Ptr{J}` where `J` is the pointee's Julia type, and to `Ptr{Cvoid}` when the
+pointee is not itself in the contract (an opaque handle). This mirrors
+`rustcall_core`'s `Type::Ptr => true` (`deps/rustcall_core/src/types.rs:91`),
+which accepts every pointer wholesale.
+
+`nothing` is the fail-closed answer. Callers must not substitute a default for
+it; that is the guess this file exists to remove (#245 item 1).
+"""
+function ffi_lookup(rust_type::AbstractString)
+    key = strip(rust_type)
+    entry = get(FFI_TYPE_TABLE, key, nothing)
+    entry === nothing || return entry
+    return _ffi_pointer_row(key)
+end
+
+function _ffi_pointer_row(key::AbstractString)
+    if startswith(key, _FFI_PTR_CONST_PREFIX)
+        return _ffi_pointer_row(key, strip(key[(length(_FFI_PTR_CONST_PREFIX) + 1):end]))
+    elseif startswith(key, _FFI_PTR_MUT_PREFIX)
+        return _ffi_pointer_row(key, strip(key[(length(_FFI_PTR_MUT_PREFIX) + 1):end]))
+    end
+    return nothing
+end
+
+function _ffi_pointer_row(key::AbstractString, pointee::AbstractString)
+    inner = get(FFI_TYPE_TABLE, pointee, nothing)
+    T = if inner === nothing || inner.abi != :by_value
+        Ptr{Cvoid}
+    else
+        Ptr{inner.ccall_type}
+    end
+    note = inner === nothing ? "Opaque pointee: the contract does not know $(pointee)." : ""
+    return FFIType(String(key), T, T, Symbol(T), :pointer, :borrowed, note)
+end
+
+"""
+    ffi_known(rust_type::AbstractString) -> Bool
+
+Whether the contract covers this Rust type spelling.
+"""
+ffi_known(rust_type::AbstractString) = ffi_lookup(rust_type) !== nothing
+
+"""
+    ffi_ccall_type(rust_type::AbstractString) -> Union{Type, Nothing}
+
+The Julia type of the leading C slot, or `nothing` when the type is unknown.
+For multi-slot ABIs use [`ffi_argument_contract`](@ref) /
+[`ffi_return_contract`](@ref), whose `ccall_types` lists every slot.
+"""
+function ffi_ccall_type(rust_type::AbstractString)
+    entry = ffi_lookup(rust_type)
+    return entry === nothing ? nothing : entry.ccall_type
+end
+
+"""
+    ffi_surface_type(rust_type::AbstractString) -> Union{Type, Nothing}
+
+The Julia type a caller sees for this Rust type, or `nothing` when unknown.
+"""
+function ffi_surface_type(rust_type::AbstractString)
+    entry = ffi_lookup(rust_type)
+    return entry === nothing ? nothing : entry.surface_type
+end
+
+"""
+    ffi_julia_symbol(rust_type::AbstractString) -> Union{Symbol, Nothing}
+
+How the surface type should be *spelled* in generated code (`:Cvoid`,
+`:Csize_t`, ...), or `nothing` when the type is unknown.
+
+This is the replacement for `_rust_type_to_julia_type_symbol`
+(`src/julia_functions.jl:220`) and `rust_to_julia_type_sym`
+(`src/structs.jl:665`) — except that both of those answer `:Any` for unknown
+types, while this answers `nothing` so the caller can fail closed.
+"""
+function ffi_julia_symbol(rust_type::AbstractString)
+    entry = ffi_lookup(rust_type)
+    return entry === nothing ? nothing : entry.julia_symbol
+end
+
+"""
+    ffi_ownership(rust_type::AbstractString) -> Symbol
+
+The ownership tag of a Rust type in return position, or `:unknown`.
+"""
+function ffi_ownership(rust_type::AbstractString)
+    entry = ffi_lookup(rust_type)
+    return entry === nothing ? :unknown : entry.ownership
+end
+
+# ============================================================================
+# Positional contracts
+# ============================================================================
+
+const _FFI_UNKNOWN_SLOTS = Type[]
+
+"""
+    ffi_manifest_abi_kind(abi::AbstractString) -> Union{Symbol, Nothing}
+
+Translate the manifest `abi` column (`Arg.abi`, `Method.return_abi`; #270 and
+PR #274) into an [`FFI_ABI_KINDS`] entry, given the direction it appears in.
+
+The column is a small closed vocabulary of strings:
+
+| column     | argument     | return          |
+| ---------- | ------------ | --------------- |
+| `""`       | as written   | as written      |
+| `"string"` | `:ptr_len`   | `:ptr_len_cap`  |
+| `"str"`    | `:ptr_len`   | `:ptr_len`      |
+
+`""` means "the Rust type spelling decides", and is returned as `nothing`.
+An unrecognised column value is an error rather than a fallback.
+"""
+function ffi_manifest_abi_kind(abi::AbstractString, direction::Symbol)
+    _ffi_check_direction(direction)
+    column = strip(abi)
+    isempty(column) && return nothing
+    if column == "string"
+        return direction === :return ? :ptr_len_cap : :ptr_len
+    elseif column == "str"
+        return :ptr_len
+    end
+    throw(ArgumentError("unknown manifest abi column \"$column\"; expected \"\", \"string\" or \"str\""))
+end
+
+function _ffi_check_direction(direction::Symbol)
+    direction === :argument || direction === :return ||
+        throw(ArgumentError("direction must be :argument or :return, got :$direction"))
+    return direction
+end
+
+"""
+    ffi_slots(abi::Symbol) -> Vector{Type}
+
+The C slots an ABI kind occupies, for the pointer-carrying kinds. Scalar and
+pointer kinds depend on the concrete type and are filled in by
+[`ffi_argument_contract`](@ref) / [`ffi_return_contract`](@ref).
+"""
+function ffi_slots(abi::Symbol)
+    if abi === :ptr_len
+        return Type[Ptr{UInt8}, Csize_t]
+    elseif abi === :ptr_len_cap
+        return Type[Ptr{UInt8}, Csize_t, Csize_t]
+    elseif abi === :void
+        return Type[]
+    end
+    throw(ArgumentError("ffi_slots is only defined for :void, :ptr_len and :ptr_len_cap, got :$abi"))
+end
+
+"""
+    ffi_argument_contract(rust_type; abi = "") -> FFIContract
+
+The contract for one argument position.
+
+`abi` is the manifest `Arg.abi` column (PR #274); when non-empty it overrides
+the ABI derived from the Rust spelling, which is what makes the manifest
+normative (#270). When the Rust type is unknown the returned contract has
+`known = false`, empty `ccall_types` and `:unknown` ownership — callers must
+raise rather than substitute a default.
+
+```julia
+c = RustCall.ffi_argument_contract("&str")
+c.ccall_types   # Type[Ptr{UInt8}, Csize_t]
+c.ownership     # :owned_by_julia  (Julia's buffer, rooted for the call)
+```
+"""
+function ffi_argument_contract(rust_type::AbstractString; abi::AbstractString = "")
+    return _ffi_contract(rust_type, :argument, abi)
+end
+
+"""
+    ffi_return_contract(rust_type; abi = "") -> FFIContract
+
+The contract for the return position. `abi` is the manifest `Method.return_abi`
+column (PR #274). See [`ffi_argument_contract`](@ref).
+
+```julia
+c = RustCall.ffi_return_contract("String")
+c.abi           # :ptr_len_cap
+c.ownership     # :owned_by_rust — Julia must free it through the owning library (#246)
+```
+"""
+function ffi_return_contract(rust_type::AbstractString; abi::AbstractString = "")
+    return _ffi_contract(rust_type, :return, abi)
+end
+
+function _ffi_contract(rust_type::AbstractString, direction::Symbol, abi::AbstractString)
+    _ffi_check_direction(direction)
+    key = String(strip(rust_type))
+    override = ffi_manifest_abi_kind(abi, direction)
+    entry = ffi_lookup(key)
+
+    if entry === nothing
+        override === nothing && return FFIContract(
+            key, direction, :unknown, copy(_FFI_UNKNOWN_SLOTS), Any, :unknown, nothing, false,
+        )
+        # The manifest named the ABI even though the spelling is unknown to the
+        # table: the manifest wins, which is the whole point of #270.
+        return FFIContract(
+            key, direction, override, ffi_slots(override),
+            direction === :argument ? String : (override === :ptr_len_cap ? RustString : RustStr),
+            _ffi_ownership_for(override, direction), nothing, true,
+        )
+    end
+
+    kind = override === nothing ? _ffi_directional_abi(entry, direction) : override
+    slots = if kind === :void
+        Type[]
+    elseif kind === :by_value || kind === :pointer
+        Type[entry.ccall_type]
+    else
+        ffi_slots(kind)
+    end
+    ownership = if entry.abi === :by_value || entry.abi === :void || entry.abi === :pointer
+        # Scalars own nothing; for a raw pointer the contract cannot know who
+        # owns the pointee, so it stays `:borrowed` and the caller must say.
+        entry.ownership
+    else
+        _ffi_ownership_for(kind, direction)
+    end
+    surface = direction === :argument && (kind === :ptr_len || kind === :ptr_len_cap) ?
+        String : entry.surface_type
+    return FFIContract(key, direction, kind, slots, surface, ownership, nothing, true)
+end
+
+# `String` and `&str` are `(ptr, len)` in argument position regardless of which
+# of the two they are: the wrapper copies for `String` and borrows for `&str`.
+function _ffi_directional_abi(entry::FFIType, direction::Symbol)
+    if direction === :argument && entry.abi === :ptr_len_cap
+        return :ptr_len
+    end
+    return entry.abi
+end
+
+function _ffi_ownership_for(kind::Symbol, direction::Symbol)
+    kind === :void && return :none
+    kind === :by_value && return :none
+    direction === :argument && return :owned_by_julia
+    kind === :ptr_len_cap && return :owned_by_rust
+    return :borrowed
+end
+
+"""
+    ffi_describe(rust_type; direction = :return, abi = "") -> String
+
+A one-line human-readable rendering of a contract, for error messages and for
+the documentation of the supported-type matrix (#245 item 4).
+"""
+function ffi_describe(rust_type::AbstractString; direction::Symbol = :return, abi::AbstractString = "")
+    c = _ffi_contract(rust_type, direction, abi)
+    c.known || return "$(c.rust_type): not in the FFI contract"
+    slots = isempty(c.ccall_types) ? "no slots" : join(string.(c.ccall_types), ", ")
+    return "$(c.rust_type) [$(c.direction)]: abi=$(c.abi), slots=($slots), surface=$(c.surface_type), ownership=$(c.ownership)"
+end

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -124,18 +124,81 @@ const ALL_SPELLINGS = vcat(
         # `Type::Ptr(_) => true`) but degrades the pointee to `Cvoid`.
         @test RustCall.ffi_ccall_type("*mut Point") === Ptr{Cvoid}
         @test RustCall.ffi_return_contract("*mut Point").abi === :pointer
-        @test RustCall.ffi_return_contract("*mut Point").ownership === :borrowed
         @test RustCall.ffi_lookup("*const  u8").ccall_type === Ptr{UInt8}
     end
 
-    @testset "strings: the ABI depends on direction" begin
-        # A `ccall` has exactly one return type, and the generated wrapper
-        # returns one `#[repr(C)]` aggregate
-        # (`<fn>_RustCallOwnedString { ptr, len, cap }`,
-        # deps/rustcall_core/src/codegen.rs:837-863), which the existing Julia
-        # path receives as `CRustString` (src/structs.jl:511-528). So the
-        # return contract carries the aggregate, not the word list.
-        ret = RustCall.ffi_return_contract("String")
+    @testset "raw-pointer ownership is not derivable from the spelling" begin
+        # A generated constructor returns `Box::into_raw`
+        # (deps/rustcall_core/src/codegen.rs:386-392) — Julia owns that
+        # allocation and must free it. Another `*mut T` may point into memory
+        # Rust keeps. Nothing in the spelling separates the two, so the default
+        # is `:unknown`, never `:borrowed` (whose documented lifetime is only
+        # the duration of the call).
+        @test RustCall.ffi_return_contract("*mut Point").ownership === :unknown
+        @test RustCall.ffi_return_contract("*const u8").ownership === :unknown
+        @test RustCall.ffi_argument_contract("*mut Point").ownership === :unknown
+        @test RustCall.ffi_ownership("*mut Point") === :unknown
+
+        # A consumer that has the metadata states it.
+        ctor = RustCall.ffi_return_contract("*mut Point";
+                                            ownership = :transferred_to_julia,
+                                            free_symbol = "Point_free")
+        @test ctor.ownership === :transferred_to_julia
+        @test ctor.free_symbol == "Point_free"
+        @test ctor.abi === :pointer
+        @test ctor.ccall_types == Type[Ptr{Cvoid}]
+        @test ctor.known
+
+        borrowed = RustCall.ffi_return_contract("*const u8"; ownership = :borrowed)
+        @test borrowed.ownership === :borrowed
+        @test borrowed.free_symbol === nothing
+
+        # Validation: an owned value with no way to release it is refused.
+        @test_throws ArgumentError RustCall.ffi_return_contract(
+            "*mut Point"; ownership = :transferred_to_julia)
+        @test_throws ArgumentError RustCall.ffi_return_contract(
+            "*mut Point"; ownership = :owned_by_rust)
+        @test_throws ArgumentError RustCall.ffi_return_contract(
+            "*mut Point"; ownership = :not_a_tag, free_symbol = "Point_free")
+        # `owner` also satisfies it, through the string convention.
+        @test RustCall.ffi_return_contract("*mut Point"; ownership = :owned_by_rust,
+                                           owner = "Point").free_symbol ==
+              "Point_free_rust_string"
+        # Tags that imply no release need no symbol.
+        @test RustCall.ffi_return_contract("*mut Point"; ownership = :none).ownership === :none
+    end
+
+    @testset "strings: only the manifest says whether lowering happened" begin
+        # On `main` the lowering is NOT uniform: `transform_simple_function`
+        # (deps/rustcall_core/src/codegen.rs:53-58) only marks a free
+        # `#[julia] fn ... -> String` signature `extern "C"` and
+        # `generate_method_wrapper_crate` (:378, :414, :443) forwards the
+        # original types; only `inline_method_wrapper` (:774-863) lowers to
+        # `(ptr, len)` / `CRustString`. So a bare spelling must fail closed.
+        for s in ("String", "&str", "str")
+            @test RustCall.ffi_argument_contract(s).known == false
+            @test RustCall.ffi_argument_contract(s).abi === :unknown
+            @test RustCall.ffi_return_contract(s).known == false
+            @test RustCall.ffi_return_contract(s).abi === :unknown
+            @test RustCall.ffi_return_contract(s).ownership === :unknown
+            @test isempty(RustCall.ffi_return_contract(s).ccall_types)
+            @test RustCall.ffi_return_ccall_type(s) === nothing
+            # Not even a single-slot answer, since there is no single slot.
+            @test RustCall.ffi_ccall_type(s) === nothing
+            # The Julia-visible type is still well defined; only the calling
+            # convention is not.
+            @test RustCall.ffi_surface_type(s) !== nothing
+            @test RustCall.ffi_known(s)
+        end
+
+        # With the manifest column, the lowered form appears. A `ccall` has
+        # exactly one return type, and the wrapper returns one `#[repr(C)]`
+        # aggregate (`<fn>_RustCallOwnedString { ptr, len, cap }`,
+        # codegen.rs:837-863), received as `CRustString`
+        # (src/structs.jl:511-528) — so the return contract carries the
+        # aggregate, not the word list.
+        ret = RustCall.ffi_return_contract("String"; abi = "string")
+        @test ret.known
         @test ret.abi === :ptr_len_cap
         @test ret.ccall_types == Type[RustCall.CRustString]
         @test ret.aggregate_type === RustCall.CRustString
@@ -143,12 +206,13 @@ const ALL_SPELLINGS = vcat(
         @test fieldtypes(RustCall.CRustString) == (Ptr{UInt8}, UInt, UInt)
         @test ret.ownership === :owned_by_rust      # Julia must free it (#246)
         @test ret.surface_type === RustCall.RustString
-        @test RustCall.ffi_return_ccall_type("String") === RustCall.CRustString
+        @test RustCall.ffi_return_ccall_type("String"; abi = "string") ===
+              RustCall.CRustString
 
         # Arguments are the other half: the wrapper takes the words as separate
         # parameters, so the argument contract expands them and has no
         # aggregate.
-        arg = RustCall.ffi_argument_contract("String")
+        arg = RustCall.ffi_argument_contract("String"; abi = "string")
         @test arg.abi === :ptr_len
         @test arg.ccall_types == Type[Ptr{UInt8}, Csize_t]
         @test arg.aggregate_type === nothing
@@ -156,25 +220,28 @@ const ALL_SPELLINGS = vcat(
         @test arg.ownership === :owned_by_julia
         @test arg.surface_type === String
 
-        sref = RustCall.ffi_return_contract("&str")
+        sref = RustCall.ffi_return_contract("&str"; abi = "str")
         @test sref.abi === :ptr_len
         @test sref.ccall_types == Type[RustCall.CRustStr]      # one return type
         @test sref.aggregate_type === RustCall.CRustStr
         @test sref.layout == Type[Ptr{UInt8}, Csize_t]
         @test fieldtypes(RustCall.CRustStr) == (Ptr{UInt8}, UInt)
         @test sref.ownership === :borrowed
-        @test RustCall.ffi_return_ccall_type("&str") === RustCall.CRustStr
-        @test RustCall.ffi_argument_contract("&str").ccall_types == Type[Ptr{UInt8}, Csize_t]
-        @test RustCall.ffi_argument_contract("&str").aggregate_type === nothing
+        @test RustCall.ffi_return_ccall_type("&str"; abi = "str") === RustCall.CRustStr
+        @test RustCall.ffi_argument_contract("&str"; abi = "str").ccall_types ==
+              Type[Ptr{UInt8}, Csize_t]
+        @test RustCall.ffi_argument_contract("&str"; abi = "str").aggregate_type === nothing
 
         # The free symbol is per-owner, so it appears only when the caller names
         # the owner (`deps/rustcall_core/src/codegen.rs:633`).
         @test RustCall.ffi_free_symbol("shout") == "shout_free_rust_string"
-        @test RustCall.ffi_return_contract("String"; owner = "shout").free_symbol ==
+        @test RustCall.ffi_return_contract("String"; abi = "string",
+                                           owner = "shout").free_symbol ==
               "shout_free_rust_string"
-        @test RustCall.ffi_return_contract("String").free_symbol === nothing
+        @test RustCall.ffi_return_contract("String"; abi = "string").free_symbol === nothing
         # Only an `:owned_by_rust` value has one.
-        @test RustCall.ffi_return_contract("&str"; owner = "peek").free_symbol === nothing
+        @test RustCall.ffi_return_contract("&str"; abi = "str",
+                                           owner = "peek").free_symbol === nothing
         @test RustCall.ffi_return_contract("i32"; owner = "add").free_symbol === nothing
 
         # Single-word positions carry no aggregate and no layout at all.
@@ -261,11 +328,12 @@ const ALL_SPELLINGS = vcat(
               RustCall.CRustStr
         @test RustCall.ffi_argument_contract("Cow<'a, str>"; abi = "str").ccall_types ==
               Type[Ptr{UInt8}, Csize_t]
-        # And it agrees with the spelling when both are present.
-        @test RustCall.ffi_return_contract("String"; abi = "string").abi ===
-              RustCall.ffi_return_contract("String").abi
-        @test RustCall.ffi_argument_contract("&str"; abi = "str").abi ===
-              RustCall.ffi_argument_contract("&str").abi
+        # And it is the ONLY authority for the string spellings: without it
+        # they are unknown, with it they lower (see the strings testset).
+        @test RustCall.ffi_return_contract("String").abi === :unknown
+        @test RustCall.ffi_return_contract("String"; abi = "string").abi === :ptr_len_cap
+        @test RustCall.ffi_argument_contract("&str").abi === :unknown
+        @test RustCall.ffi_argument_contract("&str"; abi = "str").abi === :ptr_len
     end
 
     @testset "ffi_slots" begin
@@ -393,10 +461,17 @@ const ALL_SPELLINGS = vcat(
         @test RustCall.rusttype_to_julia("String") === RustCall.RustString
         @test RustCall.rusttype_to_julia("str") === Cstring
         @test table_structs("str") === :Any
-        # The contract says what neither of them says: the shape and the owner.
-        @test RustCall.ffi_return_contract("String").abi === :ptr_len_cap
-        @test RustCall.ffi_return_contract("String").ownership === :owned_by_rust
-        @test RustCall.ffi_return_contract("&str").ownership === :borrowed
+        # The contract says what neither of them says: the shape and the owner
+        # — but only once the manifest says the wrapper lowered the string.
+        # `main`'s free-function wrapper does NOT lower it
+        # (`transform_simple_function`, deps/rustcall_core/src/codegen.rs:53-58,
+        # only adds `extern "C"`), so Phase B must not assume the lowering
+        # until #274 lands; the contract fails closed in the meantime.
+        @test RustCall.ffi_return_contract("String").known == false
+        @test RustCall.ffi_return_contract("String"; abi = "string").abi === :ptr_len_cap
+        @test RustCall.ffi_return_contract("String"; abi = "string").ownership ===
+              :owned_by_rust
+        @test RustCall.ffi_return_contract("&str"; abi = "str").ownership === :borrowed
     end
 
     @testset "divergence: raw pointers (#245 item 2)" begin
@@ -450,11 +525,13 @@ const ALL_SPELLINGS = vcat(
         # (#246) and why the drop symbol is chosen from the Julia-side type tag
         # rather than from the allocating library (#249).
         @test table_structs("String") === :RustString   # a type, no owner
-        @test RustCall.ffi_return_contract("String").ownership === :owned_by_rust
-        @test RustCall.ffi_argument_contract("String").ownership === :owned_by_julia
+        @test RustCall.ffi_return_contract("String"; abi = "string").ownership ===
+              :owned_by_rust
+        @test RustCall.ffi_argument_contract("String"; abi = "string").ownership ===
+              :owned_by_julia
         # The free symbol is per-function (`<fn>_free_rust_string`), so the
-        # type-keyed table cannot name it yet; the field exists for Phase B.
-        @test RustCall.ffi_return_contract("String").free_symbol === nothing
+        # type-keyed table cannot name it unless the caller supplies the owner.
+        @test RustCall.ffi_return_contract("String"; abi = "string").free_symbol === nothing
         # Scalars own nothing, which must stay distinguishable from "unknown".
         @test RustCall.ffi_return_contract("i64").ownership === :none
         @test RustCall.ffi_return_contract("Vec<f64>").ownership === :unknown

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -30,21 +30,24 @@ const CORE_NON_FFI = ["String", "Vec", "Box", "Rc", "Arc", "HashMap", "HashSet",
 
 _is_ptr_spelling(s) = startswith(s, "*const ") || startswith(s, "*mut ")
 
-# `is_ffi_compatible_type`: a path type whose last segment is a primitive, the
-# empty tuple, or *any* raw pointer (`Type::Ptr(_) => true`).
+# `last_ident`: the final path segment of a path type, ignoring generic args.
+core_last_ident(s::AbstractString) = String(last(split(first(split(s, '<')), "::")))
+
+# `is_ffi_compatible_type`: a path type whose LAST SEGMENT is a primitive (so
+# `core::primitive::i32` and `mycrate::i32` both qualify), the empty tuple, or
+# *any* raw pointer (`Type::Ptr(_) => true`).
 function core_is_ffi_compatible(s::AbstractString)
     s == "()" && return true
     _is_ptr_spelling(s) && return true
     startswith(s, "&") && return false
-    head = first(split(s, '<'))
-    return head in CORE_PRIMITIVES
+    return core_last_ident(s) in CORE_PRIMITIVES
 end
 
-# `is_non_ffi_type`: the known container list, plus every reference.
+# `is_non_ffi_type`: the known container list (again by last segment), plus
+# every reference.
 function core_is_non_ffi(s::AbstractString)
     startswith(s, "&") && return true
-    head = first(split(s, '<'))
-    return head in CORE_NON_FFI
+    return core_last_ident(s) in CORE_NON_FFI
 end
 
 # Tables 2-5 are Julia functions and can be called directly.
@@ -108,6 +111,8 @@ const ALL_SPELLINGS = vcat(
         @test c.known == false
         @test c.abi === :unknown
         @test isempty(c.ccall_types)
+        @test c.aggregate_type === nothing
+        @test isempty(c.layout)
         @test c.ownership === :unknown
         @test occursin("not in the FFI contract", RustCall.ffi_describe("Vec<f64>"))
     end
@@ -124,23 +129,103 @@ const ALL_SPELLINGS = vcat(
     end
 
     @testset "strings: the ABI depends on direction" begin
+        # A `ccall` has exactly one return type, and the generated wrapper
+        # returns one `#[repr(C)]` aggregate
+        # (`<fn>_RustCallOwnedString { ptr, len, cap }`,
+        # deps/rustcall_core/src/codegen.rs:837-863), which the existing Julia
+        # path receives as `CRustString` (src/structs.jl:511-528). So the
+        # return contract carries the aggregate, not the word list.
         ret = RustCall.ffi_return_contract("String")
         @test ret.abi === :ptr_len_cap
-        @test ret.ccall_types == Type[Ptr{UInt8}, Csize_t, Csize_t]
+        @test ret.ccall_types == Type[RustCall.CRustString]
+        @test ret.aggregate_type === RustCall.CRustString
+        @test ret.layout == Type[Ptr{UInt8}, Csize_t, Csize_t]
+        @test fieldtypes(RustCall.CRustString) == (Ptr{UInt8}, UInt, UInt)
         @test ret.ownership === :owned_by_rust      # Julia must free it (#246)
         @test ret.surface_type === RustCall.RustString
+        @test RustCall.ffi_return_ccall_type("String") === RustCall.CRustString
 
+        # Arguments are the other half: the wrapper takes the words as separate
+        # parameters, so the argument contract expands them and has no
+        # aggregate.
         arg = RustCall.ffi_argument_contract("String")
         @test arg.abi === :ptr_len
         @test arg.ccall_types == Type[Ptr{UInt8}, Csize_t]
+        @test arg.aggregate_type === nothing
+        @test arg.layout == Type[Ptr{UInt8}, Csize_t]
         @test arg.ownership === :owned_by_julia
         @test arg.surface_type === String
 
         sref = RustCall.ffi_return_contract("&str")
         @test sref.abi === :ptr_len
-        @test sref.ccall_types == Type[Ptr{UInt8}, Csize_t]
+        @test sref.ccall_types == Type[RustCall.CRustStr]      # one return type
+        @test sref.aggregate_type === RustCall.CRustStr
+        @test sref.layout == Type[Ptr{UInt8}, Csize_t]
+        @test fieldtypes(RustCall.CRustStr) == (Ptr{UInt8}, UInt)
         @test sref.ownership === :borrowed
+        @test RustCall.ffi_return_ccall_type("&str") === RustCall.CRustStr
         @test RustCall.ffi_argument_contract("&str").ccall_types == Type[Ptr{UInt8}, Csize_t]
+        @test RustCall.ffi_argument_contract("&str").aggregate_type === nothing
+
+        # The free symbol is per-owner, so it appears only when the caller names
+        # the owner (`deps/rustcall_core/src/codegen.rs:633`).
+        @test RustCall.ffi_free_symbol("shout") == "shout_free_rust_string"
+        @test RustCall.ffi_return_contract("String"; owner = "shout").free_symbol ==
+              "shout_free_rust_string"
+        @test RustCall.ffi_return_contract("String").free_symbol === nothing
+        # Only an `:owned_by_rust` value has one.
+        @test RustCall.ffi_return_contract("&str"; owner = "peek").free_symbol === nothing
+        @test RustCall.ffi_return_contract("i32"; owner = "add").free_symbol === nothing
+
+        # Single-word positions carry no aggregate and no layout at all.
+        @test RustCall.ffi_return_contract("i32").aggregate_type === nothing
+        @test isempty(RustCall.ffi_return_contract("i32").layout)
+        @test RustCall.ffi_return_ccall_type("i32") === Int32
+        @test RustCall.ffi_return_ccall_type("()") === Cvoid
+        @test RustCall.ffi_return_ccall_type("Vec<f64>") === nothing
+    end
+
+    @testset "qualified primitive spellings" begin
+        # `type_to_string` keeps the qualified spelling in the manifest and
+        # `is_ffi_compatible_type` accepts it, so the contract must resolve it
+        # or a fail-closed migration would reject a wrapper the extractor
+        # deliberately generated.
+        @test RustCall.ffi_normalize_spelling("core::primitive::i32") == "i32"
+        @test RustCall.ffi_normalize_spelling("std::primitive::u8") == "u8"
+        @test RustCall.ffi_ccall_type("core::primitive::i32") === Int32
+        @test RustCall.ffi_ccall_type("std::primitive::u8") === UInt8
+        @test RustCall.ffi_julia_symbol("core::primitive::usize") === :Csize_t
+        @test RustCall.ffi_return_contract("std::primitive::f64").ccall_types == Type[Float64]
+        @test RustCall.ffi_ccall_type("*mut core::primitive::i32") === Ptr{Int32}
+        @test RustCall.ffi_ccall_type("  core::primitive::bool  ") === Bool
+
+        # Negative: only those two prefixes. `rustcall_core` is laxer — it
+        # matches on the last path segment alone, so it also accepts
+        # `mycrate::i32`, where `i32` may be a user alias with a different
+        # layout. The contract refuses to infer from an unqualified last
+        # segment and fails closed instead; see FFI_PRIMITIVE_PATH_PREFIXES.
+        @test core_is_ffi_compatible("mycrate::i32")     # `rustcall_core` says yes
+        @test RustCall.ffi_normalize_spelling("mycrate::i32") == "mycrate::i32"
+        @test RustCall.ffi_lookup("mycrate::i32") === nothing
+        @test RustCall.ffi_lookup("core::primitive::i32::Foo") === nothing
+        @test RustCall.ffi_normalize_spelling("core::primitive::foo::bar") ==
+              "core::primitive::foo::bar"
+        # A qualified spelling of a non-primitive is still not a primitive.
+        @test RustCall.ffi_lookup("core::primitive::Widget") === nothing
+    end
+
+    @testset "nested raw pointers" begin
+        @test RustCall.ffi_ccall_type("*const *mut i32") === Ptr{Ptr{Int32}}
+        @test RustCall.ffi_ccall_type("*mut *mut u8") === Ptr{Ptr{UInt8}}
+        @test RustCall.ffi_ccall_type("*mut *const *mut f64") === Ptr{Ptr{Ptr{Float64}}}
+        @test RustCall.ffi_surface_type("*const *mut i32") === Ptr{Ptr{Int32}}
+        @test RustCall.ffi_return_contract("*const *mut i32").ccall_types ==
+              Type[Ptr{Ptr{Int32}}]
+        @test RustCall.ffi_return_contract("*const *mut i32").abi === :pointer
+        # An opaque pointee still degrades, at whatever depth it appears.
+        @test RustCall.ffi_ccall_type("*mut *const Widget") === Ptr{Ptr{Cvoid}}
+        # A multi-word pointee has no single-word C form, so it degrades too.
+        @test RustCall.ffi_ccall_type("*const String") === Ptr{Cvoid}
     end
 
     @testset "void and scalar positions" begin
@@ -168,6 +253,12 @@ const ALL_SPELLINGS = vcat(
         @test c.known
         @test c.abi === :ptr_len_cap
         @test c.ownership === :owned_by_rust
+        # …including the aggregate shape of the return.
+        @test c.ccall_types == Type[RustCall.CRustString]
+        @test c.aggregate_type === RustCall.CRustString
+        @test c.layout == Type[Ptr{UInt8}, Csize_t, Csize_t]
+        @test RustCall.ffi_return_contract("MyAlias"; abi = "str").aggregate_type ===
+              RustCall.CRustStr
         @test RustCall.ffi_argument_contract("Cow<'a, str>"; abi = "str").ccall_types ==
               Type[Ptr{UInt8}, Csize_t]
         # And it agrees with the spelling when both are present.
@@ -182,6 +273,19 @@ const ALL_SPELLINGS = vcat(
         @test RustCall.ffi_slots(:ptr_len_cap) == Type[Ptr{UInt8}, Csize_t, Csize_t]
         @test isempty(RustCall.ffi_slots(:void))
         @test_throws ArgumentError RustCall.ffi_slots(:by_value)
+    end
+
+    @testset "ffi_aggregate_type" begin
+        @test RustCall.ffi_aggregate_type(:ptr_len) === RustCall.CRustStr
+        @test RustCall.ffi_aggregate_type(:ptr_len_cap) === RustCall.CRustString
+        @test RustCall.ffi_aggregate_type(:by_value) === nothing
+        @test RustCall.ffi_aggregate_type(:pointer) === nothing
+        @test RustCall.ffi_aggregate_type(:void) === nothing
+        @test RustCall.ffi_aggregate_type(:unknown) === nothing
+        # The aggregates must match the word list they stand for.
+        @test collect(fieldtypes(RustCall.CRustStr)) ==
+              [Ptr{UInt8}, UInt] == [Ptr{UInt8}, Csize_t]
+        @test length(fieldtypes(RustCall.CRustString)) == length(RustCall.ffi_slots(:ptr_len_cap))
     end
 
     # ========================================================================

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -160,10 +160,18 @@ const ALL_SPELLINGS = vcat(
             "*mut Point"; ownership = :owned_by_rust)
         @test_throws ArgumentError RustCall.ffi_return_contract(
             "*mut Point"; ownership = :not_a_tag, free_symbol = "Point_free")
-        # `owner` also satisfies it, through the string convention.
-        @test RustCall.ffi_return_contract("*mut Point"; ownership = :owned_by_rust,
-                                           owner = "Point").free_symbol ==
-              "Point_free_rust_string"
+        # `owner` supplies only the STRING release convention
+        # (`<owner>_free_rust_string`, deps/rustcall_core/src/codegen.rs:633),
+        # which is wrong for a pointer — the crate exports e.g. `Point_free`.
+        # So it does not satisfy the requirement here.
+        @test_throws ArgumentError RustCall.ffi_return_contract(
+            "*mut Point"; ownership = :transferred_to_julia, owner = "Point")
+        @test_throws ArgumentError RustCall.ffi_return_contract(
+            "*mut Point"; ownership = :owned_by_rust, owner = "Point")
+        # …but an explicit symbol does.
+        @test RustCall.ffi_return_contract("*mut Point"; ownership = :transferred_to_julia,
+                                           free_symbol = "Point_free").free_symbol ==
+              "Point_free"
         # Tags that imply no release need no symbol.
         @test RustCall.ffi_return_contract("*mut Point"; ownership = :none).ownership === :none
     end
@@ -204,7 +212,15 @@ const ALL_SPELLINGS = vcat(
         @test ret.aggregate_type === RustCall.CRustString
         @test ret.layout == Type[Ptr{UInt8}, Csize_t, Csize_t]
         @test fieldtypes(RustCall.CRustString) == (Ptr{UInt8}, UInt, UInt)
-        @test ret.ownership === :owned_by_rust      # Julia must free it (#246)
+        # Derived-but-unnameable: the ABI says the buffer is owned, but no owner
+        # was given, so there is no symbol to free it with. The contract reports
+        # `:unknown` rather than an unfreeable `:owned_by_rust` (#246, #249).
+        @test ret.ownership === :unknown
+        @test ret.free_symbol === nothing
+        # Name the owner and it becomes owned, with the symbol.
+        owned = RustCall.ffi_return_contract("String"; abi = "string", owner = "shout")
+        @test owned.ownership === :owned_by_rust    # Julia must free it (#246)
+        @test owned.free_symbol == "shout_free_rust_string"
         @test ret.surface_type === RustCall.RustString
         @test RustCall.ffi_return_ccall_type("String"; abi = "string") ===
               RustCall.CRustString
@@ -266,6 +282,19 @@ const ALL_SPELLINGS = vcat(
         @test RustCall.ffi_ccall_type("*mut core::primitive::i32") === Ptr{Int32}
         @test RustCall.ffi_ccall_type("  core::primitive::bool  ") === Bool
 
+        # Rooted paths: `type_to_string` preserves the leading `::`.
+        @test RustCall.ffi_normalize_spelling("::core::primitive::i32") == "i32"
+        @test RustCall.ffi_normalize_spelling("::std::primitive::u8") == "u8"
+        @test RustCall.ffi_ccall_type("::core::primitive::i32") === Int32
+        @test RustCall.ffi_ccall_type("::std::primitive::u8") === UInt8
+        @test RustCall.ffi_ccall_type("*mut ::core::primitive::f64") === Ptr{Float64}
+        @test RustCall.ffi_return_contract("::std::primitive::bool").ccall_types ==
+              Type[Bool]
+        # …and the rooted form of an arbitrary crate path still fails closed.
+        @test RustCall.ffi_lookup("::mycrate::i32") === nothing
+        @test RustCall.ffi_normalize_spelling("::mycrate::i32") == "::mycrate::i32"
+        @test RustCall.ffi_lookup("::core::primitive::Widget") === nothing
+
         # Negative: only those two prefixes. `rustcall_core` is laxer — it
         # matches on the last path segment alone, so it also accepts
         # `mycrate::i32`, where `i32` may be a user alias with a different
@@ -316,7 +345,7 @@ const ALL_SPELLINGS = vcat(
         # The column overrides the spelling, which is what makes the manifest
         # normative: an alias the table has never heard of still gets the right
         # ABI once the extractor labels it.
-        c = RustCall.ffi_return_contract("MyAlias"; abi = "string")
+        c = RustCall.ffi_return_contract("MyAlias"; abi = "string", owner = "MyAlias")
         @test c.known
         @test c.abi === :ptr_len_cap
         @test c.ownership === :owned_by_rust
@@ -469,8 +498,8 @@ const ALL_SPELLINGS = vcat(
         # until #274 lands; the contract fails closed in the meantime.
         @test RustCall.ffi_return_contract("String").known == false
         @test RustCall.ffi_return_contract("String"; abi = "string").abi === :ptr_len_cap
-        @test RustCall.ffi_return_contract("String"; abi = "string").ownership ===
-              :owned_by_rust
+        @test RustCall.ffi_return_contract("String"; abi = "string",
+                                           owner = "shout").ownership === :owned_by_rust
         @test RustCall.ffi_return_contract("&str"; abi = "str").ownership === :borrowed
     end
 
@@ -525,8 +554,8 @@ const ALL_SPELLINGS = vcat(
         # (#246) and why the drop symbol is chosen from the Julia-side type tag
         # rather than from the allocating library (#249).
         @test table_structs("String") === :RustString   # a type, no owner
-        @test RustCall.ffi_return_contract("String"; abi = "string").ownership ===
-              :owned_by_rust
+        @test RustCall.ffi_return_contract("String"; abi = "string",
+                                           owner = "shout").ownership === :owned_by_rust
         @test RustCall.ffi_argument_contract("String"; abi = "string").ownership ===
               :owned_by_julia
         # The free symbol is per-function (`<fn>_free_rust_string`), so the
@@ -535,6 +564,29 @@ const ALL_SPELLINGS = vcat(
         # Scalars own nothing, which must stay distinguishable from "unknown".
         @test RustCall.ffi_return_contract("i64").ownership === :none
         @test RustCall.ffi_return_contract("Vec<f64>").ownership === :unknown
+    end
+
+    @testset "invariant: an owned position always names its free symbol" begin
+        # A contract tagged :owned_by_rust / :transferred_to_julia must carry a
+        # free_symbol — an owned value with no way to release it is the shape of
+        # #246 and #249, so the contract reports :unknown (derived) or raises
+        # (asserted) instead.
+        cases = Any[]
+        for s in ALL_SPELLINGS, dir in (:argument, :return), abi in ("", "string", "str")
+            push!(cases, dir === :argument ?
+                  RustCall.ffi_argument_contract(s; abi = abi) :
+                  RustCall.ffi_return_contract(s; abi = abi))
+            dir === :return || continue
+            push!(cases, RustCall.ffi_return_contract(s; abi = abi, owner = "Owner"))
+        end
+        @test !isempty(cases)
+        for c in cases
+            if c.ownership in RustCall.FFI_OWNERSHIP_NEEDS_FREE
+                @test c.free_symbol !== nothing
+            end
+        end
+        # And the sweep really does exercise the owned branch.
+        @test any(c -> c.ownership === :owned_by_rust, cases)
     end
 
     @testset "no existing table was changed" begin

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -1,0 +1,368 @@
+# Tests for the single source of truth of the FFI type contract
+# (`src/ffi_contract.jl`, issue #276 Phase A).
+#
+# Two jobs:
+#
+#  1. test the new table and its API directly;
+#  2. **enumerate the disagreements** between the five type tables that exist on
+#     `main` and the new one. Phase A migrates no call site, so the divergence
+#     tests below assert the *current* (in several cases wrong) behaviour and
+#     name the issue each one belongs to. When Phase B moves a call site onto
+#     the contract, the corresponding `@test` here is what must be flipped —
+#     which makes these the regression tests for #245, #246 and #249.
+
+using Test
+using RustCall
+
+# ----------------------------------------------------------------------------
+# The five tables, as callable probes
+# ----------------------------------------------------------------------------
+
+# Table 1: `deps/rustcall_core/src/types.rs:85` / `:104`. It lives in Rust, so
+# it is mirrored here as data. `PRIMITIVES` is `types.rs:12` verbatim.
+const CORE_PRIMITIVES = [
+    "i8", "i16", "i32", "i64", "i128", "u8", "u16", "u32", "u64", "u128",
+    "f32", "f64", "bool", "char", "usize", "isize",
+]
+
+const CORE_NON_FFI = ["String", "Vec", "Box", "Rc", "Arc", "HashMap", "HashSet",
+                      "BTreeMap", "BTreeSet", "Cow"]
+
+_is_ptr_spelling(s) = startswith(s, "*const ") || startswith(s, "*mut ")
+
+# `is_ffi_compatible_type`: a path type whose last segment is a primitive, the
+# empty tuple, or *any* raw pointer (`Type::Ptr(_) => true`).
+function core_is_ffi_compatible(s::AbstractString)
+    s == "()" && return true
+    _is_ptr_spelling(s) && return true
+    startswith(s, "&") && return false
+    head = first(split(s, '<'))
+    return head in CORE_PRIMITIVES
+end
+
+# `is_non_ffi_type`: the known container list, plus every reference.
+function core_is_non_ffi(s::AbstractString)
+    startswith(s, "&") && return true
+    head = first(split(s, '<'))
+    return head in CORE_NON_FFI
+end
+
+# Tables 2-5 are Julia functions and can be called directly.
+table_conversion(s) = RustCall._rust_type_to_julia_conversion_type(s)      # src/julia_functions.jl:193
+table_symbol(s) = RustCall._rust_type_to_julia_type_symbol(s)              # src/julia_functions.jl:220
+table_ruststr(s) = RustCall._rust_primitive_to_julia_type(s)               # src/ruststr.jl:519
+table_structs(s) = RustCall.rust_to_julia_type_sym(s)                      # src/structs.jl:665
+
+# The union of the spellings any of the five tables (or the contract) has an
+# opinion about.
+const ALL_SPELLINGS = vcat(
+    CORE_PRIMITIVES,
+    ["()", "String", "&str", "str", "*const u8", "*mut i32", "*mut c_void", "Vec<f64>"],
+)
+
+@testset "FFI contract (#276 Phase A)" begin
+
+    @testset "table shape" begin
+        for (spelling, entry) in RustCall.FFI_TYPE_TABLE
+            @test entry.rust == spelling
+            @test entry.abi in RustCall.FFI_ABI_KINDS
+            @test entry.ownership in RustCall.FFI_OWNERSHIP_KINDS
+            @test isconcretetype(entry.ccall_type) || entry.ccall_type === Cvoid
+        end
+        # Every primitive `rustcall_core` accepts must be in the contract —
+        # this is acceptance criterion 3 of #276 for the primitive subset.
+        for p in CORE_PRIMITIVES
+            @test RustCall.ffi_known(p)
+        end
+        @test RustCall.ffi_known("()")
+    end
+
+    @testset "scalars" begin
+        @test RustCall.ffi_ccall_type("i32") === Int32
+        @test RustCall.ffi_surface_type("u64") === UInt64
+        @test RustCall.ffi_julia_symbol("usize") === :Csize_t
+        @test RustCall.ffi_ccall_type("usize") === Csize_t
+        @test RustCall.ffi_julia_symbol("isize") === :Cssize_t
+        @test RustCall.ffi_julia_symbol("()") === :Cvoid
+        @test RustCall.ffi_ownership("f64") === :none
+        # 128-bit integers: known to `rustcall_core`, unknown to every Julia
+        # table on `main`.
+        @test RustCall.ffi_ccall_type("i128") === Int128
+        @test RustCall.ffi_ccall_type("u128") === UInt128
+        # Rust `char` is a code point in 4 bytes; Julia `Char` stores UTF-8 code
+        # units left-aligned, so the C slot is `UInt32` and the surface value
+        # must be converted, never reinterpreted.
+        @test RustCall.ffi_ccall_type("char") === UInt32
+        @test RustCall.ffi_surface_type("char") === Char
+    end
+
+    @testset "unknown types fail closed" begin
+        @test RustCall.ffi_lookup("Vec<f64>") === nothing
+        @test RustCall.ffi_lookup("HashMap<String, i32>") === nothing
+        @test RustCall.ffi_known("MyStruct") == false
+        @test RustCall.ffi_ccall_type("Vec<f64>") === nothing
+        @test RustCall.ffi_julia_symbol("Vec<f64>") === nothing
+        @test RustCall.ffi_ownership("Vec<f64>") === :unknown
+
+        c = RustCall.ffi_return_contract("Vec<f64>")
+        @test c.known == false
+        @test c.abi === :unknown
+        @test isempty(c.ccall_types)
+        @test c.ownership === :unknown
+        @test occursin("not in the FFI contract", RustCall.ffi_describe("Vec<f64>"))
+    end
+
+    @testset "raw pointers" begin
+        @test RustCall.ffi_ccall_type("*const u8") === Ptr{UInt8}
+        @test RustCall.ffi_ccall_type("*mut i32") === Ptr{Int32}
+        # Opaque pointee: the contract accepts the pointer (matching
+        # `Type::Ptr(_) => true`) but degrades the pointee to `Cvoid`.
+        @test RustCall.ffi_ccall_type("*mut Point") === Ptr{Cvoid}
+        @test RustCall.ffi_return_contract("*mut Point").abi === :pointer
+        @test RustCall.ffi_return_contract("*mut Point").ownership === :borrowed
+        @test RustCall.ffi_lookup("*const  u8").ccall_type === Ptr{UInt8}
+    end
+
+    @testset "strings: the ABI depends on direction" begin
+        ret = RustCall.ffi_return_contract("String")
+        @test ret.abi === :ptr_len_cap
+        @test ret.ccall_types == Type[Ptr{UInt8}, Csize_t, Csize_t]
+        @test ret.ownership === :owned_by_rust      # Julia must free it (#246)
+        @test ret.surface_type === RustCall.RustString
+
+        arg = RustCall.ffi_argument_contract("String")
+        @test arg.abi === :ptr_len
+        @test arg.ccall_types == Type[Ptr{UInt8}, Csize_t]
+        @test arg.ownership === :owned_by_julia
+        @test arg.surface_type === String
+
+        sref = RustCall.ffi_return_contract("&str")
+        @test sref.abi === :ptr_len
+        @test sref.ccall_types == Type[Ptr{UInt8}, Csize_t]
+        @test sref.ownership === :borrowed
+        @test RustCall.ffi_argument_contract("&str").ccall_types == Type[Ptr{UInt8}, Csize_t]
+    end
+
+    @testset "void and scalar positions" begin
+        @test RustCall.ffi_return_contract("()").abi === :void
+        @test isempty(RustCall.ffi_return_contract("()").ccall_types)
+        @test RustCall.ffi_argument_contract("f32").ccall_types == Type[Float32]
+        @test RustCall.ffi_argument_contract("f32").ownership === :none
+    end
+
+    @testset "manifest abi column (#270 / PR #274)" begin
+        # `""` defers to the Rust spelling.
+        @test RustCall.ffi_manifest_abi_kind("", :argument) === nothing
+        @test RustCall.ffi_manifest_abi_kind("", :return) === nothing
+        @test RustCall.ffi_manifest_abi_kind("string", :argument) === :ptr_len
+        @test RustCall.ffi_manifest_abi_kind("string", :return) === :ptr_len_cap
+        @test RustCall.ffi_manifest_abi_kind("str", :argument) === :ptr_len
+        @test RustCall.ffi_manifest_abi_kind("str", :return) === :ptr_len
+        @test_throws ArgumentError RustCall.ffi_manifest_abi_kind("bytes", :return)
+        @test_throws ArgumentError RustCall.ffi_manifest_abi_kind("", :sideways)
+
+        # The column overrides the spelling, which is what makes the manifest
+        # normative: an alias the table has never heard of still gets the right
+        # ABI once the extractor labels it.
+        c = RustCall.ffi_return_contract("MyAlias"; abi = "string")
+        @test c.known
+        @test c.abi === :ptr_len_cap
+        @test c.ownership === :owned_by_rust
+        @test RustCall.ffi_argument_contract("Cow<'a, str>"; abi = "str").ccall_types ==
+              Type[Ptr{UInt8}, Csize_t]
+        # And it agrees with the spelling when both are present.
+        @test RustCall.ffi_return_contract("String"; abi = "string").abi ===
+              RustCall.ffi_return_contract("String").abi
+        @test RustCall.ffi_argument_contract("&str"; abi = "str").abi ===
+              RustCall.ffi_argument_contract("&str").abi
+    end
+
+    @testset "ffi_slots" begin
+        @test RustCall.ffi_slots(:ptr_len) == Type[Ptr{UInt8}, Csize_t]
+        @test RustCall.ffi_slots(:ptr_len_cap) == Type[Ptr{UInt8}, Csize_t, Csize_t]
+        @test isempty(RustCall.ffi_slots(:void))
+        @test_throws ArgumentError RustCall.ffi_slots(:by_value)
+    end
+
+    # ========================================================================
+    # Divergences between the five existing tables and the contract.
+    #
+    # Every `@test` below asserts what `main` does TODAY. None of them is a
+    # statement about what the code should do.
+    # ========================================================================
+
+    @testset "divergence: no table covers every spelling" begin
+        # A quick census, so a table gaining an entry shows up as a failure here
+        # rather than silently.
+        covered = Dict(
+            "julia_functions/conversion" => count(s -> table_conversion(s) !== nothing, ALL_SPELLINGS),
+            "julia_functions/symbol" => count(s -> table_symbol(s) !== nothing, ALL_SPELLINGS),
+            "ruststr/primitive" => count(s -> table_ruststr(s) !== nothing, ALL_SPELLINGS),
+            "structs/type_sym" => count(s -> table_structs(s) !== :Any, ALL_SPELLINGS),
+            "ffi_contract" => count(RustCall.ffi_known, ALL_SPELLINGS),
+        )
+        @test covered["julia_functions/conversion"] == 13
+        @test covered["julia_functions/symbol"] == 14
+        @test covered["ruststr/primitive"] == 14
+        @test covered["structs/type_sym"] == 10
+        # The contract covers everything except the genuinely unsupported
+        # aggregate, which it refuses on purpose.
+        @test covered["ffi_contract"] == length(ALL_SPELLINGS) - 1
+    end
+
+    @testset "divergence: i128 / u128 / char (#245 item 2)" begin
+        # `rustcall_core` accepts these — a wrapper or accessor IS generated…
+        for s in ("i128", "u128", "char")
+            @test core_is_ffi_compatible(s)
+            # …but every Julia table mistranslates them.
+            @test table_conversion(s) === nothing
+            @test table_symbol(s) === nothing
+            @test table_ruststr(s) === nothing
+            @test table_structs(s) === :Any        # fail-open: `Any` in a ccall
+            # The contract knows all three.
+            @test RustCall.ffi_known(s)
+        end
+        @test RustCall.ffi_surface_type("i128") === Int128
+        @test RustCall.ffi_surface_type("u128") === UInt128
+        # For `char` the disagreement is not just "missing": mapping Rust `char`
+        # onto Julia `Char` bit-for-bit would be wrong, so the contract splits
+        # the C slot (`UInt32`) from the surface type (`Char`).
+        @test RustCall.ffi_ccall_type("char") !== RustCall.ffi_surface_type("char")
+    end
+
+    @testset "divergence: small integers missing from src/structs.jl (#245 item 2)" begin
+        # `rust_to_julia_type_sym` knows 8 primitives. A `#[julia]` struct field
+        # of type `u16` therefore becomes `:Any` in generated accessor code,
+        # while the same type in a free function becomes `:UInt16`.
+        for s in ("i8", "i16", "u8", "u16", "i128", "u128", "usize", "isize", "char")
+            @test table_structs(s) === :Any
+            @test table_symbol(s) !== :Any
+        end
+        @test table_symbol("u16") === :UInt16
+        @test RustCall.ffi_julia_symbol("u16") === :UInt16
+    end
+
+    @testset "divergence: usize / isize spelling (#245 item 2)" begin
+        # Two tables spell the platform-sized integers with the C aliases and
+        # one with the fixed-width names. Same type on every supported
+        # platform, different spelling in generated code — and a real
+        # divergence on any target where `Csize_t !== UInt64`.
+        @test table_conversion("usize") === :Csize_t
+        @test table_symbol("usize") === :Csize_t
+        @test table_ruststr("usize") === UInt64
+        @test table_structs("usize") === :Any
+        @test RustCall.ffi_julia_symbol("usize") === :Csize_t
+        # Today these coincide; the test records the assumption.
+        @test Csize_t === UInt64
+        @test Cssize_t === Int64
+    end
+
+    @testset "divergence: the unit type" begin
+        # `_rust_type_to_julia_conversion_type` has no `()` entry (it is an
+        # argument-conversion table), the other three do. A caller that uses the
+        # conversion table for a return position gets `nothing` and falls
+        # through to the guess path.
+        @test table_conversion("()") === nothing
+        @test table_symbol("()") === :Cvoid
+        @test table_ruststr("()") === Cvoid
+        @test table_structs("()") === :Cvoid
+        @test RustCall.ffi_julia_symbol("()") === :Cvoid
+    end
+
+    @testset "divergence: String / &str (#246)" begin
+        # Only `src/structs.jl` maps the string types at all.
+        @test table_structs("String") === :RustString
+        @test table_structs("&str") === :RustStr
+        @test table_conversion("String") === nothing
+        @test table_symbol("String") === nothing
+        @test table_ruststr("String") === nothing
+        @test table_conversion("&str") === nothing
+        @test table_symbol("&str") === nothing
+        @test table_ruststr("&str") === nothing
+        # `rustcall_core` classifies both as *non*-FFI…
+        @test core_is_non_ffi("String")
+        @test core_is_non_ffi("&str")
+        @test core_is_ffi_compatible("String") == false
+        # …yet `rusttype_to_julia`, the sixth table, happily produces a type,
+        # and `bare str` becomes a `Cstring` — the NUL-terminated pointer that
+        # #246 identifies as the wrong shape for a Rust `String`.
+        @test RustCall.rusttype_to_julia("String") === RustCall.RustString
+        @test RustCall.rusttype_to_julia("str") === Cstring
+        @test table_structs("str") === :Any
+        # The contract says what neither of them says: the shape and the owner.
+        @test RustCall.ffi_return_contract("String").abi === :ptr_len_cap
+        @test RustCall.ffi_return_contract("String").ownership === :owned_by_rust
+        @test RustCall.ffi_return_contract("&str").ownership === :borrowed
+    end
+
+    @testset "divergence: raw pointers (#245 item 2)" begin
+        # `rustcall_core` accepts every raw pointer wholesale; no Julia table
+        # has a pointer entry, so the pointer lands on the `:Any` / `nothing`
+        # path in each of them.
+        for s in ("*const u8", "*mut i32", "*mut c_void")
+            @test core_is_ffi_compatible(s)
+            @test table_conversion(s) === nothing
+            @test table_symbol(s) === nothing
+            @test table_ruststr(s) === nothing
+            @test table_structs(s) === :Any
+            @test RustCall.ffi_known(s)
+        end
+    end
+
+    @testset "divergence: fail-open vs fail-closed (#245 item 1)" begin
+        # `rust_to_julia_type_sym` answers `:Any` for anything it does not know,
+        # which is indistinguishable from a real answer at the call site.
+        @test table_structs("Vec<f64>") === :Any
+        @test table_structs("CompletelyMadeUp") === :Any
+        # The contract answers `nothing`, which a caller cannot mistake for one.
+        @test RustCall.ffi_julia_symbol("Vec<f64>") === nothing
+        @test RustCall.ffi_return_contract("CompletelyMadeUp").known == false
+    end
+
+    @testset "divergence: the return-type guess (#245 item 1)" begin
+        # `call_rust_function_infer` (src/codegen.jl:304) derives the RETURN
+        # type from the FIRST ARGUMENT, defaulting to `Int64`. Read out of the
+        # code the `@generated` body emits, so the guess is visible without
+        # calling into a library.
+        function guessed_return(argtype)
+            ci = Base.code_lowered(RustCall.call_rust_function_infer, (Ptr{Cvoid}, argtype))[1]
+            # `:(Core.tuple(_2, <ret_type>))`
+            return ci.code[2].args[end]
+        end
+        @test guessed_return(Float64) === Float64   # `fn f(x: f64) -> i32` read as Float64
+        @test guessed_return(Int32) === Int32
+        @test guessed_return(Bool) === Bool
+        @test guessed_return(Ptr{Cvoid}) === Int64  # the silent default
+        @test guessed_return(String) === Cstring    # the ABI-broken path of #246
+        # The contract has no such path: an unknown return type has no type.
+        @test RustCall.ffi_return_contract("i32").ccall_types == Type[Int32]
+        @test RustCall.ffi_return_contract("").known == false
+    end
+
+    @testset "divergence: ownership is unrepresented (#246, #249)" begin
+        # None of the five tables carries an ownership column at all: each maps
+        # a spelling to a bare Julia type, so nothing in the pipeline records
+        # who frees a returned buffer. That absence is why `String` returns leak
+        # (#246) and why the drop symbol is chosen from the Julia-side type tag
+        # rather than from the allocating library (#249).
+        @test table_structs("String") === :RustString   # a type, no owner
+        @test RustCall.ffi_return_contract("String").ownership === :owned_by_rust
+        @test RustCall.ffi_argument_contract("String").ownership === :owned_by_julia
+        # The free symbol is per-function (`<fn>_free_rust_string`), so the
+        # type-keyed table cannot name it yet; the field exists for Phase B.
+        @test RustCall.ffi_return_contract("String").free_symbol === nothing
+        # Scalars own nothing, which must stay distinguishable from "unknown".
+        @test RustCall.ffi_return_contract("i64").ownership === :none
+        @test RustCall.ffi_return_contract("Vec<f64>").ownership === :unknown
+    end
+
+    @testset "no existing table was changed" begin
+        # Phase A is additive. If any of these change, a call site was migrated
+        # and the divergence tests above must be revisited.
+        @test length(RustCall.RUST_TO_JULIA_TYPE_MAP) == 26
+        @test table_symbol("i32") === :Int32
+        @test table_conversion("i32") === :Int32
+        @test table_ruststr("i32") === Int32
+        @test table_structs("i32") === :Int32
+    end
+end

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -310,6 +310,43 @@ const ALL_SPELLINGS = vcat(
         @test RustCall.ffi_lookup("core::primitive::Widget") === nothing
     end
 
+    @testset "julia_expr is a Julia AST, not a printed name" begin
+        # `Symbol("Ptr{Int32}")` would splice into generated code as
+        # `var"Ptr{Int32}"` — an undefined binding. Parametric types must be
+        # `Expr(:curly, ...)`.
+        @test RustCall.ffi_julia_symbol("*const *mut i32") == :(Ptr{Ptr{Int32}})
+        @test RustCall.ffi_julia_symbol("*const u8") == :(Ptr{UInt8})
+        @test RustCall.ffi_julia_symbol("*mut Point") == :(Ptr{Cvoid})
+        @test RustCall.ffi_julia_symbol("*mut *const *mut f64") ==
+              :(Ptr{Ptr{Ptr{Float64}}})
+        @test RustCall.ffi_julia_symbol("*const *mut i32") isa Expr
+        @test RustCall.ffi_julia_type("*const *mut i32") === Ptr{Ptr{Int32}}
+        @test RustCall.ffi_julia_type("*mut *const *mut f64") === Ptr{Ptr{Ptr{Float64}}}
+        @test RustCall.ffi_julia_type("Vec<f64>") === nothing
+
+        # Plain names stay plain `Symbol`s.
+        for s in ("i32", "usize", "()", "String", "char")
+            @test RustCall.ffi_julia_symbol(s) isa Symbol
+        end
+        @test RustCall.ffi_julia_symbol("i32") === :Int32
+        @test RustCall.ffi_julia_symbol("()") === :Cvoid
+
+        # Every spelling the contract knows must render to something that
+        # evaluates, in RustCall, to exactly its surface type.
+        for s in vcat(ALL_SPELLINGS, ["*const *mut i32", "core::primitive::u8"])
+            e = RustCall.ffi_julia_symbol(s)
+            e === nothing && continue
+            @test Core.eval(RustCall, e) === RustCall.ffi_julia_type(s)
+            @test Core.eval(RustCall, e) === RustCall.ffi_surface_type(s)
+        end
+
+        # And the renderer itself.
+        @test RustCall.ffi_type_expr(Int32) === :Int32
+        @test RustCall.ffi_type_expr(Cvoid) === :Cvoid       # not :Nothing
+        @test RustCall.ffi_type_expr(Ptr{Cvoid}) == :(Ptr{Cvoid})
+        @test RustCall.ffi_type_expr(Ptr{Ptr{UInt8}}) == :(Ptr{Ptr{UInt8}})
+    end
+
     @testset "nested raw pointers" begin
         @test RustCall.ffi_ccall_type("*const *mut i32") === Ptr{Ptr{Int32}}
         @test RustCall.ffi_ccall_type("*mut *mut u8") === Ptr{Ptr{UInt8}}
@@ -587,6 +624,32 @@ const ALL_SPELLINGS = vcat(
         end
         # And the sweep really does exercise the owned branch.
         @test any(c -> c.ownership === :owned_by_rust, cases)
+    end
+
+    @testset "ownership tags: both owned tags release through free_symbol" begin
+        # `:transferred_to_julia` does NOT mean "Julia frees it with its own
+        # allocator": a `Box::into_raw` handle must be released by calling the
+        # Rust export, so the Rust destructor runs on the allocating allocator
+        # (#249). The two owned tags differ in WHEN, not HOW:
+        #   :owned_by_rust        — released within the call (the wrapper copies,
+        #                           then frees; src/structs.jl:511-523)
+        #   :transferred_to_julia — the handle outlives the call and Julia frees
+        #                           it later, from a finalizer
+        @test :owned_by_rust in RustCall.FFI_OWNERSHIP_NEEDS_FREE
+        @test :transferred_to_julia in RustCall.FFI_OWNERSHIP_NEEDS_FREE
+        @test !(:borrowed in RustCall.FFI_OWNERSHIP_NEEDS_FREE)
+        @test !(:owned_by_julia in RustCall.FFI_OWNERSHIP_NEEDS_FREE)
+        @test !(:none in RustCall.FFI_OWNERSHIP_NEEDS_FREE)
+        for tag in RustCall.FFI_OWNERSHIP_NEEDS_FREE
+            @test tag in RustCall.FFI_OWNERSHIP_KINDS
+            # Both require the symbol, and both keep it.
+            @test_throws ArgumentError RustCall.ffi_return_contract("*mut Point";
+                                                                    ownership = tag)
+            c = RustCall.ffi_return_contract("*mut Point"; ownership = tag,
+                                             free_symbol = "Point_free")
+            @test c.ownership === tag
+            @test c.free_symbol == "Point_free"
+        end
     end
 
     @testset "no existing table was changed" begin


### PR DESCRIPTION
Phase A of #276. **Strictly additive: no call site has been migrated yet.**

`src/ffi_contract.jl` is the single table the five existing ones are meant to
collapse into, plus the two things the manifest leaves implicit today:

* the **C ABI form** of each position — `:void`, `:by_value`, `:pointer`,
  `:ptr_len`, `:ptr_len_cap`, `:unknown`;
* **ownership** — `:none`, `:borrowed`, `:owned_by_julia`, `:owned_by_rust`
  (with a `free_symbol` slot for #246/#249), `:transferred_to_julia`,
  `:unknown`.

API (internal, no new exports): `ffi_lookup`, `ffi_known`, `ffi_normalize_spelling`,
`ffi_ccall_type`, `ffi_surface_type`, `ffi_julia_symbol`, `ffi_julia_type`,
`ffi_type_expr`, `ffi_ownership`, `ffi_slots`, `ffi_aggregate_type`,
`ffi_free_symbol`, `ffi_manifest_abi_kind`, `ffi_argument_contract`,
`ffi_return_contract`, `ffi_return_ccall_type`, `ffi_describe`.

Type spellings are Julia ASTs, not printed names: `ffi_julia_symbol` returns a
`Symbol` for a plain name and an `Expr` for a parametric one
(`:(Ptr{Ptr{Int32}})`), so it can be spliced into generated code with `$`;
`ffi_julia_type` gives the `Type` itself.

A contract separates the **calling convention** from the **value's shape**,
because the two multi-word ABIs reach a `ccall` differently depending on
direction: `ccall_types` is the argument slots in argument position and the one
`#[repr(C)]` aggregate (`CRustString` / `CRustStr`, matching
`<fn>_RustCallOwnedString` / `<fn>_RustCallBorrowedString`) in return position,
since a `ccall` has exactly one return type; `aggregate_type` names it; `layout`
keeps the direction-independent word list. `ffi_return_contract` takes an
`owner` so an `:owned_by_rust` return carries its `<owner>_free_rust_string`.

Forward compatibility with #270 / #274: `ffi_argument_contract` and
`ffi_return_contract` take the manifest `abi` column (`Arg.abi`,
`Method.return_abi` — the `""` / `"string"` / `"str"` vocabulary already on
`feature/string-ffi`) verbatim and let it **override** the ABI derived from the
Rust spelling. Wiring the manifest in later is a parameter pass, not a rewrite.

Unknown types resolve to `nothing` / `known = false` rather than to a default,
which is the fail-closed behaviour Phase B needs. Two things are deliberately
**not** derived from the Rust spelling, because the spelling does not carry them:

* **whether a string was lowered.** On `main` the lowering is not uniform —
  `transform_simple_function` (`codegen.rs:53-58`) only marks a free
  `#[julia] fn ... -> String` signature `extern "C"` and
  `generate_method_wrapper_crate` (`:378`, `:414`, `:443`) forwards the original
  types; only `inline_method_wrapper` (`:774-863`) emits `(ptr, len)` /
  `CRustString`. The manifest `abi` column is therefore the only authority: a
  bare `String` / `&str` / `str` fails closed, and `abi = "string"` / `"str"`
  selects the lowered form. This rule is correct both before and after #274.
* **who owns a raw pointer.** A generated constructor returns `Box::into_raw`
  (`codegen.rs:386-392`) that Julia owns; another `*mut T` may point into memory
  Rust keeps. The default is `:unknown`, and `ffi_return_contract` takes
  `ownership` / `free_symbol` for a consumer that has the metadata.

The contract keeps one invariant, `FFI_OWNERSHIP_NEEDS_FREE`: a position tagged
`:owned_by_rust` or `:transferred_to_julia` **always** names the `free_symbol`
that releases it. Asserting such a tag without a symbol is an `ArgumentError`
(`owner` stands in only for the lowered owned-string return, whose convention is
`<owner>_free_rust_string`); deriving one with no symbol available reports
`:unknown` instead. An owned value nobody can free is the shape of #246 and
#249, so it is refused rather than recorded.

The only edit to an existing source file is the `include("ffi_contract.jl")`
line in `src/RustCall.jl`, placed right after `typetranslation.jl`. Nothing
touched in `src/julia_functions.jl`, `src/structs.jl`, `src/ruststr.jl`,
`src/manifest.jl`, `src/crate_bindings.jl` or
`deps/rustcall_core/src/types.rs`, so this does not conflict with #272 or #274.

## Divergences found

`test/test_ffi_contract.jl` enumerates these as executable documentation. Every
assertion records what `main` does **today**; where a divergence corresponds to
#245, #246 or #249 the test names the issue in a comment, so it is the
regression test to flip when Phase B migrates that call site.

| # | Spelling(s) | Divergence | Issue |
| - | ----------- | ---------- | ----- |
| 1 | `i128`, `u128`, `char` | Accepted by `rustcall_core`'s `PRIMITIVES` (a wrapper/accessor *is* generated), but absent from all four Julia tables: `nothing`, `nothing`, `nothing`, `:Any`. | #245 item 2 |
| 2 | `char` (specifically) | Even where it is mapped, mapping it onto Julia `Char` bit-for-bit is wrong: Rust `char` is a code point, Julia `Char` stores UTF-8 code units left-aligned. The contract splits the C slot (`UInt32`) from the surface type (`Char`). | #245 item 2 |
| 3 | `i8`, `i16`, `u8`, `u16`, `i128`, `u128`, `usize`, `isize`, `char` | `rust_to_julia_type_sym` (`src/structs.jl:665`) knows only 8 primitives, so a `#[julia]` struct field of type `u16` becomes `:Any` while the same type in a free function becomes `:UInt16`. | #245 item 2 |
| 4 | `usize`, `isize` | Spelled `:Csize_t`/`:Cssize_t` by both `julia_functions.jl` tables but `UInt64`/`Int64` by `src/ruststr.jl:519`; absent from `src/structs.jl:665` (`:Any`). Same *type* on every supported platform, different *spelling* in generated code — and a genuine type divergence on any target where `Csize_t !== UInt64`. | #245 item 2 |
| 5 | `()` | `_rust_type_to_julia_conversion_type` has no entry (it is an argument table) while the other three give `Cvoid`. A caller reaching for the conversion table in return position gets `nothing` and falls through to the guess path. | #245 item 1 |
| 6 | `String`, `&str` | Only `src/structs.jl:665` maps them (`:RustString` / `:RustStr`); `julia_functions.jl` and `ruststr.jl` return `nothing`, so a `-> String` function drops into `call_rust_function_infer`. Meanwhile `rustcall_core` classifies both as *non*-FFI, and the sixth table (`rusttype_to_julia`) maps bare `str` to `Cstring` — the NUL-terminated pointer #246 identifies as the wrong shape for an owned Rust `String`. | #246 |
| 7 | `*const T`, `*mut T` | `rustcall_core` accepts **every** raw pointer wholesale (`Type::Ptr(_) => true`), and no Julia table has a single pointer entry — all four answer `nothing` / `:Any`. The contract synthesises `Ptr{J}`, degrading an unknown pointee to `Ptr{Cvoid}`. | #245 item 2 |
| 8 | anything unknown (`Vec<f64>`, a user type) | `rust_to_julia_type_sym` answers `:Any`, indistinguishable at the call site from a real answer (fail-open). The contract answers `nothing` / `known = false`. | #245 item 1 |
| 9 | return position, no annotation | `call_rust_function_infer` (`src/codegen.jl:304`) picks the return type from the **first argument**, defaulting to `Int64`: `Float64→Float64`, `Int32→Int32`, `Bool→Bool`, `Ptr→Int64`, `String→Cstring`. Read out of the `@generated` body in the test, so the guess is asserted without calling into a library. | #245 item 1 |
| 10a | `String`, `&str` in a non-inline wrapper | `main` lowers strings only for inline methods; the free-function and crate-method wrappers forward the Rust types as written. Nothing in the manifest records which happened until #274, so any spelling-derived answer is wrong for some wrapper flavour. The contract fails closed and waits for the `abi` column. | #246, #270 |
| 10b | `*mut T` returns | A constructor's `Box::into_raw` handle and a pointer into Rust-owned memory have the same spelling. No table distinguishes them, and the previous revision of this contract called both `:borrowed`. Now `:unknown` unless a consumer states otherwise. | #249 |
| 10 | every spelling | **No table has an ownership column at all** — each maps a spelling to a bare Julia type, so nothing in the pipeline records who frees a returned buffer. That absence is why `String` returns leak and why the drop symbol is chosen from the Julia-side type tag rather than from the allocating library. | #246, #249 |
| 11 | `core::primitive::i32`, `mycrate::i32` | `is_ffi_compatible_type` matches on `last_ident` alone, so it accepts **any** path ending in a primitive segment, while `type_to_string` keeps the qualified spelling in the manifest. The contract resolves the two guaranteed prefixes (`core::primitive::`, `std::primitive::`) and deliberately refuses `mycrate::i32` — an unqualified last segment is not evidence that a user alias is the primitive — so that case fails closed until the extractor resolves paths (#270). | #245 item 2, #270 |
| 12 | direction | The five tables are direction-blind, but the string ABI is not: as an argument `String`/`&str` are `(ptr, len)`; as a return `String` is an owned `(ptr, len, cap)` and `&str` a borrowed `(ptr, len)`. A single flat table cannot express this, which is exactly the gap #270's `abi` column fills. | #246, #270 |

A census test also pins the current coverage of each table over the union of
spellings (13 / 14 / 14 / 10 entries), so a table silently gaining an entry
shows up as a failure rather than as drift.

## Verification

* `bash scripts/lint_interpolation.sh src` — OK
* `bash scripts/lint_rust_syntax_regex.sh src` — OK
* `cd deps/rustcall_extract && cargo build --release`, `RUSTCALL_EXTRACT` exported,
  then `julia --project -e 'using Pkg; Pkg.test()'` — the full suite passes
  (1861 + 270 tests, exit 0), same as `main`.

Part of #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
