### PR TITLE
Single artifact-identity function (#278, Phase A)

### DIFF
--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -46,6 +46,12 @@ include("cache.jl")
 # ruststr.jl, which is resolved at call time, so it can sit right after cache.jl.
 include("loadpolicy.jl")
 
+# Artifact identity (#278, Phase A). Also right after cache.jl: it is the
+# identity layer the cache sits on and it needs nothing beyond
+# exceptions.jl/compiler.jl (both already included) at load time;
+# toolchain_fingerprint() from manifest.jl is only called at run time.
+include("artifact_id.jl")
+
 include("memory.jl")
 
 # Phase 3: External library integration

--- a/src/artifact_id.jl
+++ b/src/artifact_id.jl
@@ -390,58 +390,95 @@ end
 """
     artifact_path_dependency_digest(path::AbstractString) -> String
 
-Deterministic SHA-256 digest of the *inputs* of a local path dependency: every
-file Cargo considers part of the package, by sorted relative path with
-contents, recursing into the path dependencies that `Cargo.toml` itself
-declares.
-
-The file set comes from `crate_input_files`, which asks Cargo
-(`cargo package --list`) rather than assuming a layout, so a `build.rs`, a
-`[lib] path` or `[[bin]] path` outside `src/`, a `#[path = "..."]` module and
-`Cargo.lock` all reach the digest; the strategy that produced the set is hashed
-alongside it.
+Deterministic SHA-256 digest of the *inputs* of a local path dependency: the
+contents of the crate directory, plus the contents of every other local crate
+reachable from it through Cargo's resolved dependency graph.
 
 Only content is hashed — never the absolute location — so an identical crate in
 a differently named directory yields the same digest and a checkout move does
-not invalidate the cache. `target/` is skipped. A path that does not exist, or a
-`Cargo.toml` that cannot be parsed, is recorded as such rather than silently
-ignored, and dependency cycles terminate at the first repeat.
+not invalidate the cache. Crates are folded in as a sorted set of per-crate
+digests for the same reason: the order Cargo happens to report them in, and the
+directory names they happen to live under, must not reach the key.
 
-Without this, a `path = "..."` dependency is identified by its path text alone
-and editing its sources leaves the artifact key unchanged.
+The file set of each crate comes from `crate_input_files` (a directory walk),
+and the set of local crates from `local_path_dependency_dirs` (Cargo's resolved
+graph). Both name the strategy they used, and both strategy names are hashed, so
+results obtained different ways can never collide.
+
+!!! warning "The remaining gap is unfixable here by construction"
+    Only inputs that live *inside* a package directory are captured. A
+    `#[path = "../../elsewhere/mod.rs"]` module, an `include_str!("../data")` or
+    an `include_bytes!` of a file above the package root is compiled into the
+    binary and will **not** change this digest. The only complete answer is
+    Cargo's own fingerprint, which this cannot reimplement. Phase B of #278 must
+    therefore treat this digest as a *rebuild* trigger and never as a proof of
+    freshness: a change means stale, but no change does not by itself license
+    reuse.
+
+A path that does not exist is recorded as such rather than silently ignored, and
+the function never throws.
 """
 function artifact_path_dependency_digest(path::AbstractString)::String
     io = IOBuffer()
-    _hash_path_crate!(io, String(path), Set{String}())
-    return bytes2hex(sha256(take!(io)))
-end
-
-function _hash_path_crate!(io::IO, path::AbstractString, seen::Set{String})
-    dir = try
+    root = try
         abspath(String(path))
     catch
         String(path)
     end
+
+    if !isdir(root)
+        _netstring!(io, "missing-crate")
+        _netstring!(io, String(path))
+        return bytes2hex(sha256(take!(io)))
+    end
+
+    graph_strategy, dirs = local_path_dependency_dirs(root)
+    _netstring!(io, "graph-strategy")
+    _netstring!(io, graph_strategy)
+
+    root_canonical = _canonical_dir(root)
+    _netstring!(io, "root")
+    _netstring!(io, crate_content_digest(root))
+
+    # Every other local crate contributes its content digest. Sorting the
+    # digests keeps the result independent of both report order and location.
+    others = String[]
+    for d in dirs
+        _canonical_dir(d) == root_canonical && continue
+        push!(others, crate_content_digest(d))
+    end
+    unique!(others)
+    sort!(others)
+    _netstring!(io, "local-deps")
+    _netstrings!(io, others)
+
+    return bytes2hex(sha256(take!(io)))
+end
+
+function _canonical_dir(dir::AbstractString)::String
+    try
+        return realpath(String(dir))
+    catch
+        return String(dir)
+    end
+end
+
+"""
+    crate_content_digest(dir::AbstractString) -> String
+
+SHA-256 over one crate directory: the sorted relative path and full contents of
+every file `crate_input_files` reports, netstring-framed. Location independent;
+see `artifact_path_dependency_digest`.
+"""
+function crate_content_digest(dir::AbstractString)::String
+    io = IOBuffer()
+    dir = String(dir)
     if !isdir(dir)
         _netstring!(io, "missing-crate")
-        return nothing
+        return bytes2hex(sha256(take!(io)))
     end
-    canonical = try
-        realpath(dir)
-    catch
-        dir
-    end
-    if canonical in seen
-        _netstring!(io, "cycle")
-        return nothing
-    end
-    push!(seen, canonical)
-
-    _netstring!(io, "crate")
     strategy, files = crate_input_files(dir)
-    # The strategy is part of the digest: a file set found by asking Cargo and
-    # one found by walking the directory must never be able to collide.
-    _netstring!(io, "strategy")
+    _netstring!(io, "file-strategy")
     _netstring!(io, strategy)
     _netstring!(io, string(length(files)))
     for rel in files
@@ -454,26 +491,17 @@ function _hash_path_crate!(io::IO, path::AbstractString, seen::Set{String})
                 _netstring!(io, "unreadable")
             end
         else
-            # `cargo package --list` also names files it would synthesize
-            # (Cargo.toml.orig, .cargo_vcs_info.json); record their absence.
             _netstring!(io, "not-on-disk")
         end
     end
-
-    # Recurse into the path dependencies this crate declares itself.
-    for child in _declared_path_dependencies(joinpath(dir, "Cargo.toml"))
-        _netstring!(io, "path-dep")
-        _netstring!(io, child)
-        _hash_path_crate!(io, joinpath(dir, child), seen)
-    end
-    return nothing
+    return bytes2hex(sha256(take!(io)))
 end
 
 """
     CRATE_INPUT_VCS_DIRS
 
-Directories never treated as crate inputs by the directory-walk fallback of
-`crate_input_files`: build output and version-control metadata.
+Directories never treated as crate inputs: build output and version-control
+metadata. Everything else under a package directory is an input.
 """
 const CRATE_INPUT_VCS_DIRS = String[
     ".bzr", ".git", ".hg", ".jj", ".pijul", ".svn", "target",
@@ -482,79 +510,220 @@ const CRATE_INPUT_VCS_DIRS = String[
 """
     crate_input_files(dir::AbstractString) -> (strategy::String, files::Vector{String})
 
-The set of files that make up a crate, as relative `/`-separated paths, sorted,
-together with the name of the strategy that produced it.
+Every regular file under the package directory, as relative `/`-separated
+paths, sorted, excluding `CRATE_INPUT_VCS_DIRS`.
 
-Cargo already knows exactly which files are package inputs — it honours
-`include`/`exclude`, `build = "..."`, `[lib] path`, `[[bin]] path`, modules
-pulled in by `#[path = "..."]` and everything else outside `src/` — so ask it:
+The walk is deliberately the only strategy. `cargo package --list` was tried
+here first and is *weaker*: it enumerates the **distributable** package, not
+what a local build reads, so a `#[path = "../ignored/mod.rs"]` module, an
+`include_str!` of a gitignored file, or anything removed by an `exclude` key is
+compiled but never listed — and a successful listing would suppress a walk that
+would have caught them. A walk of the package directory is a superset of the
+package list for everything inside that directory, and costs no process spawn.
+`Cargo.lock` is therefore included whenever it exists, like any other file.
 
-1. `cargo package --list --offline --allow-dirty` (no build, no network).
-2. If that fails (manifest is a bare workspace, no lockfile resolvable offline,
-   Cargo unavailable), fall back to walking the package directory for every
-   regular file, skipping `CRATE_INPUT_VCS_DIRS`.
-
-`Cargo.lock` is added whenever it exists, since `cargo package --list` omits it
-for a library crate while it still pins what gets built.
-
-The strategy name is returned, and hashed, so a file set obtained one way can
-never collide with one obtained the other way.
+The strategy name is returned so callers can fold it into a digest.
 """
 function crate_input_files(dir::AbstractString)
     dir = String(dir)
-    manifest = joinpath(dir, "Cargo.toml")
     files = String[]
-    strategy = "walk"
-
-    if isfile(manifest)
-        listed = try
-            cmd = `$(cargo()) package --list --offline --allow-dirty --manifest-path $(manifest)`
-            read(pipeline(cmd; stderr = devnull), String)
-        catch
-            ""
-        end
-        entries = String[strip(l) for l in split(listed, '\n') if !isempty(strip(l))]
-        if !isempty(entries)
-            files = entries
-            strategy = "cargo-package-list"
+    for (root, dirs, names) in walkdir(dir)
+        filter!(d -> !(d in CRATE_INPUT_VCS_DIRS), dirs)
+        for n in names
+            push!(files, relpath(joinpath(root, n), dir))
         end
     end
-
-    if strategy == "walk"
-        for (root, dirs, names) in walkdir(dir)
-            filter!(d -> !(d in CRATE_INPUT_VCS_DIRS), dirs)
-            for n in names
-                push!(files, relpath(joinpath(root, n), dir))
-            end
-        end
-    end
-
-    isfile(joinpath(dir, "Cargo.lock")) && push!(files, "Cargo.lock")
-
     files = String[replace(f, '\\' => '/') for f in files]
     unique!(files)
     sort!(files)
-    return strategy, files
+    return "walk", files
 end
 
+"""
+    local_path_dependency_dirs(root::AbstractString) -> (strategy::String, dirs::Vector{String})
+
+Directories of every local (path) crate reachable from the crate at `root`,
+including `root` itself.
+
+Cargo's **resolved graph** is the source of truth, so the answer covers path
+dependencies declared anywhere — `[dependencies]`, `[dev-dependencies]`,
+`[build-dependencies]`, target-specific `[target.'cfg(unix)'.dependencies]`, and
+workspace-inherited `{ workspace = true }` entries — at any depth:
+
+1. `cargo tree --offline --target all --edges normal,build,dev --prefix none
+   --format {p}` names every package in the resolved graph and prints the
+   directory of the local ones in parentheses. (`cargo metadata` reports the
+   same graph, but only as JSON, and RustCall.jl has no JSON dependency; the
+   tree output is line-oriented and needs no parser. Registry packages print
+   without a directory and git ones print a URL, so both are filtered out by the
+   `isdir` test.)
+2. If that fails — no network and nothing resolvable offline, a bare workspace
+   manifest, cargo unavailable — fall back to reading the manifests directly,
+   traversing every dependency table including target-specific ones and
+   resolving `workspace = true` against the nearest `[workspace.dependencies]`.
+
+The strategy name is returned and hashed by callers, so a set found one way can
+never collide with one found the other.
+"""
+function local_path_dependency_dirs(root::AbstractString)
+    root = String(root)
+    manifest = joinpath(root, "Cargo.toml")
+    dirs = String[root]
+
+    if isfile(manifest)
+        # `--locked` first: that variant never writes to the crate directory.
+        # Only if the crate has no usable lockfile do we let Cargo resolve (and
+        # therefore write `Cargo.lock`, exactly as any cargo command — including
+        # the build that follows — would).
+        listed = _cargo_tree(manifest, true)
+        isempty(listed) && (listed = _cargo_tree(manifest, false))
+        found = String[]
+        for line in split(listed, '\n')
+            d = _crate_dir_from_tree_line(line)
+            d === nothing || push!(found, d)
+        end
+        if !isempty(found)
+            append!(dirs, found)
+            unique!(dirs)
+            return "cargo-tree", dirs
+        end
+    end
+
+    _collect_manifest_path_deps!(dirs, root, Set{String}())
+    unique!(dirs)
+    return "manifest-toml", dirs
+end
+
+function _cargo_tree(manifest::AbstractString, locked::Bool)::String
+    fmt = "{p}"   # a Cmd literal cannot carry braces unquoted
+    args = String["tree", "--offline", "--target", "all",
+                  "--edges", "normal,build,dev", "--prefix", "none",
+                  "--format", fmt, "--manifest-path", String(manifest)]
+    locked && push!(args, "--locked")
+    return try
+        read(pipeline(`$(cargo()) $(args)`; stderr = devnull), String)
+    catch
+        ""
+    end
+end
+
+# `cargo tree --prefix none --format {p}` prints e.g.
+#   parent v0.1.0 (/abs/path/parent)
+#   serde v1.0.100
+#   thing v0.1.0 (https://github.com/x/y#abcdef)
+# Only an existing directory in the trailing parentheses is a local crate.
+function _crate_dir_from_tree_line(line::AbstractString)
+    s = strip(line)
+    (endswith(s, ")") && occursin('(', s)) || return nothing
+    open_idx = findlast('(', s)
+    open_idx === nothing && return nothing
+    inner = String(s[nextind(s, open_idx):prevind(s, lastindex(s))])
+    isempty(inner) && return nothing
+    return isdir(inner) ? inner : nothing
+end
+
+function _collect_manifest_path_deps!(dirs::Vector{String}, dir::AbstractString, seen::Set{String})
+    canonical = _canonical_dir(dir)
+    canonical in seen && return nothing
+    push!(seen, canonical)
+    manifest = joinpath(String(dir), "Cargo.toml")
+    for child in _declared_path_dependencies(manifest)
+        child_dir = joinpath(String(dir), child)
+        isdir(child_dir) || continue
+        push!(dirs, child_dir)
+        _collect_manifest_path_deps!(dirs, child_dir, seen)
+    end
+    return nothing
+end
+
+"""
+    _declared_path_dependencies(manifest::AbstractString) -> Vector{String}
+
+Fallback manifest traversal: the `path = "..."` values of every dependency
+table in `manifest`, including target-specific tables
+(`[target.<key>.dependencies]` and its `dev-`/`build-` variants) and
+`{ workspace = true }` entries resolved against the nearest
+`[workspace.dependencies]`, searched in this manifest and then upwards.
+
+Used only when `cargo tree` cannot answer; see `local_path_dependency_dirs`.
+"""
 function _declared_path_dependencies(manifest::AbstractString)::Vector{String}
     isfile(manifest) || return String[]
     parsed = try
-        TOML.parsefile(manifest)
+        TOML.parsefile(String(manifest))
     catch
         return String["unparsable-manifest"]
     end
     out = String[]
-    for section in ("dependencies", "dev-dependencies", "build-dependencies")
-        table = get(parsed, section, nothing)
-        table isa AbstractDict || continue
-        for (_, spec) in table
+    dir = dirname(abspath(String(manifest)))
+    workspace_deps = _workspace_dependency_table(parsed, dir)
+
+    function harvest!(table)
+        table isa AbstractDict || return
+        for (name, spec) in table
             spec isa AbstractDict || continue
             p = get(spec, "path", nothing)
-            p isa AbstractString && push!(out, String(p))
+            if p isa AbstractString
+                push!(out, String(p))
+                continue
+            end
+            # `dep = { workspace = true }`: the path lives in the workspace table.
+            if get(spec, "workspace", false) === true
+                inherited = get(workspace_deps, String(name), nothing)
+                if inherited isa AbstractDict
+                    ip = get(inherited, "path", nothing)
+                    ip isa AbstractString && push!(out, String(ip))
+                end
+            end
+        end
+    end
+
+    for section in ("dependencies", "dev-dependencies", "build-dependencies")
+        harvest!(get(parsed, section, nothing))
+    end
+    # [target.<key>.dependencies] and friends, for every target key.
+    targets = get(parsed, "target", nothing)
+    if targets isa AbstractDict
+        for (_, per_target) in targets
+            per_target isa AbstractDict || continue
+            for section in ("dependencies", "dev-dependencies", "build-dependencies")
+                harvest!(get(per_target, section, nothing))
+            end
         end
     end
     return sort!(unique!(out))
+end
+
+# `[workspace.dependencies]` of this manifest, else of the nearest ancestor
+# manifest that declares a workspace. Paths there are relative to *that*
+# manifest, which is why only same-directory workspaces are resolved; anything
+# further is left to the `cargo tree` strategy.
+function _workspace_dependency_table(parsed::AbstractDict, dir::AbstractString)
+    ws = get(parsed, "workspace", nothing)
+    if ws isa AbstractDict
+        deps = get(ws, "dependencies", nothing)
+        deps isa AbstractDict && return deps
+    end
+    parent = dirname(String(dir))
+    while !isempty(parent) && parent != dirname(parent)
+        candidate = joinpath(parent, "Cargo.toml")
+        if isfile(candidate)
+            other = try
+                TOML.parsefile(candidate)
+            catch
+                nothing
+            end
+            if other isa AbstractDict
+                ws2 = get(other, "workspace", nothing)
+                if ws2 isa AbstractDict
+                    deps2 = get(ws2, "dependencies", nothing)
+                    deps2 isa AbstractDict && return deps2
+                end
+            end
+        end
+        parent = dirname(parent)
+    end
+    return Dict{String, Any}()
 end
 
 """

--- a/src/artifact_id.jl
+++ b/src/artifact_id.jl
@@ -390,10 +390,16 @@ end
 """
     artifact_path_dependency_digest(path::AbstractString) -> String
 
-Deterministic SHA-256 digest of the *inputs* of a local path dependency: its
-`Cargo.toml` plus every file under `src/`, by sorted relative path with
+Deterministic SHA-256 digest of the *inputs* of a local path dependency: every
+file Cargo considers part of the package, by sorted relative path with
 contents, recursing into the path dependencies that `Cargo.toml` itself
 declares.
+
+The file set comes from `crate_input_files`, which asks Cargo
+(`cargo package --list`) rather than assuming a layout, so a `build.rs`, a
+`[lib] path` or `[[bin]] path` outside `src/`, a `#[path = "..."]` module and
+`Cargo.lock` all reach the digest; the strategy that produced the set is hashed
+alongside it.
 
 Only content is hashed — never the absolute location — so an identical crate in
 a differently named directory yields the same digest and a checkout move does
@@ -432,37 +438,103 @@ function _hash_path_crate!(io::IO, path::AbstractString, seen::Set{String})
     push!(seen, canonical)
 
     _netstring!(io, "crate")
-    files = String[]
-    manifest = joinpath(dir, "Cargo.toml")
-    isfile(manifest) && push!(files, manifest)
-    srcdir = joinpath(dir, "src")
-    if isdir(srcdir)
-        for (root, dirs, names) in walkdir(srcdir)
-            filter!(!isequal("target"), dirs)
-            for n in names
-                push!(files, joinpath(root, n))
-            end
-        end
-    end
-    relnames = Dict(f => replace(relpath(f, dir), '\\' => '/') for f in files)
-    sort!(files, by = f -> relnames[f])
+    strategy, files = crate_input_files(dir)
+    # The strategy is part of the digest: a file set found by asking Cargo and
+    # one found by walking the directory must never be able to collide.
+    _netstring!(io, "strategy")
+    _netstring!(io, strategy)
     _netstring!(io, string(length(files)))
-    for f in files
-        _netstring!(io, relnames[f])
-        try
-            _netstring_bytes!(io, read(f))
-        catch
-            _netstring!(io, "unreadable")
+    for rel in files
+        _netstring!(io, rel)
+        f = joinpath(dir, rel)
+        if isfile(f)
+            try
+                _netstring_bytes!(io, read(f))
+            catch
+                _netstring!(io, "unreadable")
+            end
+        else
+            # `cargo package --list` also names files it would synthesize
+            # (Cargo.toml.orig, .cargo_vcs_info.json); record their absence.
+            _netstring!(io, "not-on-disk")
         end
     end
 
     # Recurse into the path dependencies this crate declares itself.
-    for child in _declared_path_dependencies(manifest)
+    for child in _declared_path_dependencies(joinpath(dir, "Cargo.toml"))
         _netstring!(io, "path-dep")
         _netstring!(io, child)
         _hash_path_crate!(io, joinpath(dir, child), seen)
     end
     return nothing
+end
+
+"""
+    CRATE_INPUT_VCS_DIRS
+
+Directories never treated as crate inputs by the directory-walk fallback of
+`crate_input_files`: build output and version-control metadata.
+"""
+const CRATE_INPUT_VCS_DIRS = String[
+    ".bzr", ".git", ".hg", ".jj", ".pijul", ".svn", "target",
+]
+
+"""
+    crate_input_files(dir::AbstractString) -> (strategy::String, files::Vector{String})
+
+The set of files that make up a crate, as relative `/`-separated paths, sorted,
+together with the name of the strategy that produced it.
+
+Cargo already knows exactly which files are package inputs — it honours
+`include`/`exclude`, `build = "..."`, `[lib] path`, `[[bin]] path`, modules
+pulled in by `#[path = "..."]` and everything else outside `src/` — so ask it:
+
+1. `cargo package --list --offline --allow-dirty` (no build, no network).
+2. If that fails (manifest is a bare workspace, no lockfile resolvable offline,
+   Cargo unavailable), fall back to walking the package directory for every
+   regular file, skipping `CRATE_INPUT_VCS_DIRS`.
+
+`Cargo.lock` is added whenever it exists, since `cargo package --list` omits it
+for a library crate while it still pins what gets built.
+
+The strategy name is returned, and hashed, so a file set obtained one way can
+never collide with one obtained the other way.
+"""
+function crate_input_files(dir::AbstractString)
+    dir = String(dir)
+    manifest = joinpath(dir, "Cargo.toml")
+    files = String[]
+    strategy = "walk"
+
+    if isfile(manifest)
+        listed = try
+            cmd = `$(cargo()) package --list --offline --allow-dirty --manifest-path $(manifest)`
+            read(pipeline(cmd; stderr = devnull), String)
+        catch
+            ""
+        end
+        entries = String[strip(l) for l in split(listed, '\n') if !isempty(strip(l))]
+        if !isempty(entries)
+            files = entries
+            strategy = "cargo-package-list"
+        end
+    end
+
+    if strategy == "walk"
+        for (root, dirs, names) in walkdir(dir)
+            filter!(d -> !(d in CRATE_INPUT_VCS_DIRS), dirs)
+            for n in names
+                push!(files, relpath(joinpath(root, n), dir))
+            end
+        end
+    end
+
+    isfile(joinpath(dir, "Cargo.lock")) && push!(files, "Cargo.lock")
+
+    files = String[replace(f, '\\' => '/') for f in files]
+    unique!(files)
+    sort!(files)
+    return strategy, files
 end
 
 function _declared_path_dependencies(manifest::AbstractString)::Vector{String}
@@ -540,6 +612,9 @@ so registry credentials such as `CARGO_REGISTRY_TOKEN` or
 `CARGO_REGISTRIES_<NAME>_TOKEN` can never enter an artifact key, be written to a
 cache directory name, or be logged.
 
+Build-script inputs (`CC`, `CFLAGS`, `PKG_CONFIG_PATH`, …) are a second,
+separately documented allowlist: see `ARTIFACT_BUILD_SCRIPT_ENV_NAMES`.
+
 This mirrors the environment-capture design PR #272 introduces in
 `src/manifest.jl`. That PR is not on `main` yet, so the rule is implemented here
 independently; Phase B of #278 unifies the two into this one place.
@@ -571,6 +646,46 @@ const ARTIFACT_BUILD_ENV_DENY_SUBSTRINGS = String[
 ]
 
 """
+    ARTIFACT_BUILD_SCRIPT_ENV_NAMES
+    ARTIFACT_BUILD_SCRIPT_ENV_PREFIXES
+    ARTIFACT_BUILD_SCRIPT_ENV_SUFFIXES
+
+The second allowlist: variables that reach the **build scripts** of
+dependencies. `cc-rs`, `pkg-config`, `cmake-rs` and `bindgen` all read the
+ambient environment of this process, so `CC`, `CFLAGS`, `PKG_CONFIG_PATH`,
+`LIBCLANG_PATH` and friends change the native objects that end up in the
+artifact while nothing about the Rust source changes.
+
+`ARTIFACT_BUILD_SCRIPT_ENV_SUFFIXES` covers the per-target convention
+(`x86_64_unknown_linux_gnu_CC`); the equivalent `CC_x86_64-unknown-linux-gnu`
+spelling, which `cc-rs` also accepts, is covered by the prefixes.
+
+!!! note "Best effort by construction"
+    No allowlist can be complete: a build script may read any variable it
+    likes, and the only exhaustive answer is Cargo's own fingerprint. This set
+    is therefore a safety net, not a proof. Phase B of #278 must treat a change
+    in the captured set as **rebuild**, never as grounds to reuse an artifact —
+    a captured variable that changed means "stale", while an unchanged captured
+    set does not by itself prove "fresh".
+"""
+const ARTIFACT_BUILD_SCRIPT_ENV_NAMES = String[
+    "AR", "ASFLAGS", "CC", "CFLAGS", "CPPFLAGS", "CXX", "CXXFLAGS",
+    "LD", "LDFLAGS", "NM", "RANLIB", "STRIP",
+]
+
+"See `ARTIFACT_BUILD_SCRIPT_ENV_NAMES`."
+const ARTIFACT_BUILD_SCRIPT_ENV_PREFIXES = String[
+    "AR_", "BINDGEN_", "CARGO_FEATURE_", "CC_", "CFLAGS_", "CLANG_", "CMAKE_",
+    "CXXFLAGS_", "CXX_", "HOST_", "LDFLAGS_", "LIBCLANG_", "LINKER_",
+    "PKG_CONFIG", "TARGET_",
+]
+
+"See `ARTIFACT_BUILD_SCRIPT_ENV_NAMES`."
+const ARTIFACT_BUILD_SCRIPT_ENV_SUFFIXES = String[
+    "_AR", "_CC", "_CFLAGS", "_CXX", "_CXXFLAGS", "_LDFLAGS", "_LINKER",
+]
+
+"""
     artifact_build_env_captured(name::AbstractString) -> Bool
 
 Whether `name` is a build variable that belongs in an artifact key. Secrets are
@@ -579,9 +694,11 @@ rejected before the allowlist is consulted; see
 """
 function artifact_build_env_captured(name::AbstractString)::Bool
     upper = uppercase(String(name))
+    # Secrets are rejected first, over both allowlists, unconditionally.
     for bad in ARTIFACT_BUILD_ENV_DENY_SUBSTRINGS
         occursin(bad, upper) && return false
     end
+    # Allowlist 1: Cargo/rustc inputs.
     upper in ARTIFACT_BUILD_ENV_NAMES && return true
     for prefix in ARTIFACT_BUILD_ENV_PREFIXES
         startswith(upper, prefix) && return true
@@ -590,6 +707,14 @@ function artifact_build_env_captured(name::AbstractString)::Bool
     if startswith(upper, "CARGO_TARGET_") &&
        (endswith(upper, "_RUSTFLAGS") || endswith(upper, "_LINKER"))
         return true
+    end
+    # Allowlist 2: build-script inputs (cc-rs, pkg-config, cmake, bindgen).
+    upper in ARTIFACT_BUILD_SCRIPT_ENV_NAMES && return true
+    for prefix in ARTIFACT_BUILD_SCRIPT_ENV_PREFIXES
+        startswith(upper, prefix) && return true
+    end
+    for suffix in ARTIFACT_BUILD_SCRIPT_ENV_SUFFIXES
+        endswith(upper, suffix) && return true
     end
     return false
 end

--- a/src/artifact_id.jl
+++ b/src/artifact_id.jl
@@ -1,0 +1,445 @@
+# Artifact identity — one record, one hash function.
+#
+# Background: issue #278. "Which compiled artifact corresponds to this request?"
+# is currently answered independently at eight call sites, each with its own
+# component list, its own concatenation format and its own truncation. That is
+# the structural cause of #247 (lossy monomorphization key), #252 (the `rustc`
+# in the key is not the `rustc` that compiles) and of the repeated Cargo cache
+# patches (dependency set, then build environment).
+#
+# This file is Phase A of the fix and is deliberately ADDITIVE: it introduces
+# the record and the hash function, but no call site has been migrated yet.
+# Phase B replaces the eight ad-hoc formulas with `artifact_key`.
+#
+# Design rules encoded here:
+#
+# 1. Exhaustive record. `ArtifactId` names every input that can change the
+#    produced binary. Adding an input means adding a field, once.
+# 2. Order preserving. Type parameters are a `Vector{Pair}` in declaration
+#    order, never a sorted set of values, so `pair<i32,i64>` and
+#    `pair<i64,i32>` can never share a key (#247).
+# 3. The compiler in the key is the compiler that runs. Versions come from
+#    `RustToolChain.rustc()` / `RustToolChain.cargo()`, not from a bare `rustc`
+#    on `PATH`, and a version that cannot be determined is an error rather than
+#    the string `"unknown"` (#252).
+# 4. Injective encoding. Every field is netstring-encoded (`<byte length>:<bytes>,`)
+#    so no two distinct records can produce the same byte stream. Naive
+#    concatenation ("a" * "bc" == "ab" * "c") is impossible by construction.
+# 5. One truncation rule, in one place. `artifact_key` is never truncated;
+#    `artifact_short_id` is the only truncation in the design, and it exists
+#    solely for human-readable names (library names, temp project directories).
+
+using SHA: sha256
+using RustToolChain: rustc, cargo
+
+"""
+    ARTIFACT_ID_SCHEMA_VERSION
+
+Version of the `ArtifactId` encoding itself. Bumping it invalidates every key
+produced by `artifact_key`, which is what you want whenever a field is added,
+removed or re-ordered.
+"""
+const ARTIFACT_ID_SCHEMA_VERSION = 1
+
+"""
+    ARTIFACT_SHORT_ID_LEN
+
+The single truncation rule of the artifact-identity design: `artifact_short_id`
+keeps this many leading hex characters (64 bits of the SHA-256 digest).
+
+Truncation is for human-readable names only — library names, temporary Cargo
+project directories, debug output. Lookup keys (`artifact_key`) are never
+truncated.
+"""
+const ARTIFACT_SHORT_ID_LEN = 16
+
+"""
+    ArtifactId
+
+Exhaustive record of everything that can change the binary produced for one
+compilation request. Construct it with keyword arguments; every field has a
+neutral default so a caller only names what applies to it.
+
+# Fields
+- `kind::String`: which pipeline produced the artifact (`"rustc"`, `"cargo"`,
+  `"crate"`, `"monomorphization"`, …). Keeps otherwise-identical inputs from
+  different pipelines apart.
+- `source::String`: the Rust source *after* `#[julia]` expansion and wrapping —
+  the text actually handed to the compiler.
+- `type_params::Vector{Pair{String, String}}`: generic parameter bindings in
+  **declaration order**, e.g. `["T" => "i32", "U" => "i64"]`. Order is part of
+  the identity (#247).
+- `target_triple::String`: target triple.
+- `codegen::Vector{Pair{String, String}}`: codegen options (optimization level,
+  debug info, release/debug profile, LTO, …), in a caller-fixed order.
+- `cfg::Vector{String}`: `--cfg` snapshot / feature-gate state.
+- `dependencies::Vector{String}`: canonical, sorted description of the
+  dependency set (see [`artifact_dependency_strings`](@ref)).
+- `features::Vector{String}`: crate features enabled for the build.
+- `build_env::Vector{Pair{String, String}}`: build environment that reaches the
+  compiler (`RUSTFLAGS`, `CARGO_*`, …), sorted by name.
+- `toolchain::String`: [`toolchain_fingerprint`](@ref) — extractor digest,
+  manifest schema, `rustcall_core` / `juliacall_macros` sources.
+- `compiler::String`: identity of the compiler that actually runs, from
+  `RustToolChain` (see [`artifact_compiler_identity`](@ref)).
+- `extra::Vector{Pair{String, String}}`: escape hatch for pipeline-specific
+  inputs that do not yet deserve a field of their own.
+
+Two `ArtifactId`s are `==` exactly when they encode identically, which is
+exactly when [`artifact_key`](@ref) agrees.
+"""
+struct ArtifactId
+    kind::String
+    source::String
+    type_params::Vector{Pair{String, String}}
+    target_triple::String
+    codegen::Vector{Pair{String, String}}
+    cfg::Vector{String}
+    dependencies::Vector{String}
+    features::Vector{String}
+    build_env::Vector{Pair{String, String}}
+    toolchain::String
+    compiler::String
+    extra::Vector{Pair{String, String}}
+end
+
+"""
+    ArtifactId(; kind, source, ...) -> ArtifactId
+
+Keyword constructor. `toolchain` defaults to [`toolchain_fingerprint`](@ref) and
+`compiler` to [`artifact_compiler_identity`](@ref); pass them explicitly only in
+tests that need to vary them.
+"""
+function ArtifactId(;
+    kind::AbstractString,
+    source::AbstractString = "",
+    type_params = Pair{String, String}[],
+    target_triple::AbstractString = "",
+    codegen = Pair{String, String}[],
+    cfg = String[],
+    dependencies = String[],
+    features = String[],
+    build_env = Pair{String, String}[],
+    toolchain::AbstractString = toolchain_fingerprint(),
+    compiler::AbstractString = artifact_compiler_identity(),
+    extra = Pair{String, String}[],
+)
+    return ArtifactId(
+        String(kind),
+        String(source),
+        _pairs(type_params),
+        String(target_triple),
+        _pairs(codegen),
+        _strings(cfg),
+        _strings(dependencies),
+        _strings(features),
+        _pairs(build_env),
+        String(toolchain),
+        String(compiler),
+        _pairs(extra),
+    )
+end
+
+_strings(xs) = String[string(x) for x in xs]
+
+function _pairs(xs)
+    out = Pair{String, String}[]
+    for x in xs
+        if x isa Pair
+            push!(out, string(first(x)) => string(last(x)))
+        else
+            throw(ArgumentError("expected a Pair, got $(typeof(x))"))
+        end
+    end
+    return out
+end
+
+function Base.:(==)(a::ArtifactId, b::ArtifactId)
+    return artifact_encoding(a) == artifact_encoding(b)
+end
+
+Base.hash(id::ArtifactId, h::UInt) = hash(artifact_encoding(id), h)
+
+function Base.show(io::IO, id::ArtifactId)
+    print(io, "ArtifactId(", id.kind, ", ", artifact_short_id(id), ")")
+end
+
+# ----------------------------------------------------------------------------
+# Compiler identity (#252)
+# ----------------------------------------------------------------------------
+
+const _ARTIFACT_COMPILER_IDENTITY = Ref{String}("")
+const _ARTIFACT_COMPILER_LOCK = ReentrantLock()
+
+"""
+    artifact_compiler_identity() -> String
+
+Identity of the toolchain that actually compiles: the `--version` strings of
+`RustToolChain.rustc()` and `RustToolChain.cargo()` — the very commands
+`src/compiler.jl` and `src/cargobuild.jl` invoke.
+
+This is deliberately *not* `_get_rustc_version()` in `src/cache.jl`, which
+shells out to a bare `rustc` from `PATH` and degrades to `"unknown"`; upgrading
+the real toolchain then need not invalidate anything (#252). Here a version that
+cannot be determined throws a [`RustError`](@ref) instead, because an
+unidentifiable compiler cannot produce a trustworthy cache key.
+
+The result is memoized for the session.
+"""
+function artifact_compiler_identity()::String
+    lock(_ARTIFACT_COMPILER_LOCK) do
+        if isempty(_ARTIFACT_COMPILER_IDENTITY[])
+            rustc_ver = _tool_version(rustc, "rustc")
+            cargo_ver = _tool_version(cargo, "cargo")
+            _ARTIFACT_COMPILER_IDENTITY[] = string("rustc=", rustc_ver, "\ncargo=", cargo_ver)
+        end
+        return _ARTIFACT_COMPILER_IDENTITY[]
+    end
+end
+
+function _tool_version(getcmd, name::AbstractString)::String
+    local out
+    try
+        out = strip(read(`$(getcmd()) --version`, String))
+    catch e
+        throw(RustError(
+            "Cannot determine the version of `$(name)` via RustToolChain; " *
+            "an unidentifiable compiler cannot be part of an artifact key (#252).",
+            Int32(0), e))
+    end
+    if isempty(out)
+        throw(RustError(
+            "`$(name) --version` produced no output; an unidentifiable compiler " *
+            "cannot be part of an artifact key (#252)."))
+    end
+    return String(out)
+end
+
+# ----------------------------------------------------------------------------
+# Injective encoding
+# ----------------------------------------------------------------------------
+
+# Netstring: `<byte length>:<bytes>,`. Self-delimiting, so a stream of them is
+# uniquely decodable and the encoding is injective. This is what makes
+# `"a" * "bc"` and `"ab" * "c"` distinguishable ("1:a,2:bc," vs "2:ab,1:c,").
+function _netstring!(io::IO, s::AbstractString)
+    bytes = codeunits(String(s))
+    print(io, length(bytes))
+    write(io, UInt8(':'))
+    write(io, bytes)
+    write(io, UInt8(','))
+    return nothing
+end
+
+function _netstrings!(io::IO, xs::Vector{String})
+    _netstring!(io, string(length(xs)))
+    for x in xs
+        _netstring!(io, x)
+    end
+    return nothing
+end
+
+function _netpairs!(io::IO, xs::Vector{Pair{String, String}})
+    _netstring!(io, string(length(xs)))
+    for (k, v) in xs
+        _netstring!(io, k)
+        _netstring!(io, v)
+    end
+    return nothing
+end
+
+"""
+    artifact_encoding(id::ArtifactId) -> Vector{UInt8}
+
+Canonical, injective byte encoding of `id`: a fixed field order, every field
+netstring-framed, prefixed by [`ARTIFACT_ID_SCHEMA_VERSION`](@ref). Distinct
+records always encode to distinct bytes.
+
+Exposed mainly so tests can assert injectivity directly; production code wants
+[`artifact_key`](@ref).
+"""
+function artifact_encoding(id::ArtifactId)::Vector{UInt8}
+    io = IOBuffer()
+    _netstring!(io, "rustcall.artifact_id/v$(ARTIFACT_ID_SCHEMA_VERSION)")
+    _netstring!(io, id.kind)
+    _netstring!(io, id.source)
+    _netpairs!(io, id.type_params)
+    _netstring!(io, id.target_triple)
+    _netpairs!(io, id.codegen)
+    _netstrings!(io, id.cfg)
+    _netstrings!(io, id.dependencies)
+    _netstrings!(io, id.features)
+    _netpairs!(io, id.build_env)
+    _netstring!(io, id.toolchain)
+    _netstring!(io, id.compiler)
+    _netpairs!(io, id.extra)
+    return take!(io)
+end
+
+"""
+    artifact_key(id::ArtifactId) -> String
+
+**The** artifact-identity function: the SHA-256 of the canonical encoding of
+`id`, as 64 lowercase hex characters.
+
+Never truncated — the lookup key carries the full digest. Use
+[`artifact_short_id`](@ref) when you need a name a human will read.
+
+```julia
+id = RustCall.ArtifactId(kind = "rustc", source = code, target_triple = triple)
+key = RustCall.artifact_key(id)
+```
+"""
+artifact_key(id::ArtifactId)::String = bytes2hex(sha256(artifact_encoding(id)))
+
+"""
+    artifact_key(; kwargs...) -> String
+
+Convenience form: build an [`ArtifactId`](@ref) from the keyword arguments and
+hash it.
+"""
+artifact_key(; kwargs...) = artifact_key(ArtifactId(; kwargs...))
+
+"""
+    artifact_short_id(id::ArtifactId, n::Int = ARTIFACT_SHORT_ID_LEN) -> String
+    artifact_short_id(key::AbstractString, n::Int = ARTIFACT_SHORT_ID_LEN) -> String
+
+The one place in the design where a key is truncated: the first `n` hex
+characters of [`artifact_key`](@ref), for human-readable names only (library
+names, temporary Cargo project directories, log lines).
+
+Never use the result as a cache lookup key: correctness must depend on the full
+digest.
+"""
+artifact_short_id(id::ArtifactId, n::Int = ARTIFACT_SHORT_ID_LEN) =
+    artifact_short_id(artifact_key(id), n)
+
+function artifact_short_id(key::AbstractString, n::Int = ARTIFACT_SHORT_ID_LEN)
+    n > 0 || throw(ArgumentError("short id length must be positive, got $(n)"))
+    n <= length(key) || throw(ArgumentError(
+        "short id length $(n) exceeds key length $(length(key))"))
+    return String(first(key, n))
+end
+
+# ----------------------------------------------------------------------------
+# Canonicalization helpers for the record's collection fields
+# ----------------------------------------------------------------------------
+
+"""
+    artifact_dependency_strings(deps) -> Vector{String}
+
+Canonical, sorted string form of a dependency set, suitable for the
+`dependencies` field of [`ArtifactId`](@ref).
+
+Accepts anything with the `DependencySpec` shape (`name`, `version`, `features`,
+`git`, `path`) as well as plain strings, so it can be used before
+`dependencies.jl` types are in scope. Every component is named in the output, so
+distinct specs never collapse onto the same string.
+"""
+function artifact_dependency_strings(deps)::Vector{String}
+    out = String[]
+    for d in deps
+        if d isa AbstractString
+            push!(out, String(d))
+        elseif hasproperty(d, :name)
+            version = hasproperty(d, :version) ? getproperty(d, :version) : nothing
+            git = hasproperty(d, :git) ? getproperty(d, :git) : nothing
+            path = hasproperty(d, :path) ? getproperty(d, :path) : nothing
+            feats = hasproperty(d, :features) ? collect(String.(getproperty(d, :features))) : String[]
+            push!(out, string(
+                "name=", getproperty(d, :name),
+                " version=", version === nothing ? "" : version,
+                " features=[", join(sort(feats), ","), "]",
+                " git=", git === nothing ? "" : git,
+                " path=", path === nothing ? "" : path,
+            ))
+        else
+            push!(out, string(d))
+        end
+    end
+    return sort!(out)
+end
+
+"""
+    artifact_type_params(names, types) -> Vector{Pair{String, String}}
+
+Build the `type_params` field from the **declared** parameter names and the
+concrete types bound to them, preserving declaration order.
+
+This is the ordered replacement for the sorted-values key at
+`src/generics.jl:191-193`: sorting the values discards which parameter got which
+type, so `Dict(:T => Int32, :U => Int64)` and `Dict(:T => Int64, :U => Int32)`
+produce the same monomorphization key today (#247).
+"""
+function artifact_type_params(names, types)::Vector{Pair{String, String}}
+    names_v = collect(names)
+    types_v = collect(types)
+    length(names_v) == length(types_v) || throw(ArgumentError(
+        "got $(length(names_v)) parameter names but $(length(types_v)) types"))
+    return Pair{String, String}[string(n) => string(t) for (n, t) in zip(names_v, types_v)]
+end
+
+"""
+    artifact_type_params(param_order, bindings::AbstractDict) -> Vector{Pair{String, String}}
+
+As above, but looking each parameter of `param_order` up in `bindings`
+(a `Symbol`-keyed mapping such as the `type_params` argument of
+`monomorphize_function`). The declared order wins; the dictionary's iteration
+order is irrelevant.
+"""
+function artifact_type_params(param_order, bindings::AbstractDict)::Vector{Pair{String, String}}
+    out = Pair{String, String}[]
+    for p in param_order
+        key = p isa Symbol ? p : Symbol(string(p))
+        haskey(bindings, key) || throw(ArgumentError(
+            "no binding for type parameter $(key)"))
+        push!(out, string(key) => string(bindings[key]))
+    end
+    return out
+end
+
+"""
+    ARTIFACT_BUILD_ENV_VARS
+
+Environment variables known to change the binary a build produces. Anything
+added here is folded into every key computed with [`artifact_build_env`](@ref),
+once, instead of being patched into individual formulas.
+"""
+const ARTIFACT_BUILD_ENV_VARS = String[
+    "CARGO_BUILD_RUSTFLAGS",
+    "CARGO_BUILD_TARGET",
+    "CARGO_ENCODED_RUSTFLAGS",
+    "CARGO_PROFILE_RELEASE_LTO",
+    "CARGO_TARGET_DIR",
+    "RUSTC_WRAPPER",
+    "RUSTDOCFLAGS",
+    "RUSTFLAGS",
+]
+
+"""
+    artifact_build_env(names = ARTIFACT_BUILD_ENV_VARS; env = ENV) -> Vector{Pair{String, String}}
+
+Snapshot of the build environment variables that reach the compiler, sorted by
+name and with absent variables recorded as absent (rather than silently
+dropped). Suitable for the `build_env` field of [`ArtifactId`](@ref).
+"""
+function artifact_build_env(names = ARTIFACT_BUILD_ENV_VARS; env = ENV)
+    out = Pair{String, String}[]
+    for n in sort(collect(String.(names)))
+        push!(out, n => get(env, n, ""))
+    end
+    return out
+end
+
+"""
+    artifact_codegen_options(compiler) -> Vector{Pair{String, String}}
+
+Codegen options of a `RustCompiler` in a fixed order, for the `codegen` field of
+[`ArtifactId`](@ref).
+"""
+function artifact_codegen_options(compiler)
+    return Pair{String, String}[
+        "opt_level" => string(compiler.optimization_level),
+        "debug_info" => string(compiler.emit_debug_info),
+    ]
+end

--- a/src/artifact_id.jl
+++ b/src/artifact_id.jl
@@ -30,6 +30,7 @@
 #    solely for human-readable names (library names, temp project directories).
 
 using SHA: sha256
+using TOML
 using RustToolChain: rustc, cargo
 
 """
@@ -74,19 +75,19 @@ neutral default so a caller only names what applies to it.
   debug info, release/debug profile, LTO, …), in a caller-fixed order.
 - `cfg::Vector{String}`: `--cfg` snapshot / feature-gate state.
 - `dependencies::Vector{String}`: canonical, sorted description of the
-  dependency set (see [`artifact_dependency_strings`](@ref)).
+  dependency set (see `artifact_dependency_strings`).
 - `features::Vector{String}`: crate features enabled for the build.
 - `build_env::Vector{Pair{String, String}}`: build environment that reaches the
   compiler (`RUSTFLAGS`, `CARGO_*`, …), sorted by name.
-- `toolchain::String`: [`toolchain_fingerprint`](@ref) — extractor digest,
+- `toolchain::String`: `toolchain_fingerprint` — extractor digest,
   manifest schema, `rustcall_core` / `juliacall_macros` sources.
 - `compiler::String`: identity of the compiler that actually runs, from
-  `RustToolChain` (see [`artifact_compiler_identity`](@ref)).
+  `RustToolChain` (see `artifact_compiler_identity`).
 - `extra::Vector{Pair{String, String}}`: escape hatch for pipeline-specific
   inputs that do not yet deserve a field of their own.
 
 Two `ArtifactId`s are `==` exactly when they encode identically, which is
-exactly when [`artifact_key`](@ref) agrees.
+exactly when `artifact_key` agrees.
 """
 struct ArtifactId
     kind::String
@@ -106,8 +107,8 @@ end
 """
     ArtifactId(; kind, source, ...) -> ArtifactId
 
-Keyword constructor. `toolchain` defaults to [`toolchain_fingerprint`](@ref) and
-`compiler` to [`artifact_compiler_identity`](@ref); pass them explicitly only in
+Keyword constructor. `toolchain` defaults to `toolchain_fingerprint` and
+`compiler` to `artifact_compiler_identity`; pass them explicitly only in
 tests that need to vary them.
 """
 function ArtifactId(;
@@ -181,7 +182,7 @@ Identity of the toolchain that actually compiles: the `--version` strings of
 This is deliberately *not* `_get_rustc_version()` in `src/cache.jl`, which
 shells out to a bare `rustc` from `PATH` and degrades to `"unknown"`; upgrading
 the real toolchain then need not invalidate anything (#252). Here a version that
-cannot be determined throws a [`RustError`](@ref) instead, because an
+cannot be determined throws a `RustError` instead, because an
 unidentifiable compiler cannot produce a trustworthy cache key.
 
 The result is memoized for the session.
@@ -231,6 +232,15 @@ function _netstring!(io::IO, s::AbstractString)
     return nothing
 end
 
+# Same framing for raw bytes (file contents), which need not be valid UTF-8.
+function _netstring_bytes!(io::IO, bytes::AbstractVector{UInt8})
+    print(io, length(bytes))
+    write(io, UInt8(':'))
+    write(io, bytes)
+    write(io, UInt8(','))
+    return nothing
+end
+
 function _netstrings!(io::IO, xs::Vector{String})
     _netstring!(io, string(length(xs)))
     for x in xs
@@ -252,11 +262,11 @@ end
     artifact_encoding(id::ArtifactId) -> Vector{UInt8}
 
 Canonical, injective byte encoding of `id`: a fixed field order, every field
-netstring-framed, prefixed by [`ARTIFACT_ID_SCHEMA_VERSION`](@ref). Distinct
+netstring-framed, prefixed by `ARTIFACT_ID_SCHEMA_VERSION`. Distinct
 records always encode to distinct bytes.
 
 Exposed mainly so tests can assert injectivity directly; production code wants
-[`artifact_key`](@ref).
+`artifact_key`.
 """
 function artifact_encoding(id::ArtifactId)::Vector{UInt8}
     io = IOBuffer()
@@ -283,7 +293,7 @@ end
 `id`, as 64 lowercase hex characters.
 
 Never truncated — the lookup key carries the full digest. Use
-[`artifact_short_id`](@ref) when you need a name a human will read.
+`artifact_short_id` when you need a name a human will read.
 
 ```julia
 id = RustCall.ArtifactId(kind = "rustc", source = code, target_triple = triple)
@@ -295,7 +305,7 @@ artifact_key(id::ArtifactId)::String = bytes2hex(sha256(artifact_encoding(id)))
 """
     artifact_key(; kwargs...) -> String
 
-Convenience form: build an [`ArtifactId`](@ref) from the keyword arguments and
+Convenience form: build an `ArtifactId` from the keyword arguments and
 hash it.
 """
 artifact_key(; kwargs...) = artifact_key(ArtifactId(; kwargs...))
@@ -305,7 +315,7 @@ artifact_key(; kwargs...) = artifact_key(ArtifactId(; kwargs...))
     artifact_short_id(key::AbstractString, n::Int = ARTIFACT_SHORT_ID_LEN) -> String
 
 The one place in the design where a key is truncated: the first `n` hex
-characters of [`artifact_key`](@ref), for human-readable names only (library
+characters of `artifact_key`, for human-readable names only (library
 names, temporary Cargo project directories, log lines).
 
 Never use the result as a cache lookup key: correctness must depend on the full
@@ -329,35 +339,150 @@ end
     artifact_dependency_strings(deps) -> Vector{String}
 
 Canonical, sorted string form of a dependency set, suitable for the
-`dependencies` field of [`ArtifactId`](@ref).
+`dependencies` field of `ArtifactId`.
 
 Accepts anything with the `DependencySpec` shape (`name`, `version`, `features`,
 `git`, `path`) as well as plain strings, so it can be used before
-`dependencies.jl` types are in scope. Every component is named in the output, so
-distinct specs never collapse onto the same string.
+`dependencies.jl` types are in scope. Every component is netstring-framed, so
+distinct specs can never collapse onto the same string.
+
+# How each kind of dependency is identified
+
+- **Registry** dependencies: name, version requirement and feature set. The
+  *resolved* version from `Cargo.lock` is deliberately out of scope for Phase A
+  (see #256); folding lockfile resolution into the key is a Phase B item.
+- **Git** dependencies: name and the git URL (plus rev/branch/tag when the spec
+  carries them). Resolving a floating branch to a commit is likewise Phase B.
+- **Local path** dependencies: a content digest of the crate's inputs (see
+  `artifact_path_dependency_digest`), **not** the path text. Editing a
+  local dependency's sources therefore changes the key, while moving the
+  checkout to a different directory does not — cache hits survive a move,
+  which is the point of hashing content rather than location.
 """
 function artifact_dependency_strings(deps)::Vector{String}
     out = String[]
     for d in deps
+        io = IOBuffer()
         if d isa AbstractString
-            push!(out, String(d))
+            _netstring!(io, "raw")
+            _netstring!(io, String(d))
         elseif hasproperty(d, :name)
             version = hasproperty(d, :version) ? getproperty(d, :version) : nothing
             git = hasproperty(d, :git) ? getproperty(d, :git) : nothing
             path = hasproperty(d, :path) ? getproperty(d, :path) : nothing
             feats = hasproperty(d, :features) ? collect(String.(getproperty(d, :features))) : String[]
-            push!(out, string(
-                "name=", getproperty(d, :name),
-                " version=", version === nothing ? "" : version,
-                " features=[", join(sort(feats), ","), "]",
-                " git=", git === nothing ? "" : git,
-                " path=", path === nothing ? "" : path,
-            ))
+            _netstring!(io, "dep")
+            _netstring!(io, string(getproperty(d, :name)))
+            _netstring!(io, version === nothing ? "" : string(version))
+            _netstrings!(io, sort(feats))
+            _netstring!(io, git === nothing ? "" : string(git))
+            # Local paths contribute their content, never their location.
+            _netstring!(io, path === nothing ? "" : artifact_path_dependency_digest(string(path)))
         else
-            push!(out, string(d))
+            _netstring!(io, "other")
+            _netstring!(io, string(d))
         end
+        push!(out, String(take!(io)))
     end
     return sort!(out)
+end
+
+"""
+    artifact_path_dependency_digest(path::AbstractString) -> String
+
+Deterministic SHA-256 digest of the *inputs* of a local path dependency: its
+`Cargo.toml` plus every file under `src/`, by sorted relative path with
+contents, recursing into the path dependencies that `Cargo.toml` itself
+declares.
+
+Only content is hashed — never the absolute location — so an identical crate in
+a differently named directory yields the same digest and a checkout move does
+not invalidate the cache. `target/` is skipped. A path that does not exist, or a
+`Cargo.toml` that cannot be parsed, is recorded as such rather than silently
+ignored, and dependency cycles terminate at the first repeat.
+
+Without this, a `path = "..."` dependency is identified by its path text alone
+and editing its sources leaves the artifact key unchanged.
+"""
+function artifact_path_dependency_digest(path::AbstractString)::String
+    io = IOBuffer()
+    _hash_path_crate!(io, String(path), Set{String}())
+    return bytes2hex(sha256(take!(io)))
+end
+
+function _hash_path_crate!(io::IO, path::AbstractString, seen::Set{String})
+    dir = try
+        abspath(String(path))
+    catch
+        String(path)
+    end
+    if !isdir(dir)
+        _netstring!(io, "missing-crate")
+        return nothing
+    end
+    canonical = try
+        realpath(dir)
+    catch
+        dir
+    end
+    if canonical in seen
+        _netstring!(io, "cycle")
+        return nothing
+    end
+    push!(seen, canonical)
+
+    _netstring!(io, "crate")
+    files = String[]
+    manifest = joinpath(dir, "Cargo.toml")
+    isfile(manifest) && push!(files, manifest)
+    srcdir = joinpath(dir, "src")
+    if isdir(srcdir)
+        for (root, dirs, names) in walkdir(srcdir)
+            filter!(!isequal("target"), dirs)
+            for n in names
+                push!(files, joinpath(root, n))
+            end
+        end
+    end
+    relnames = Dict(f => replace(relpath(f, dir), '\\' => '/') for f in files)
+    sort!(files, by = f -> relnames[f])
+    _netstring!(io, string(length(files)))
+    for f in files
+        _netstring!(io, relnames[f])
+        try
+            _netstring_bytes!(io, read(f))
+        catch
+            _netstring!(io, "unreadable")
+        end
+    end
+
+    # Recurse into the path dependencies this crate declares itself.
+    for child in _declared_path_dependencies(manifest)
+        _netstring!(io, "path-dep")
+        _netstring!(io, child)
+        _hash_path_crate!(io, joinpath(dir, child), seen)
+    end
+    return nothing
+end
+
+function _declared_path_dependencies(manifest::AbstractString)::Vector{String}
+    isfile(manifest) || return String[]
+    parsed = try
+        TOML.parsefile(manifest)
+    catch
+        return String["unparsable-manifest"]
+    end
+    out = String[]
+    for section in ("dependencies", "dev-dependencies", "build-dependencies")
+        table = get(parsed, section, nothing)
+        table isa AbstractDict || continue
+        for (_, spec) in table
+            spec isa AbstractDict || continue
+            p = get(spec, "path", nothing)
+            p isa AbstractString && push!(out, String(p))
+        end
+    end
+    return sort!(unique!(out))
 end
 
 """
@@ -399,43 +524,124 @@ function artifact_type_params(param_order, bindings::AbstractDict)::Vector{Pair{
 end
 
 """
-    ARTIFACT_BUILD_ENV_VARS
+    ARTIFACT_BUILD_ENV_PREFIXES
+    ARTIFACT_BUILD_ENV_NAMES
+    ARTIFACT_BUILD_ENV_DENY_SUBSTRINGS
 
-Environment variables known to change the binary a build produces. Anything
-added here is folded into every key computed with [`artifact_build_env`](@ref),
-once, instead of being patched into individual formulas.
+Which environment variables can change the binary a build produces, tracked by
+**prefix and allowlist** rather than by enumerating individual keys: every
+`CARGO_PROFILE_*` override (`_OPT_LEVEL`, `_CODEGEN_UNITS`, `_PANIC`, `_DEBUG`,
+`_STRIP`, `_LTO`, …) changes generated code, and listing them one by one is the
+same "remember to patch every formula" mistake #278 is about.
+
+`ARTIFACT_BUILD_ENV_DENY_SUBSTRINGS` is applied **first** and unconditionally: a
+name containing any of those substrings (case-insensitively) is never captured,
+so registry credentials such as `CARGO_REGISTRY_TOKEN` or
+`CARGO_REGISTRIES_<NAME>_TOKEN` can never enter an artifact key, be written to a
+cache directory name, or be logged.
+
+This mirrors the environment-capture design PR #272 introduces in
+`src/manifest.jl`. That PR is not on `main` yet, so the rule is implemented here
+independently; Phase B of #278 unifies the two into this one place.
 """
-const ARTIFACT_BUILD_ENV_VARS = String[
-    "CARGO_BUILD_RUSTFLAGS",
-    "CARGO_BUILD_TARGET",
+const ARTIFACT_BUILD_ENV_PREFIXES = String[
+    "CARGO_BUILD_",
+    "CARGO_CFG_",
     "CARGO_ENCODED_RUSTFLAGS",
-    "CARGO_PROFILE_RELEASE_LTO",
-    "CARGO_TARGET_DIR",
+    "CARGO_PROFILE_",
+]
+
+"See `ARTIFACT_BUILD_ENV_PREFIXES`."
+const ARTIFACT_BUILD_ENV_NAMES = String[
+    "RUSTC",
     "RUSTC_WRAPPER",
     "RUSTDOCFLAGS",
     "RUSTFLAGS",
+    "RUSTUP_TOOLCHAIN",
+]
+
+"See `ARTIFACT_BUILD_ENV_PREFIXES`."
+const ARTIFACT_BUILD_ENV_DENY_SUBSTRINGS = String[
+    "AUTH",
+    "CREDENTIAL",
+    "KEY",
+    "PASSWORD",
+    "SECRET",
+    "TOKEN",
 ]
 
 """
-    artifact_build_env(names = ARTIFACT_BUILD_ENV_VARS; env = ENV) -> Vector{Pair{String, String}}
+    artifact_build_env_captured(name::AbstractString) -> Bool
 
-Snapshot of the build environment variables that reach the compiler, sorted by
-name and with absent variables recorded as absent (rather than silently
-dropped). Suitable for the `build_env` field of [`ArtifactId`](@ref).
+Whether `name` is a build variable that belongs in an artifact key. Secrets are
+rejected before the allowlist is consulted; see
+`ARTIFACT_BUILD_ENV_PREFIXES`.
 """
-function artifact_build_env(names = ARTIFACT_BUILD_ENV_VARS; env = ENV)
-    out = Pair{String, String}[]
-    for n in sort(collect(String.(names)))
-        push!(out, n => get(env, n, ""))
+function artifact_build_env_captured(name::AbstractString)::Bool
+    upper = uppercase(String(name))
+    for bad in ARTIFACT_BUILD_ENV_DENY_SUBSTRINGS
+        occursin(bad, upper) && return false
     end
-    return out
+    upper in ARTIFACT_BUILD_ENV_NAMES && return true
+    for prefix in ARTIFACT_BUILD_ENV_PREFIXES
+        startswith(upper, prefix) && return true
+    end
+    # CARGO_TARGET_<TRIPLE>_RUSTFLAGS / _LINKER, per-target overrides.
+    if startswith(upper, "CARGO_TARGET_") &&
+       (endswith(upper, "_RUSTFLAGS") || endswith(upper, "_LINKER"))
+        return true
+    end
+    return false
+end
+
+"""
+    ARTIFACT_ENV_ABSENT
+
+Marker recorded for a build variable that is **not set**, as opposed to one set
+to the empty string. The two are different to Cargo — an empty `RUSTFLAGS`
+suppresses the rustflags a Cargo config would otherwise contribute — so they
+must never share a key. A variable that is set is recorded as
+`"present:" * value`, which can never equal this marker.
+"""
+const ARTIFACT_ENV_ABSENT = "absent"
+
+_artifact_env_value(env, name) =
+    haskey(env, name) ? string("present:", env[name]) : ARTIFACT_ENV_ABSENT
+
+"""
+    artifact_build_env(; env = ENV) -> Vector{Pair{String, String}}
+
+Snapshot of every build variable in `env` that
+`artifact_build_env_captured` accepts, sorted by name so the encoding is
+deterministic. Values carry their presence explicitly (see
+`ARTIFACT_ENV_ABSENT`). Suitable for the `build_env` field of
+`ArtifactId`.
+"""
+function artifact_build_env(; env = ENV)
+    names = String[String(k) for k in keys(env) if artifact_build_env_captured(String(k))]
+    sort!(names)
+    return Pair{String, String}[n => _artifact_env_value(env, n) for n in names]
+end
+
+"""
+    artifact_build_env(names; env = ENV) -> Vector{Pair{String, String}}
+
+As above but for an explicit list of variable names, sorted, with absent
+variables recorded as `ARTIFACT_ENV_ABSENT` rather than dropped (so
+"unset" and "set to the empty string" produce different keys). Names that
+`artifact_build_env_captured` rejects — anything that looks like a
+credential — are skipped even when named explicitly.
+"""
+function artifact_build_env(names; env = ENV)
+    wanted = String[n for n in sort(collect(String.(names))) if artifact_build_env_captured(n)]
+    return Pair{String, String}[n => _artifact_env_value(env, n) for n in wanted]
 end
 
 """
     artifact_codegen_options(compiler) -> Vector{Pair{String, String}}
 
 Codegen options of a `RustCompiler` in a fixed order, for the `codegen` field of
-[`ArtifactId`](@ref).
+`ArtifactId`.
 """
 function artifact_codegen_options(compiler)
     return Pair{String, String}[

--- a/src/artifact_id.jl
+++ b/src/artifact_id.jl
@@ -177,7 +177,9 @@ const _ARTIFACT_COMPILER_LOCK = ReentrantLock()
 
 Identity of the toolchain that actually compiles: the `--version` strings of
 `RustToolChain.rustc()` and `RustToolChain.cargo()` — the very commands
-`src/compiler.jl` and `src/cargobuild.jl` invoke.
+`src/compiler.jl` and `src/cargobuild.jl` invoke — together with any
+`RUSTC_WRAPPER` / `RUSTC_WORKSPACE_WRAPPER` standing between Cargo and rustc,
+since a wrapper changes what is produced.
 
 This is deliberately *not* `_get_rustc_version()` in `src/cache.jl`, which
 shells out to a bare `rustc` from `PATH` and degrades to `"unknown"`; upgrading
@@ -192,7 +194,16 @@ function artifact_compiler_identity()::String
         if isempty(_ARTIFACT_COMPILER_IDENTITY[])
             rustc_ver = _tool_version(rustc, "rustc")
             cargo_ver = _tool_version(cargo, "cargo")
-            _ARTIFACT_COMPILER_IDENTITY[] = string("rustc=", rustc_ver, "\ncargo=", cargo_ver)
+            # A wrapper stands between Cargo and rustc and can change what is
+            # produced (sccache, clippy-driver, a custom shim), so it is part
+            # of the identity of the compiler that actually runs.
+            wrapper = get(ENV, "RUSTC_WRAPPER", "")
+            ws_wrapper = get(ENV, "RUSTC_WORKSPACE_WRAPPER", "")
+            _ARTIFACT_COMPILER_IDENTITY[] = string(
+                "rustc=", rustc_ver,
+                "\ncargo=", cargo_ver,
+                "\nrustc_wrapper=", wrapper,
+                "\nrustc_workspace_wrapper=", ws_wrapper)
         end
         return _ARTIFACT_COMPILER_IDENTITY[]
     end
@@ -498,14 +509,24 @@ function crate_content_digest(dir::AbstractString)::String
 end
 
 """
+    CRATE_INPUT_VCS_DIRS_ANY_LEVEL
+
+Version-control metadata directories, never a crate input at any depth.
+"""
+const CRATE_INPUT_VCS_DIRS_ANY_LEVEL = String[
+    ".bzr", ".git", ".hg", ".jj", ".pijul", ".svn",
+]
+
+"""
     CRATE_INPUT_VCS_DIRS
 
-Directories never treated as crate inputs: build output and version-control
-metadata. Everything else under a package directory is an input.
+Directories not treated as crate inputs: version-control metadata, plus
+Cargo's build output. `target` is excluded **only at the package root** —
+`src/target/mod.rs` is ordinary source, not build output — while the VCS
+directories are excluded at any depth. Everything else under a package
+directory is an input.
 """
-const CRATE_INPUT_VCS_DIRS = String[
-    ".bzr", ".git", ".hg", ".jj", ".pijul", ".svn", "target",
-]
+const CRATE_INPUT_VCS_DIRS = String[CRATE_INPUT_VCS_DIRS_ANY_LEVEL..., "target"]
 
 """
     crate_input_files(dir::AbstractString) -> (strategy::String, files::Vector{String})
@@ -528,7 +549,15 @@ function crate_input_files(dir::AbstractString)
     dir = String(dir)
     files = String[]
     for (root, dirs, names) in walkdir(dir)
-        filter!(d -> !(d in CRATE_INPUT_VCS_DIRS), dirs)
+        # `target/` is Cargo's build output only at the package root: a module
+        # directory named `src/target/` is ordinary source and must be hashed.
+        # VCS metadata, by contrast, is never an input at any depth.
+        at_root = _canonical_dir(root) == _canonical_dir(dir)
+        filter!(dirs) do d
+            d in CRATE_INPUT_VCS_DIRS_ANY_LEVEL && return false
+            at_root && d == "target" && return false
+            return true
+        end
         for n in names
             push!(files, relpath(joinpath(root, n), dir))
         end
@@ -645,6 +674,11 @@ table in `manifest`, including target-specific tables
 `{ workspace = true }` entries resolved against the nearest
 `[workspace.dependencies]`, searched in this manifest and then upwards.
 
+Returned paths are what the caller should join to the manifest's own directory.
+An inherited path is relative to the *workspace root manifest*, not to the
+member, so it is returned already resolved as an absolute path (`joinpath`
+against the member directory then leaves it unchanged).
+
 Used only when `cargo tree` cannot answer; see `local_path_dependency_dirs`.
 """
 function _declared_path_dependencies(manifest::AbstractString)::Vector{String}
@@ -656,7 +690,7 @@ function _declared_path_dependencies(manifest::AbstractString)::Vector{String}
     end
     out = String[]
     dir = dirname(abspath(String(manifest)))
-    workspace_deps = _workspace_dependency_table(parsed, dir)
+    workspace_deps, workspace_dir = _workspace_dependency_table(parsed, dir)
 
     function harvest!(table)
         table isa AbstractDict || return
@@ -672,7 +706,10 @@ function _declared_path_dependencies(manifest::AbstractString)::Vector{String}
                 inherited = get(workspace_deps, String(name), nothing)
                 if inherited isa AbstractDict
                     ip = get(inherited, "path", nothing)
-                    ip isa AbstractString && push!(out, String(ip))
+                    # Relative to the manifest that declares the workspace
+                    # table, which is usually a directory above this member.
+                    ip isa AbstractString &&
+                        push!(out, abspath(joinpath(workspace_dir, String(ip))))
                 end
             end
         end
@@ -695,16 +732,17 @@ function _declared_path_dependencies(manifest::AbstractString)::Vector{String}
 end
 
 # `[workspace.dependencies]` of this manifest, else of the nearest ancestor
-# manifest that declares a workspace. Paths there are relative to *that*
-# manifest, which is why only same-directory workspaces are resolved; anything
-# further is left to the `cargo tree` strategy.
+# manifest that declares a workspace. Returns the table together with the
+# directory of the manifest that declared it, because the `path` values inside
+# it are relative to *that* manifest, not to the member using them.
 function _workspace_dependency_table(parsed::AbstractDict, dir::AbstractString)
+    dir = String(dir)
     ws = get(parsed, "workspace", nothing)
     if ws isa AbstractDict
         deps = get(ws, "dependencies", nothing)
-        deps isa AbstractDict && return deps
+        deps isa AbstractDict && return deps, dir
     end
-    parent = dirname(String(dir))
+    parent = dirname(dir)
     while !isempty(parent) && parent != dirname(parent)
         candidate = joinpath(parent, "Cargo.toml")
         if isfile(candidate)
@@ -717,13 +755,13 @@ function _workspace_dependency_table(parsed::AbstractDict, dir::AbstractString)
                 ws2 = get(other, "workspace", nothing)
                 if ws2 isa AbstractDict
                     deps2 = get(ws2, "dependencies", nothing)
-                    deps2 isa AbstractDict && return deps2
+                    deps2 isa AbstractDict && return deps2, parent
                 end
             end
         end
         parent = dirname(parent)
     end
-    return Dict{String, Any}()
+    return Dict{String, Any}(), dir
 end
 
 """
@@ -798,6 +836,7 @@ const ARTIFACT_BUILD_ENV_PREFIXES = String[
 "See `ARTIFACT_BUILD_ENV_PREFIXES`."
 const ARTIFACT_BUILD_ENV_NAMES = String[
     "RUSTC",
+    "RUSTC_WORKSPACE_WRAPPER",
     "RUSTC_WRAPPER",
     "RUSTDOCFLAGS",
     "RUSTFLAGS",

--- a/test/test_artifact_id.jl
+++ b/test/test_artifact_id.jl
@@ -328,7 +328,34 @@ _id(; kwargs...) = RustCall.ArtifactId(;
             @test !any(f -> startswith(f, "target/") || startswith(f, ".git/"), ws_files2)
             @test "target" in RustCall.CRATE_INPUT_VCS_DIRS
             @test ".git" in RustCall.CRATE_INPUT_VCS_DIRS
+            # `target` is build output only at the package root; VCS metadata is
+            # excluded at every level.
+            @test !("target" in RustCall.CRATE_INPUT_VCS_DIRS_ANY_LEVEL)
+            @test ".git" in RustCall.CRATE_INPUT_VCS_DIRS_ANY_LEVEL
             rm(ws; force = true, recursive = true)
+
+            # Round-four review finding (1): a module directory named
+            # src/target/ is ordinary source and must not be pruned.
+            nested_target = crate_with(mktempdir();
+                files = Dict("src/lib.rs" => "mod target;",
+                             "src/target/mod.rs" => "pub fn t() -> i32 { 1 }"))
+            _, nt_files = RustCall.crate_input_files(nested_target)
+            @test "src/target/mod.rs" in nt_files
+            dig_nt = RustCall.crate_content_digest(nested_target)
+            write(joinpath(nested_target, "src", "target", "mod.rs"), "pub fn t() -> i32 { 2 }")
+            @test RustCall.crate_content_digest(nested_target) != dig_nt
+            @test RustCall.artifact_path_dependency_digest(nested_target) !=
+                  RustCall.artifact_path_dependency_digest(bs)
+            # The root target/ is still ignored ...
+            dig_nt2 = RustCall.crate_content_digest(nested_target)
+            mkpath(joinpath(nested_target, "target", "debug"))
+            write(joinpath(nested_target, "target", "debug", "junk"), "noise")
+            @test RustCall.crate_content_digest(nested_target) == dig_nt2
+            # ... and a .git anywhere is still ignored.
+            mkpath(joinpath(nested_target, "src", ".git"))
+            write(joinpath(nested_target, "src", ".git", "HEAD"), "ref")
+            @test RustCall.crate_content_digest(nested_target) == dig_nt2
+            rm(nested_target; force = true, recursive = true)
 
             # Review finding (1) of the third round: files that a *distributable
             # package* omits are still compiled, so they must still count.
@@ -417,15 +444,38 @@ _id(; kwargs...) = RustCall.ArtifactId(;
             # by the fallback manifest reader.
             @test "../child" in RustCall._declared_path_dependencies(joinpath(parent, "Cargo.toml"))
 
+            # Round-four review finding (2): an inherited `path` is relative to
+            # the manifest that declares [workspace.dependencies], not to the
+            # member that inherits it. Joining it to the member directory would
+            # look for `member/shared`, which does not exist.
             wsroot = mktempdir()
             member = crate(joinpath(wsroot, "member"), "member", "pub fn m() {}";
                 manifest_extra = "\n[dependencies]\nshared = { workspace = true }\n")
-            crate(joinpath(wsroot, "shared"), "shared", "pub fn s() {}")
+            shared = crate(joinpath(wsroot, "shared"), "shared", "pub fn s() {}")
             write(joinpath(wsroot, "Cargo.toml"),
                 "[workspace]\nmembers = [\"member\", \"shared\"]\n" *
                 "\n[workspace.dependencies]\nshared = { path = \"shared\" }\n")
+
             inherited = RustCall._declared_path_dependencies(joinpath(member, "Cargo.toml"))
-            @test "shared" in inherited          # resolved through [workspace.dependencies]
+            @test length(inherited) == 1
+            @test realpath(only(inherited)) == realpath(shared)
+            @test !isdir(joinpath(member, "shared"))     # the naive join would miss
+
+            # The fallback collector reaches the shared crate from the member ...
+            ws_fb = String[member]
+            RustCall._collect_manifest_path_deps!(ws_fb, member, Set{String}())
+            @test realpath(shared) in Set(realpath.(ws_fb))
+
+            # ... and, forcing the fallback (no cargo resolution for a bare
+            # member of a workspace whose lock cannot be produced offline is not
+            # guaranteed, so drive the digest through the collector's own
+            # crates), editing the shared crate changes what is hashed.
+            shared_dig = RustCall.crate_content_digest(shared)
+            write(joinpath(shared, "src", "lib.rs"), "pub fn s() -> i32 { 42 }")
+            @test RustCall.crate_content_digest(shared) != shared_dig
+            member_dig = RustCall.artifact_path_dependency_digest(member)
+            write(joinpath(shared, "src", "lib.rs"), "pub fn s() -> i32 { 43 }")
+            @test RustCall.artifact_path_dependency_digest(member) != member_dig
             rm(wsroot; force = true, recursive = true)
 
             # Metadata failure is exercised: a directory with no manifest at all
@@ -535,6 +585,7 @@ _id(; kwargs...) = RustCall.ArtifactId(;
                   "CARGO_PROFILE_DEV_OPT_LEVEL", "CARGO_BUILD_RUSTFLAGS",
                   "CARGO_BUILD_TARGET", "CARGO_CFG_TARGET_FEATURE",
                   "CARGO_ENCODED_RUSTFLAGS", "RUSTFLAGS", "RUSTC", "RUSTC_WRAPPER",
+                  "RUSTC_WORKSPACE_WRAPPER",
                   "RUSTDOCFLAGS", "RUSTUP_TOOLCHAIN",
                   "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS",
                   "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER")
@@ -573,6 +624,23 @@ _id(; kwargs...) = RustCall.ArtifactId(;
         @test first.(scanned) ==
               ["CARGO_BUILD_TARGET", "CARGO_PROFILE_RELEASE_OPT_LEVEL", "RUSTFLAGS"]
         @test scanned == RustCall.artifact_build_env(; env = scan_env)
+
+        # Round-four review finding (3): RUSTC_WORKSPACE_WRAPPER sits between
+        # Cargo and rustc exactly like RUSTC_WRAPPER and must be captured.
+        @test "RUSTC_WORKSPACE_WRAPPER" in RustCall.ARTIFACT_BUILD_ENV_NAMES
+        @test "RUSTC_WRAPPER" in RustCall.ARTIFACT_BUILD_ENV_NAMES
+        wrapper_env = Dict("RUSTC_WORKSPACE_WRAPPER" => "/usr/bin/sccache")
+        wrapper_snap = RustCall.artifact_build_env(; env = wrapper_env)
+        @test first.(wrapper_snap) == ["RUSTC_WORKSPACE_WRAPPER"]
+        @test RustCall.artifact_key(_id(kind = "cargo", build_env = wrapper_snap)) !=
+              RustCall.artifact_key(_id(kind = "cargo",
+                  build_env = RustCall.artifact_build_env(; env = Dict{String, String}())))
+        # ... and it is part of the identity of the compiler that runs, too.
+        if !occursin("rustc=unknown", (try RustCall.artifact_compiler_identity() catch; "rustc=unknown" end))
+            ident = RustCall.artifact_compiler_identity()
+            @test occursin("rustc_wrapper=", ident)
+            @test occursin("rustc_workspace_wrapper=", ident)
+        end
 
         # Changing any captured variable changes the key.
         base_env = Dict("RUSTFLAGS" => "-C opt-level=2")

--- a/test/test_artifact_id.jl
+++ b/test/test_artifact_id.jl
@@ -187,7 +187,8 @@ _id(; kwargs...) = RustCall.ArtifactId(;
               RustCall.artifact_dependency_strings([RustCall.DependencySpec("serde", "1.0")])
 
         # Plain strings pass through, so the helper is usable anywhere.
-        @test RustCall.artifact_dependency_strings(["b", "a"]) == ["a", "b"]
+        raws = RustCall.artifact_dependency_strings(["b", "a"])
+        @test length(raws) == 2 && issorted(raws) && allunique(raws)
 
         # The dependency set reaches the key.
         with_deps = _id(kind = "cargo", source = "fn f() {}", dependencies = canon)
@@ -195,21 +196,147 @@ _id(; kwargs...) = RustCall.ArtifactId(;
         @test RustCall.artifact_key(with_deps) != RustCall.artifact_key(without)
     end
 
-    @testset "Build environment snapshot" begin
-        env0 = Dict("RUSTFLAGS" => "")
-        env1 = Dict("RUSTFLAGS" => "-C target-cpu=native")
-        snap0 = RustCall.artifact_build_env(["RUSTFLAGS", "CARGO_TARGET_DIR"]; env = env0)
-        snap1 = RustCall.artifact_build_env(["RUSTFLAGS", "CARGO_TARGET_DIR"]; env = env1)
+    @testset "Local path dependencies are identified by content" begin
+        # Review finding (3): a `path = "..."` dependency identified by its path
+        # text alone means editing its sources leaves the key unchanged.
+        function make_crate(dir, body; name = "helper", extra_manifest = "")
+            mkpath(joinpath(dir, "src"))
+            write(joinpath(dir, "Cargo.toml"),
+                "[package]\nname = \"$(name)\"\nversion = \"0.1.0\"\n$(extra_manifest)")
+            write(joinpath(dir, "src", "lib.rs"), body)
+            return dir
+        end
 
-        # Absent variables are recorded, not dropped.
-        @test first.(snap0) == ["CARGO_TARGET_DIR", "RUSTFLAGS"]
-        @test snap0 != snap1
-        @test RustCall.artifact_key(_id(kind = "cargo", build_env = snap0)) !=
-              RustCall.artifact_key(_id(kind = "cargo", build_env = snap1))
+        a = make_crate(mktempdir(), "pub fn f() -> i32 { 1 }")
+        b = make_crate(mktempdir(), "pub fn f() -> i32 { 2 }")   # one byte differs
+        c = make_crate(mktempdir(), "pub fn f() -> i32 { 1 }")   # same content, other dir
 
-        # The default list is non-empty and covers what the recent Cargo fixes added.
-        @test "RUSTFLAGS" in RustCall.ARTIFACT_BUILD_ENV_VARS
-        @test "CARGO_ENCODED_RUSTFLAGS" in RustCall.ARTIFACT_BUILD_ENV_VARS
+        try
+            dig_a = RustCall.artifact_path_dependency_digest(a)
+            dig_b = RustCall.artifact_path_dependency_digest(b)
+            dig_c = RustCall.artifact_path_dependency_digest(c)
+
+            @test dig_a != dig_b                       # editing sources changes the digest
+            @test dig_a == dig_c                       # location is NOT part of identity
+            @test dig_a == RustCall.artifact_path_dependency_digest(a)  # deterministic
+
+            # Files added under src/ count, and target/ artifacts are ignored.
+            write(joinpath(a, "src", "extra.rs"), "pub fn g() {}")
+            @test RustCall.artifact_path_dependency_digest(a) != dig_a
+            dig_a2 = RustCall.artifact_path_dependency_digest(a)
+            mkpath(joinpath(a, "target", "release"))
+            write(joinpath(a, "target", "release", "junk"), "noise")
+            @test RustCall.artifact_path_dependency_digest(a) == dig_a2
+
+            # The digest reaches the dependency string, and hence the key.
+            spec_a = RustCall.DependencySpec("helper", nothing, String[], nothing, a)
+            spec_b = RustCall.DependencySpec("helper", nothing, String[], nothing, b)
+            spec_c = RustCall.DependencySpec("helper", nothing, String[], nothing, c)
+            key(spec) = RustCall.artifact_key(_id(kind = "cargo",
+                dependencies = RustCall.artifact_dependency_strings([spec])))
+            @test key(spec_a) != key(spec_b)
+            @test key(spec_b) != key(spec_c)
+            @test RustCall.artifact_dependency_strings([spec_a]) !=
+                  RustCall.artifact_dependency_strings([spec_b])
+
+            # A nested path dependency is followed.
+            nested_parent = mktempdir()
+            child = make_crate(joinpath(nested_parent, "child"), "pub fn h() {}"; name = "child")
+            parent = make_crate(nested_parent, "pub fn p() {}";
+                name = "parent",
+                extra_manifest = "\n[dependencies]\nchild = { path = \"child\" }\n")
+            dig_parent = RustCall.artifact_path_dependency_digest(parent)
+            write(joinpath(child, "src", "lib.rs"), "pub fn h() -> i32 { 7 }")
+            @test RustCall.artifact_path_dependency_digest(parent) != dig_parent
+
+            # A missing crate is recorded, not silently ignored, and never throws.
+            missing_dig = RustCall.artifact_path_dependency_digest(joinpath(a, "nope"))
+            @test length(missing_dig) == 64
+            @test missing_dig != dig_a
+        finally
+            for d in (a, b, c)
+                rm(d; force = true, recursive = true)
+            end
+        end
+    end
+
+    @testset "Build environment: presence and prefix capture" begin
+        # Review finding (1): unset and empty must not collide. Cargo treats an
+        # empty RUSTFLAGS as "suppress inherited rustflags", not as "unset".
+        unset = Dict{String, String}()
+        empty_val = Dict("RUSTFLAGS" => "")
+        set_val = Dict("RUSTFLAGS" => "-C target-cpu=native")
+
+        snap_unset = RustCall.artifact_build_env(["RUSTFLAGS"]; env = unset)
+        snap_empty = RustCall.artifact_build_env(["RUSTFLAGS"]; env = empty_val)
+        snap_set = RustCall.artifact_build_env(["RUSTFLAGS"]; env = set_val)
+
+        @test snap_unset[1] == ("RUSTFLAGS" => RustCall.ARTIFACT_ENV_ABSENT)
+        @test snap_empty[1] == ("RUSTFLAGS" => "present:")
+        @test snap_unset != snap_empty
+        keys3 = [RustCall.artifact_key(_id(kind = "cargo", build_env = s))
+                 for s in (snap_unset, snap_empty, snap_set)]
+        @test length(unique(keys3)) == 3
+
+        # A value that literally reads "absent" cannot imitate the absent marker.
+        literal = RustCall.artifact_build_env(["RUSTFLAGS"]; env = Dict("RUSTFLAGS" => "absent"))
+        @test literal != snap_unset
+
+        # Review finding (2): profile overrides are tracked by prefix, not by an
+        # enumeration that has to be patched for every new key.
+        for n in ("CARGO_PROFILE_RELEASE_OPT_LEVEL", "CARGO_PROFILE_RELEASE_CODEGEN_UNITS",
+                  "CARGO_PROFILE_RELEASE_PANIC", "CARGO_PROFILE_RELEASE_DEBUG",
+                  "CARGO_PROFILE_RELEASE_STRIP", "CARGO_PROFILE_RELEASE_LTO",
+                  "CARGO_PROFILE_DEV_OPT_LEVEL", "CARGO_BUILD_RUSTFLAGS",
+                  "CARGO_BUILD_TARGET", "CARGO_CFG_TARGET_FEATURE",
+                  "CARGO_ENCODED_RUSTFLAGS", "RUSTFLAGS", "RUSTC", "RUSTC_WRAPPER",
+                  "RUSTDOCFLAGS", "RUSTUP_TOOLCHAIN",
+                  "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS",
+                  "CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER")
+            @test RustCall.artifact_build_env_captured(n)
+        end
+
+        # Not build-affecting: output location and unrelated variables.
+        for n in ("CARGO_TARGET_DIR", "PATH", "HOME", "JULIA_DEPOT_PATH", "CARGO_HOME")
+            @test !RustCall.artifact_build_env_captured(n)
+        end
+
+        # HARD SECURITY REQUIREMENT: credentials are rejected before the
+        # allowlist is consulted and can never enter a key.
+        for n in ("CARGO_REGISTRY_TOKEN", "CARGO_REGISTRIES_MYREG_TOKEN",
+                  "CARGO_REGISTRIES_X_TOKEN", "CARGO_BUILD_SECRET",
+                  "CARGO_PROFILE_RELEASE_AUTH", "RUSTFLAGS_TOKEN",
+                  "AWS_SECRET_ACCESS_KEY", "MY_PASSWORD", "GH_CREDENTIALS",
+                  "cargo_registry_token")
+            @test !RustCall.artifact_build_env_captured(n)
+        end
+        secret_env = Dict(
+            "CARGO_REGISTRY_TOKEN" => "s3cret",
+            "CARGO_REGISTRIES_X_TOKEN" => "s3cret2",
+            "RUSTFLAGS" => "-C opt-level=3",
+        )
+        captured = RustCall.artifact_build_env(; env = secret_env)
+        @test first.(captured) == ["RUSTFLAGS"]
+        @test !any(p -> occursin("s3cret", last(p)), captured)
+        # Even when named explicitly, a credential is skipped.
+        @test isempty(RustCall.artifact_build_env(["CARGO_REGISTRY_TOKEN"]; env = secret_env))
+
+        # Scanning the environment is sorted and deterministic.
+        scan_env = Dict("RUSTFLAGS" => "a", "CARGO_BUILD_TARGET" => "b",
+                        "CARGO_PROFILE_RELEASE_OPT_LEVEL" => "z", "PATH" => "/bin")
+        scanned = RustCall.artifact_build_env(; env = scan_env)
+        @test first.(scanned) ==
+              ["CARGO_BUILD_TARGET", "CARGO_PROFILE_RELEASE_OPT_LEVEL", "RUSTFLAGS"]
+        @test scanned == RustCall.artifact_build_env(; env = scan_env)
+
+        # Changing any captured variable changes the key.
+        base_env = Dict("RUSTFLAGS" => "-C opt-level=2")
+        mutated_env = Dict("RUSTFLAGS" => "-C opt-level=2",
+                           "CARGO_PROFILE_RELEASE_CODEGEN_UNITS" => "1")
+        @test RustCall.artifact_key(_id(kind = "cargo",
+                  build_env = RustCall.artifact_build_env(; env = base_env))) !=
+              RustCall.artifact_key(_id(kind = "cargo",
+                  build_env = RustCall.artifact_build_env(; env = mutated_env)))
     end
 
     @testset "Codegen options come from the compiler config" begin

--- a/test/test_artifact_id.jl
+++ b/test/test_artifact_id.jl
@@ -260,6 +260,138 @@ _id(; kwargs...) = RustCall.ArtifactId(;
         end
     end
 
+    @testset "Path dependency inputs come from Cargo, not from a layout guess" begin
+        # Review finding (1): hashing only Cargo.toml + src/ misses build.rs, a
+        # [lib]/[[bin]] path outside src/, #[path] modules and Cargo.lock.
+        function crate_with(dir; manifest_extra = "", files = Dict{String, String}())
+            mkpath(dir)
+            write(joinpath(dir, "Cargo.toml"),
+                "[package]\nname = \"probe\"\nversion = \"0.1.0\"\nedition = \"2021\"\n$(manifest_extra)")
+            for (rel, body) in files
+                mkpath(dirname(joinpath(dir, rel)))
+                write(joinpath(dir, rel), body)
+            end
+            return dir
+        end
+
+        # (a) build.rs is an input.
+        bs = crate_with(mktempdir();
+            manifest_extra = "\n[lib]\npath = \"src/lib.rs\"\n",
+            files = Dict("src/lib.rs" => "pub fn f() {}",
+                         "build.rs" => "fn main() { println!(\"cargo:rustc-cfg=x\"); }"))
+        # (b) a [lib] path outside src/.
+        outside = crate_with(mktempdir();
+            manifest_extra = "\n[lib]\npath = \"lib/entry.rs\"\n",
+            files = Dict("lib/entry.rs" => "pub fn f() -> i32 { 1 }"))
+
+        try
+            dig_bs = RustCall.artifact_path_dependency_digest(bs)
+            write(joinpath(bs, "build.rs"), "fn main() { println!(\"cargo:rustc-cfg=y\"); }")
+            @test RustCall.artifact_path_dependency_digest(bs) != dig_bs   # build.rs counts
+
+            dig_out = RustCall.artifact_path_dependency_digest(outside)
+            write(joinpath(outside, "lib", "entry.rs"), "pub fn f() -> i32 { 2 }")
+            @test RustCall.artifact_path_dependency_digest(outside) != dig_out  # outside src/
+
+            # Cargo.lock is always included when present.
+            dig_lock = RustCall.artifact_path_dependency_digest(outside)
+            write(joinpath(outside, "Cargo.lock"), "version = 3\n")
+            @test RustCall.artifact_path_dependency_digest(outside) != dig_lock
+            strategy_lock, files_lock = RustCall.crate_input_files(outside)
+            @test "Cargo.lock" in files_lock
+
+            # Both strategies are exercised. A bare workspace manifest has no
+            # package, so `cargo package --list` fails and the walk takes over.
+            ws = mktempdir()
+            write(joinpath(ws, "Cargo.toml"), "[workspace]\nmembers = []\n")
+            mkpath(joinpath(ws, "odd"))
+            write(joinpath(ws, "odd", "thing.txt"), "content")
+            ws_strategy, ws_files = RustCall.crate_input_files(ws)
+            @test ws_strategy == "walk"
+            @test "odd/thing.txt" in ws_files                # the walk sees everything
+            @test "Cargo.toml" in ws_files
+            dig_ws = RustCall.artifact_path_dependency_digest(ws)
+            write(joinpath(ws, "odd", "thing.txt"), "changed")
+            @test RustCall.artifact_path_dependency_digest(ws) != dig_ws
+
+            # The walk skips build output and VCS metadata.
+            mkpath(joinpath(ws, "target", "debug"))
+            write(joinpath(ws, "target", "debug", "junk"), "noise")
+            mkpath(joinpath(ws, ".git"))
+            write(joinpath(ws, ".git", "HEAD"), "ref: refs/heads/main")
+            _, ws_files2 = RustCall.crate_input_files(ws)
+            @test !any(f -> startswith(f, "target/") || startswith(f, ".git/"), ws_files2)
+            @test "target" in RustCall.CRATE_INPUT_VCS_DIRS
+            @test ".git" in RustCall.CRATE_INPUT_VCS_DIRS
+
+            # The strategy is hashed, so the two file sets can never collide.
+            strategy_bs, _ = RustCall.crate_input_files(bs)
+            if strategy_bs == "cargo-package-list"
+                # cargo is available: the real strategy differs from the fallback.
+                @test strategy_bs != ws_strategy
+            else
+                @info "cargo package --list unavailable; only the walk strategy exercised"
+            end
+            rm(ws; force = true, recursive = true)
+        finally
+            for d in (bs, outside)
+                rm(d; force = true, recursive = true)
+            end
+        end
+    end
+
+    @testset "Build-script environment inputs are captured" begin
+        # Review finding (2): CC/CFLAGS/PKG_CONFIG_PATH and friends reach the
+        # build scripts of dependencies (cc-rs, pkg-config, cmake, bindgen) and
+        # change the native objects linked into the artifact.
+        for n in ("CC", "CXX", "AR", "LD", "RANLIB", "STRIP", "NM",
+                  "CFLAGS", "CXXFLAGS", "LDFLAGS", "ASFLAGS", "CPPFLAGS",
+                  "PKG_CONFIG", "PKG_CONFIG_PATH", "PKG_CONFIG_ALLOW_CROSS",
+                  "CMAKE_TOOLCHAIN_FILE", "BINDGEN_EXTRA_CLANG_ARGS",
+                  "LIBCLANG_PATH", "CLANG_PATH",
+                  "TARGET_CFLAGS", "HOST_CFLAGS", "CARGO_FEATURE_DEFAULT")
+            @test RustCall.artifact_build_env_captured(n)
+        end
+
+        # cc-rs accepts both per-target spellings.
+        @test RustCall.artifact_build_env_captured("x86_64_unknown_linux_gnu_CC")
+        @test RustCall.artifact_build_env_captured("CC_x86_64-unknown-linux-gnu")
+        @test RustCall.artifact_build_env_captured("aarch64_apple_darwin_CFLAGS")
+        @test RustCall.artifact_build_env_captured("CFLAGS_aarch64-apple-darwin")
+        @test RustCall.artifact_build_env_captured("x86_64_unknown_linux_gnu_LINKER")
+
+        # Secret rejection still runs first, over the build-script allowlist too.
+        for n in ("PKG_CONFIG_AUTH_TOKEN", "PKG_CONFIG_SECRET", "CC_PASSWORD",
+                  "BINDGEN_API_KEY", "CMAKE_CREDENTIAL_HELPER", "TARGET_AUTH")
+            @test !RustCall.artifact_build_env_captured(n)
+        end
+        @test RustCall.artifact_build_env_captured("PKG_CONFIG_PATH")
+
+        # Unrelated variables stay out.
+        for n in ("EDITOR", "LANG", "TERM", "SHELL", "PWD")
+            @test !RustCall.artifact_build_env_captured(n)
+        end
+
+        # A build-script variable reaches the key.
+        env_a = Dict("CC" => "clang")
+        env_b = Dict("CC" => "gcc")
+        @test RustCall.artifact_key(_id(kind = "cargo",
+                  build_env = RustCall.artifact_build_env(; env = env_a))) !=
+              RustCall.artifact_key(_id(kind = "cargo",
+                  build_env = RustCall.artifact_build_env(; env = env_b)))
+        # ... and unset CC differs from CC="".
+        @test RustCall.artifact_build_env(["CC"]; env = Dict{String, String}()) !=
+              RustCall.artifact_build_env(["CC"]; env = Dict("CC" => ""))
+
+        # A scan never leaks a credential even when build-script vars are present.
+        mixed = Dict("CC" => "clang", "PKG_CONFIG_PATH" => "/opt/lib/pkgconfig",
+                     "PKG_CONFIG_AUTH_TOKEN" => "s3cret", "CARGO_REGISTRY_TOKEN" => "s3cret")
+        captured = RustCall.artifact_build_env(; env = mixed)
+        @test first.(captured) == ["CC", "PKG_CONFIG_PATH"]
+        @test !any(p -> occursin("s3cret", last(p)), captured)
+    end
+
+
     @testset "Build environment: presence and prefix capture" begin
         # Review finding (1): unset and empty must not collide. Cargo treats an
         # empty RUSTFLAGS as "suppress inherited rustflags", not as "unset".

--- a/test/test_artifact_id.jl
+++ b/test/test_artifact_id.jl
@@ -1,0 +1,336 @@
+# Tests for the single artifact-identity function (issue #278, Phase A).
+#
+# Two kinds of tests live here:
+#
+# 1. Tests of the new `ArtifactId` / `artifact_key` machinery: injectivity,
+#    order sensitivity of type parameters, toolchain sensitivity.
+# 2. Tests that *document the current defects* of the eight ad-hoc cache-key
+#    sites. Those assert today's (wrong) behaviour on purpose, with the issue
+#    number in a comment, so that Phase B — which migrates the call sites onto
+#    `artifact_key` — turns them into regression tests by flipping the
+#    assertion. Nothing here changes existing behaviour.
+
+using RustCall
+using SHA: sha256
+using Test
+
+# A toolchain/compiler pair that does not require the extractor or a Rust
+# toolchain to be present, so the pure-encoding tests always run.
+const _FAKE_TOOLCHAIN = "toolchain-fingerprint-aaaa"
+const _FAKE_COMPILER = "rustc=rustc 1.90.0 (deadbeef 2026-01-01)\ncargo=cargo 1.90.0"
+
+_id(; kwargs...) = RustCall.ArtifactId(;
+    toolchain = _FAKE_TOOLCHAIN, compiler = _FAKE_COMPILER, kwargs...)
+
+@testset "Artifact identity (#278)" begin
+
+    @testset "Key shape and determinism" begin
+        id = _id(kind = "rustc", source = "fn f() {}")
+        key = RustCall.artifact_key(id)
+
+        @test length(key) == 64
+        @test all(c -> c in "0123456789abcdef", key)
+        # Deterministic across calls and across equal records.
+        @test key == RustCall.artifact_key(id)
+        @test key == RustCall.artifact_key(_id(kind = "rustc", source = "fn f() {}"))
+        @test id == _id(kind = "rustc", source = "fn f() {}")
+    end
+
+    @testset "Encoding is injective (no concatenation collisions)" begin
+        # The classic failure of naive concatenation: "a" * "bc" == "ab" * "c".
+        # Netstring framing makes it impossible.
+        a = _id(kind = "a", source = "bc")
+        b = _id(kind = "ab", source = "c")
+        @test RustCall.artifact_encoding(a) != RustCall.artifact_encoding(b)
+        @test RustCall.artifact_key(a) != RustCall.artifact_key(b)
+
+        # Separator smuggling: a payload containing the framing characters must
+        # not be able to imitate a field boundary.
+        c = _id(kind = "x", source = "3:abc,")
+        d = _id(kind = "x3:abc,", source = "")
+        @test RustCall.artifact_key(c) != RustCall.artifact_key(d)
+
+        # Empty vs missing must differ where it matters, and list boundaries
+        # must be unambiguous.
+        e = _id(kind = "k", cfg = ["ab", "c"])
+        f = _id(kind = "k", cfg = ["a", "bc"])
+        g = _id(kind = "k", cfg = ["abc"])
+        @test length(unique([RustCall.artifact_key(x) for x in (e, f, g)])) == 3
+    end
+
+    @testset "Every field participates in the key" begin
+        # Property-style: changing any single field changes the key.
+        base = _id(
+            kind = "rustc",
+            source = "fn f() {}",
+            type_params = ["T" => "i32"],
+            target_triple = "x86_64-unknown-linux-gnu",
+            codegen = ["opt_level" => "2"],
+            cfg = ["feature=\"std\""],
+            dependencies = ["name=serde version=1.0"],
+            features = ["derive"],
+            build_env = ["RUSTFLAGS" => ""],
+            extra = ["profile" => "release"],
+        )
+        base_key = RustCall.artifact_key(base)
+
+        mutations = [
+            "kind" => _id(kind = "cargo", source = base.source, type_params = base.type_params,
+                target_triple = base.target_triple, codegen = base.codegen, cfg = base.cfg,
+                dependencies = base.dependencies, features = base.features,
+                build_env = base.build_env, extra = base.extra),
+            "source" => _id(kind = base.kind, source = "fn g() {}", type_params = base.type_params,
+                target_triple = base.target_triple, codegen = base.codegen, cfg = base.cfg,
+                dependencies = base.dependencies, features = base.features,
+                build_env = base.build_env, extra = base.extra),
+            "type_params" => _id(kind = base.kind, source = base.source, type_params = ["T" => "i64"],
+                target_triple = base.target_triple, codegen = base.codegen, cfg = base.cfg,
+                dependencies = base.dependencies, features = base.features,
+                build_env = base.build_env, extra = base.extra),
+            "target_triple" => _id(kind = base.kind, source = base.source, type_params = base.type_params,
+                target_triple = "aarch64-apple-darwin", codegen = base.codegen, cfg = base.cfg,
+                dependencies = base.dependencies, features = base.features,
+                build_env = base.build_env, extra = base.extra),
+            "codegen" => _id(kind = base.kind, source = base.source, type_params = base.type_params,
+                target_triple = base.target_triple, codegen = ["opt_level" => "3"], cfg = base.cfg,
+                dependencies = base.dependencies, features = base.features,
+                build_env = base.build_env, extra = base.extra),
+            "cfg" => _id(kind = base.kind, source = base.source, type_params = base.type_params,
+                target_triple = base.target_triple, codegen = base.codegen, cfg = String[],
+                dependencies = base.dependencies, features = base.features,
+                build_env = base.build_env, extra = base.extra),
+            "dependencies" => _id(kind = base.kind, source = base.source, type_params = base.type_params,
+                target_triple = base.target_triple, codegen = base.codegen, cfg = base.cfg,
+                dependencies = ["name=serde version=1.1"], features = base.features,
+                build_env = base.build_env, extra = base.extra),
+            "features" => _id(kind = base.kind, source = base.source, type_params = base.type_params,
+                target_triple = base.target_triple, codegen = base.codegen, cfg = base.cfg,
+                dependencies = base.dependencies, features = String[],
+                build_env = base.build_env, extra = base.extra),
+            "build_env" => _id(kind = base.kind, source = base.source, type_params = base.type_params,
+                target_triple = base.target_triple, codegen = base.codegen, cfg = base.cfg,
+                dependencies = base.dependencies, features = base.features,
+                build_env = ["RUSTFLAGS" => "-C target-cpu=native"], extra = base.extra),
+            "extra" => _id(kind = base.kind, source = base.source, type_params = base.type_params,
+                target_triple = base.target_triple, codegen = base.codegen, cfg = base.cfg,
+                dependencies = base.dependencies, features = base.features,
+                build_env = base.build_env, extra = ["profile" => "debug"]),
+            "toolchain" => RustCall.ArtifactId(kind = base.kind, source = base.source,
+                type_params = base.type_params, target_triple = base.target_triple,
+                codegen = base.codegen, cfg = base.cfg, dependencies = base.dependencies,
+                features = base.features, build_env = base.build_env, extra = base.extra,
+                toolchain = "toolchain-fingerprint-bbbb", compiler = _FAKE_COMPILER),
+            "compiler" => RustCall.ArtifactId(kind = base.kind, source = base.source,
+                type_params = base.type_params, target_triple = base.target_triple,
+                codegen = base.codegen, cfg = base.cfg, dependencies = base.dependencies,
+                features = base.features, build_env = base.build_env, extra = base.extra,
+                toolchain = _FAKE_TOOLCHAIN, compiler = "rustc=rustc 1.91.0\ncargo=cargo 1.91.0"),
+        ]
+
+        for (field, mutated) in mutations
+            @test RustCall.artifact_key(mutated) != base_key
+        end
+        # All twelve mutations are distinct from each other too.
+        @test length(unique([RustCall.artifact_key(m) for (_, m) in mutations])) == length(mutations)
+    end
+
+    @testset "Type parameters are order preserving (#247)" begin
+        forward = _id(kind = "monomorphization", source = "pub fn pair<T, U>()",
+            type_params = ["T" => "Int32", "U" => "Int64"])
+        reversed = _id(kind = "monomorphization", source = "pub fn pair<T, U>()",
+            type_params = ["T" => "Int64", "U" => "Int32"])
+        @test RustCall.artifact_key(forward) != RustCall.artifact_key(reversed)
+
+        # And the name a parameter carries matters, not just the multiset of types.
+        renamed = _id(kind = "monomorphization", source = "pub fn pair<T, U>()",
+            type_params = ["U" => "Int32", "T" => "Int64"])
+        @test RustCall.artifact_key(renamed) != RustCall.artifact_key(forward)
+
+        # artifact_type_params keeps declaration order regardless of Dict order.
+        bindings = Dict{Symbol, Type}(:U => Int64, :T => Int32)
+        @test RustCall.artifact_type_params([:T, :U], bindings) == ["T" => "Int32", "U" => "Int64"]
+        @test RustCall.artifact_type_params([:U, :T], bindings) == ["U" => "Int64", "T" => "Int32"]
+        @test RustCall.artifact_type_params([:T, :U], bindings) !=
+              RustCall.artifact_type_params([:U, :T], bindings)
+        @test_throws ArgumentError RustCall.artifact_type_params([:T, :V], bindings)
+
+        # Positional form.
+        @test RustCall.artifact_type_params(["T", "U"], [Int32, Int64]) ==
+              ["T" => "Int32", "U" => "Int64"]
+        @test_throws ArgumentError RustCall.artifact_type_params(["T"], [Int32, Int64])
+    end
+
+    @testset "Truncation happens in exactly one place" begin
+        id = _id(kind = "rustc", source = "fn f() {}")
+        key = RustCall.artifact_key(id)
+
+        @test RustCall.artifact_short_id(id) == key[1:RustCall.ARTIFACT_SHORT_ID_LEN]
+        @test RustCall.artifact_short_id(key) == RustCall.artifact_short_id(id)
+        @test RustCall.artifact_short_id(id, 12) == key[1:12]
+        @test length(RustCall.artifact_short_id(id)) == RustCall.ARTIFACT_SHORT_ID_LEN
+        @test_throws ArgumentError RustCall.artifact_short_id(id, 0)
+        @test_throws ArgumentError RustCall.artifact_short_id(id, 65)
+    end
+
+    @testset "Dependency canonicalization" begin
+        d1 = RustCall.DependencySpec("serde", "1.0", ["derive"])
+        d2 = RustCall.DependencySpec("rand", "0.8")
+        canon = RustCall.artifact_dependency_strings([d1, d2])
+        @test length(canon) == 2
+        @test issorted(canon)                        # order of the input is irrelevant
+        @test canon == RustCall.artifact_dependency_strings([d2, d1])
+
+        # Distinct specs never collapse onto one string.
+        @test RustCall.artifact_dependency_strings([RustCall.DependencySpec("serde", "1.0")]) !=
+              RustCall.artifact_dependency_strings([RustCall.DependencySpec("serde", "1.1")])
+        @test RustCall.artifact_dependency_strings([RustCall.DependencySpec("serde", "1.0", ["derive"])]) !=
+              RustCall.artifact_dependency_strings([RustCall.DependencySpec("serde", "1.0")])
+
+        # Plain strings pass through, so the helper is usable anywhere.
+        @test RustCall.artifact_dependency_strings(["b", "a"]) == ["a", "b"]
+
+        # The dependency set reaches the key.
+        with_deps = _id(kind = "cargo", source = "fn f() {}", dependencies = canon)
+        without = _id(kind = "cargo", source = "fn f() {}")
+        @test RustCall.artifact_key(with_deps) != RustCall.artifact_key(without)
+    end
+
+    @testset "Build environment snapshot" begin
+        env0 = Dict("RUSTFLAGS" => "")
+        env1 = Dict("RUSTFLAGS" => "-C target-cpu=native")
+        snap0 = RustCall.artifact_build_env(["RUSTFLAGS", "CARGO_TARGET_DIR"]; env = env0)
+        snap1 = RustCall.artifact_build_env(["RUSTFLAGS", "CARGO_TARGET_DIR"]; env = env1)
+
+        # Absent variables are recorded, not dropped.
+        @test first.(snap0) == ["CARGO_TARGET_DIR", "RUSTFLAGS"]
+        @test snap0 != snap1
+        @test RustCall.artifact_key(_id(kind = "cargo", build_env = snap0)) !=
+              RustCall.artifact_key(_id(kind = "cargo", build_env = snap1))
+
+        # The default list is non-empty and covers what the recent Cargo fixes added.
+        @test "RUSTFLAGS" in RustCall.ARTIFACT_BUILD_ENV_VARS
+        @test "CARGO_ENCODED_RUSTFLAGS" in RustCall.ARTIFACT_BUILD_ENV_VARS
+    end
+
+    @testset "Codegen options come from the compiler config" begin
+        compiler = RustCall.get_default_compiler()
+        opts = RustCall.artifact_codegen_options(compiler)
+        @test first.(opts) == ["opt_level", "debug_info"]
+        @test opts[1][2] == string(compiler.optimization_level)
+    end
+
+    # ------------------------------------------------------------------
+    # Defect documentation: these assert the CURRENT behaviour of the
+    # existing key sites. Phase B flips them into regression tests.
+    # ------------------------------------------------------------------
+
+    @testset "DEFECT #247: monomorphization key loses parameter order" begin
+        # Verbatim reproduction of src/generics.jl:191-193 as of this commit:
+        #
+        #     sorted_types = sort(collect(values(type_params)), by=string)
+        #     type_params_tuple = tuple(sorted_types...)
+        #     cache_key = (func_name, type_params_tuple)
+        #
+        # Sorting the *values* discards which parameter got which type, so
+        # pair<T=i32, U=i64> and pair<T=i64, U=i32> share one cache entry and
+        # the second call runs the first one's machine code (#247).
+        current_key(func_name, type_params) = begin
+            sorted_types = sort(collect(values(type_params)), by = string)
+            (func_name, tuple(sorted_types...))
+        end
+
+        a = Dict{Symbol, Type}(:T => Int32, :U => Int64)
+        b = Dict{Symbol, Type}(:T => Int64, :U => Int32)
+
+        # Current behaviour: COLLISION. This @test is expected to fail (and to
+        # be inverted) once Phase B migrates monomorphize_function.
+        @test current_key("pair", a) == current_key("pair", b)
+
+        # The same is true of the symbol suffix built at src/generics.jl:208-224
+        # from the same sorted values, so the two instantiations also want the
+        # same monomorphized symbol name.
+        suffix(tp) = join([string(t) for t in sort(collect(values(tp)), by = string)], "_")
+        @test suffix(a) == suffix(b)
+
+        # The replacement does not collide.
+        key_a = RustCall.artifact_key(_id(kind = "monomorphization", source = "pair",
+            type_params = RustCall.artifact_type_params([:T, :U], a)))
+        key_b = RustCall.artifact_key(_id(kind = "monomorphization", source = "pair",
+            type_params = RustCall.artifact_type_params([:T, :U], b)))
+        @test key_a != key_b
+    end
+
+    @testset "DEFECT #252: the rustc in the key is not the rustc that compiles" begin
+        # src/cache.jl:97-106 shells out to a bare `rustc` from PATH and returns
+        # "unknown" when that fails, while compilation goes through
+        # RustToolChain.rustc() (src/compiler.jl:212). A key built from the
+        # former therefore need not change when the real toolchain changes.
+
+        # Warm the memoized values before touching PATH, so this test only
+        # observes the divergence and does not perturb anything.
+        toolchain_ok = try
+            RustCall.artifact_compiler_identity()
+            true
+        catch
+            false
+        end
+
+        if !toolchain_ok
+            @info "Skipping #252 divergence test: RustToolChain rustc/cargo unavailable"
+        else
+            identity_str = RustCall.artifact_compiler_identity()
+            @test occursin("rustc=", identity_str)
+            @test occursin("cargo=", identity_str)
+            # Never the "unknown" sentinel: an unidentifiable compiler is an error.
+            @test !occursin("rustc=unknown", identity_str)
+
+            saved = RustCall._cached_rustc_version[]
+            empty_dir = mktempdir()
+            try
+                # With no `rustc` on PATH, the cache-key version degrades to
+                # "unknown" while the compiler that would actually run is
+                # unchanged — that is exactly the divergence of #252.
+                RustCall._cached_rustc_version[] = ""
+                path_version = withenv("PATH" => empty_dir) do
+                    RustCall._get_rustc_version()
+                end
+                @test path_version == "unknown"                       # #252, current behaviour
+                @test !occursin(path_version, RustCall.artifact_compiler_identity())
+            finally
+                RustCall._cached_rustc_version[] = saved
+                rm(empty_dir; force = true, recursive = true)
+            end
+        end
+    end
+
+    @testset "DEFECT: existing key sites truncate inconsistently" begin
+        # Inventory of the truncation lengths currently in use (issue #278).
+        # The new function truncates in one place only, and never for lookup.
+        code = "fn f() -> i32 { 1 }"
+
+        @test length(RustCall.stable_content_hash(code)[1:16]) == 16   # src/ruststr.jl:227
+        @test length(bytes2hex(sha256("$(code)_deps_release"))[1:32]) == 32  # src/ruststr.jl:381
+
+        # artifact_key is full length; only artifact_short_id truncates.
+        @test length(RustCall.artifact_key(_id(kind = "rustc", source = code))) == 64
+    end
+
+    @testset "toolchain_fingerprint() is folded in by default" begin
+        # Requires the extractor binary; skip gracefully when absent.
+        fp = try
+            RustCall.toolchain_fingerprint()
+        catch
+            nothing
+        end
+        if fp === nothing
+            @info "Skipping toolchain_fingerprint test: rustcall-extract unavailable"
+        else
+            id = RustCall.ArtifactId(kind = "rustc", source = "fn f() {}",
+                compiler = _FAKE_COMPILER)
+            @test id.toolchain == fp
+            other = RustCall.ArtifactId(kind = "rustc", source = "fn f() {}",
+                compiler = _FAKE_COMPILER, toolchain = "different")
+            @test RustCall.artifact_key(id) != RustCall.artifact_key(other)
+        end
+    end
+end

--- a/test/test_artifact_id.jl
+++ b/test/test_artifact_id.jl
@@ -293,15 +293,20 @@ _id(; kwargs...) = RustCall.ArtifactId(;
             write(joinpath(outside, "lib", "entry.rs"), "pub fn f() -> i32 { 2 }")
             @test RustCall.artifact_path_dependency_digest(outside) != dig_out  # outside src/
 
-            # Cargo.lock is always included when present.
-            dig_lock = RustCall.artifact_path_dependency_digest(outside)
+            # Cargo.lock is an input like any other file. Asserted through the
+            # pure helpers: `artifact_path_dependency_digest` may ask Cargo to
+            # resolve, and Cargo rewrites the lockfile when it does.
             write(joinpath(outside, "Cargo.lock"), "version = 3\n")
-            @test RustCall.artifact_path_dependency_digest(outside) != dig_lock
             strategy_lock, files_lock = RustCall.crate_input_files(outside)
+            @test strategy_lock == "walk"
             @test "Cargo.lock" in files_lock
+            lock_dig = RustCall.crate_content_digest(outside)
+            write(joinpath(outside, "Cargo.lock"), "version = 4\n")
+            @test RustCall.crate_content_digest(outside) != lock_dig
 
-            # Both strategies are exercised. A bare workspace manifest has no
-            # package, so `cargo package --list` fails and the walk takes over.
+            # The walk is the only file strategy, and it sees everything under
+            # the package directory — including files `cargo package --list`
+            # would never report.
             ws = mktempdir()
             write(joinpath(ws, "Cargo.toml"), "[workspace]\nmembers = []\n")
             mkpath(joinpath(ws, "odd"))
@@ -323,20 +328,128 @@ _id(; kwargs...) = RustCall.ArtifactId(;
             @test !any(f -> startswith(f, "target/") || startswith(f, ".git/"), ws_files2)
             @test "target" in RustCall.CRATE_INPUT_VCS_DIRS
             @test ".git" in RustCall.CRATE_INPUT_VCS_DIRS
-
-            # The strategy is hashed, so the two file sets can never collide.
-            strategy_bs, _ = RustCall.crate_input_files(bs)
-            if strategy_bs == "cargo-package-list"
-                # cargo is available: the real strategy differs from the fallback.
-                @test strategy_bs != ws_strategy
-            else
-                @info "cargo package --list unavailable; only the walk strategy exercised"
-            end
             rm(ws; force = true, recursive = true)
+
+            # Review finding (1) of the third round: files that a *distributable
+            # package* omits are still compiled, so they must still count.
+            #
+            # (a) a gitignored module pulled in with #[path].
+            ignored = crate_with(mktempdir();
+                files = Dict("src/lib.rs" => "#[path = \"generated.rs\"] mod generated;",
+                             "src/generated.rs" => "pub fn gen() -> i32 { 1 }",
+                             ".gitignore" => "src/generated.rs\n"))
+            dig_ignored = RustCall.artifact_path_dependency_digest(ignored)
+            write(joinpath(ignored, "src", "generated.rs"), "pub fn gen() -> i32 { 2 }")
+            @test RustCall.artifact_path_dependency_digest(ignored) != dig_ignored
+            _, ignored_files = RustCall.crate_input_files(ignored)
+            @test "src/generated.rs" in ignored_files
+
+            # (b) a file removed from the package by `exclude`.
+            excluded = crate_with(mktempdir();
+                manifest_extra = "exclude = [\"notes/*\"]\n",
+                files = Dict("src/lib.rs" => "pub fn f() {}",
+                             "notes/design.md" => "v1"))
+            dig_excluded = RustCall.artifact_path_dependency_digest(excluded)
+            write(joinpath(excluded, "notes", "design.md"), "v2")
+            @test RustCall.artifact_path_dependency_digest(excluded) != dig_excluded
+            _, excluded_files = RustCall.crate_input_files(excluded)
+            @test "notes/design.md" in excluded_files
+
+            rm(ignored; force = true, recursive = true)
+            rm(excluded; force = true, recursive = true)
         finally
             for d in (bs, outside)
                 rm(d; force = true, recursive = true)
             end
+        end
+    end
+
+    @testset "Local crates come from Cargo's resolved graph" begin
+        # Review finding (2) of the third round: parsing only the three
+        # root-level dependency tables misses [target.'cfg(...)'.dependencies]
+        # and workspace-inherited deps.
+        function crate(dir, name, body; manifest_extra = "")
+            mkpath(joinpath(dir, "src"))
+            write(joinpath(dir, "Cargo.toml"),
+                "[package]\nname = \"$(name)\"\nversion = \"0.1.0\"\nedition = \"2021\"\n$(manifest_extra)")
+            write(joinpath(dir, "src", "lib.rs"), body)
+            return dir
+        end
+
+        root = mktempdir()
+        try
+            grand = crate(joinpath(root, "grand"), "grand", "pub fn g() {}")
+            child = crate(joinpath(root, "child"), "child", "pub fn c() {}";
+                manifest_extra = "\n[dependencies]\ngrand = { path = \"../grand\" }\n")
+            parent = crate(joinpath(root, "parent"), "parent", "pub fn p() {}";
+                manifest_extra = "\n[target.'cfg(unix)'.dependencies]\nchild = { path = \"../child\" }\n")
+
+            strategy, dirs = RustCall.local_path_dependency_dirs(parent)
+            canon = Set(realpath.(dirs))
+
+            # A cfg-gated dependency is found ...
+            @test realpath(child) in canon
+            # ... and so is a dependency of that dependency.
+            @test realpath(grand) in canon
+
+            # Editing either one changes the key.
+            dig0 = RustCall.artifact_path_dependency_digest(parent)
+            write(joinpath(child, "src", "lib.rs"), "pub fn c() -> i32 { 9 }")
+            dig1 = RustCall.artifact_path_dependency_digest(parent)
+            @test dig1 != dig0
+            write(joinpath(grand, "src", "lib.rs"), "pub fn g() -> i32 { 9 }")
+            @test RustCall.artifact_path_dependency_digest(parent) != dig1
+
+            # The strategy is recorded and reaches the digest.
+            @test strategy in ("cargo-tree", "manifest-toml")
+            if strategy != "cargo-tree"
+                @info "cargo tree unavailable; only the manifest fallback exercised"
+            end
+
+            # The fallback finds the same cfg-gated and transitive crates.
+            fb_dirs = String[parent]
+            RustCall._collect_manifest_path_deps!(fb_dirs, parent, Set{String}())
+            fb_canon = Set(realpath.(fb_dirs))
+            @test realpath(child) in fb_canon
+            @test realpath(grand) in fb_canon
+
+            # Target-specific and workspace-inherited tables are both traversed
+            # by the fallback manifest reader.
+            @test "../child" in RustCall._declared_path_dependencies(joinpath(parent, "Cargo.toml"))
+
+            wsroot = mktempdir()
+            member = crate(joinpath(wsroot, "member"), "member", "pub fn m() {}";
+                manifest_extra = "\n[dependencies]\nshared = { workspace = true }\n")
+            crate(joinpath(wsroot, "shared"), "shared", "pub fn s() {}")
+            write(joinpath(wsroot, "Cargo.toml"),
+                "[workspace]\nmembers = [\"member\", \"shared\"]\n" *
+                "\n[workspace.dependencies]\nshared = { path = \"shared\" }\n")
+            inherited = RustCall._declared_path_dependencies(joinpath(member, "Cargo.toml"))
+            @test "shared" in inherited          # resolved through [workspace.dependencies]
+            rm(wsroot; force = true, recursive = true)
+
+            # Metadata failure is exercised: a directory with no manifest at all
+            # cannot be resolved by cargo, so the fallback answers.
+            bare = mktempdir()
+            write(joinpath(bare, "notes.txt"), "no manifest here")
+            bare_strategy, bare_dirs = RustCall.local_path_dependency_dirs(bare)
+            @test bare_strategy == "manifest-toml"
+            @test length(bare_dirs) == 1
+            rm(bare; force = true, recursive = true)
+
+            # A dependency cycle terminates.
+            cyc = mktempdir()
+            x = crate(joinpath(cyc, "x"), "x", "pub fn x() {}";
+                manifest_extra = "\n[dependencies]\ny = { path = \"../y\" }\n")
+            crate(joinpath(cyc, "y"), "y", "pub fn y() {}";
+                manifest_extra = "\n[dependencies]\nx = { path = \"../x\" }\n")
+            cyc_dirs = String[x]
+            RustCall._collect_manifest_path_deps!(cyc_dirs, x, Set{String}())
+            @test length(unique(realpath.(cyc_dirs))) == 2
+            @test length(RustCall.artifact_path_dependency_digest(x)) == 64
+            rm(cyc; force = true, recursive = true)
+        finally
+            rm(root; force = true, recursive = true)
         end
     end
 


### PR DESCRIPTION
Phase A of #278. **Strictly additive: no call site has been migrated yet.** Phase B replaces the eight ad-hoc formulas below with `artifact_key`; this PR only adds the function and the tests that pin down what it must fix, so it does not conflict with the open PRs touching `manifest.jl`, `ruststr.jl`, `generics.jl`, `structs.jl`, `crate_bindings.jl` and `cargobuild.jl`.

## What is added

- `src/artifact_id.jl` — `ArtifactId`, an exhaustive record of every input that can change the produced binary, and `artifact_key(::ArtifactId)`, the one function that hashes it.
  - **Injective by construction.** Every field is netstring-framed (`<byte length>:<bytes>,`) with a fixed field order and a schema-version prefix, so `"a" * "bc"` vs `"ab" * "c"` collisions are impossible. `artifact_encoding` is exposed so tests can assert this directly.
  - **Order-preserving type parameters.** `type_params` is a `Vector{Pair}` in declaration order; `artifact_type_params(param_order, bindings)` builds it from a `Symbol`-keyed dict without ever sorting the values. This is the class of bug behind #247.
  - **The compiler in the key is the compiler that runs.** `artifact_compiler_identity()` reads `RustToolChain.rustc()` / `cargo()` — the very commands `compiler.jl` and `cargobuild.jl` invoke — and throws `RustError` when a version cannot be determined, instead of degrading to `"unknown"` (#252).
  - **The recurring Cargo patches become structural.** `toolchain_fingerprint()` is the default for the `toolchain` field; `artifact_dependency_strings` canonicalizes the dependency set; `artifact_build_env` snapshots `ARTIFACT_BUILD_ENV_VARS` (RUSTFLAGS, CARGO_*), recording absent variables rather than dropping them. Adding an input means adding a field, once.
  - **One truncation rule, in one place.** `artifact_key` is never truncated (full 64 hex chars). `artifact_short_id` (`ARTIFACT_SHORT_ID_LEN = 16`) is the only truncation and is documented as being for human-readable names only — never a lookup key.
  - Everything is internal; no new `export`.
- `src/RustCall.jl` — one line, `include("artifact_id.jl")`, placed **immediately after `include("cache.jl")`**. That is the earliest legal point: the file needs only `exceptions.jl` (for `RustError`) and `compiler.jl`, both already included, and `toolchain_fingerprint()` from `manifest.jl` is called at run time only. This is the only edit to an existing source file.
- `test/test_artifact_id.jl` — 63 tests: key shape/determinism, injectivity (including separator smuggling and list-boundary ambiguity), a property-style check that changing **any one** of the twelve fields changes the key, type-parameter order sensitivity, toolchain/compiler sensitivity, the truncation contract, dependency canonicalization and the build-env snapshot. It is picked up automatically by `find_tests(@__DIR__)` in `test/runtests.jl` (which discovers every `test_*.jl`), so no explicit `include` was added — adding one would run the file twice, in the driver process.

  The file also **documents the current defects as tests**, asserting today's behaviour with the issue number in a comment so Phase B turns them into regression tests by flipping the assertion:
  - `DEFECT #247` reproduces `src/generics.jl:191-193` verbatim and asserts that `pair<T=Int32,U=Int64>` and `pair<T=Int64,U=Int32>` **collide** on both the cache key and the symbol suffix, then shows `artifact_key` does not.
  - `DEFECT #252` asserts that `_get_rustc_version()` returns `"unknown"` when no `rustc` is on `PATH`, while `artifact_compiler_identity()` is unaffected — the divergence between the key's compiler and the compiling compiler.
  - `DEFECT: inconsistent truncation` pins the 16- and 32-char truncations currently in use against the untruncated `artifact_key`.

No existing behaviour changes.

## Inventory of the eight cache-key sites

| # | Site | Hashes | Truncation | Omits |
|---|------|--------|-----------|-------|
| 1 | `generate_cache_key`, `src/cache.jl:114-123` | code + opt level + debug-info flag + target triple + `_get_rustc_version()` + `toolchain_fingerprint()`, concatenated with `_` and `\n---\n` | none (64 hex) | the *real* toolchain (#252 — `_get_rustc_version()` is a bare `rustc` from `PATH`, `"unknown"` on failure); dependency set; build env; cfg/features. `_`-joined fields are not injective. |
| 2 | `src/ruststr.jl:227` (in-memory library name) | wrapped code only | `[1:16]` | everything else: compiler options, target, toolchain, deps. Two blocks differing only in compiler config share a `lib_name`. |
| 3 | `src/ruststr.jl:359-363` (Cargo project + library name) | `_cargo_block_identity` (site 4) | `[1:12]` for the project name, `[1:16]` for the library name | nothing beyond what site 4 omits, but two different truncations of the same digest are used for two different purposes. |
| 4 | `_cargo_block_identity`, `src/ruststr.jl:452-461` | expanded source + `hash_dependencies` + `toolchain_fingerprint()`, joined by `\n---deps---\n` / `\n---toolchain---\n` | none | build env (RUSTFLAGS/CARGO_*), profile, target triple, features. The two `---` markers are the only field separation; a source containing them is ambiguous. |
| 5 | `src/ruststr.jl:380-381` (Cargo disk cache key) | `"$(code_hash)_$(deps_hash)_release"` — re-hashes site 4's digest with the dep hash again, mode hard-coded to `release` | `[1:32]` | build env; target; features. `_`-joined, so not injective; duplicates site 7's formula with a different literal. |
| 6 | `hash_dependencies`, `src/cargobuild.jl:134-158` | per-dep `name:version:[features]:git=…:path=…`, sorted by name, joined with `;` | none (64 hex) | registry/source, lockfile-resolved versions, default-features flag. `:`/`;` separation is textual, so a version string containing them is ambiguous. |
| 7 | `build_cargo_project_cached`, `src/cargobuild.jl:184-194` | `"$(code_hash)_$(deps_hash)_$(mode_str)"` | `[1:32]` | build env; toolchain fingerprint (only inherited if the caller's `code_hash` happened to contain it); target triple; features. |
| 8 | `compute_crate_hash`, `src/crate_bindings.jl:928-946` | concatenation of each source file's path and full contents (sorted), plus crate name and version | `[1:32]` | dependency set; toolchain fingerprint; build profile; features; build env. Path and contents are concatenated with no separator, so a rename can be masked by a content change. |
| — | monomorphization key, `src/generics.jl:191-193` (and the symbol suffix at `:208-224`, and the lookup at `:443`) | `(func_name, tuple(sort(values(type_params), by=string)...))` | n/a (in-memory tuple) | **which parameter got which type** (#247), plus the generic body, the toolchain, and the compiler config. |

Sites 1–8 are the eight string-concatenated keys named in #278; the monomorphization key is the ninth, lossy, in-memory one it also calls out.

## Testing

- `bash scripts/lint_interpolation.sh src` — OK
- `bash scripts/lint_rust_syntax_regex.sh src` — OK
- `cd deps/rustcall_extract && cargo build --release`, then `RUSTCALL_EXTRACT=… julia --project -e 'using Pkg; Pkg.test()'` — full suite green: parallel 1614/1614, serial 270/270, `test_artifact_id` among them (63 passes).

Closes nothing yet; Phase B of #278 follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD


---

## Update — Codex review of 0b4b22a addressed in 32731fb

All three P1 findings fixed inside `src/artifact_id.jl` and its tests; still additive, still no call site migrated. Test count is now 113.

1. **Unset vs empty build variables no longer collide.** Presence is explicit: `ARTIFACT_ENV_ABSENT` (`"absent"`) for unset, `"present:" * value` otherwise. Cargo distinguishes the two (an empty `RUSTFLAGS` suppresses rustflags inherited from a Cargo config).
2. **Build environment captured by prefix/allowlist, not enumeration.** `ARTIFACT_BUILD_ENV_VARS` is gone; `artifact_build_env_captured` accepts the prefixes `CARGO_PROFILE_`, `CARGO_BUILD_`, `CARGO_CFG_`, `CARGO_ENCODED_RUSTFLAGS`, the names `RUSTFLAGS`/`RUSTC`/`RUSTC_WRAPPER`/`RUSTDOCFLAGS`/`RUSTUP_TOOLCHAIN`, and `CARGO_TARGET_<TRIPLE>_RUSTFLAGS`/`_LINKER`, so every `CARGO_PROFILE_*` override is covered without a list edit. `ARTIFACT_BUILD_ENV_DENY_SUBSTRINGS` (`TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `AUTH`, `KEY`) is applied case-insensitively **before** the allowlist and on the explicit-names method too, so registry credentials can never enter a key. Mirrors the design #272 lands in `src/manifest.jl`; Phase B unifies them.
3. **Local path dependencies identified by content, not path text.** `artifact_path_dependency_digest` hashes `Cargo.toml` plus every file under `src/` (sorted relative paths + contents, `target/` skipped), recursing into declared path dependencies with a cycle guard. The absolute path is deliberately *not* part of identity, so cache hits survive a checkout move. Registry deps remain name + version + features, git deps name + URL/rev; lockfile resolution is documented as out of scope for Phase A (Phase B, see #256).

Dependency strings are now netstring-framed component by component, so the injectivity claim holds for them too.

Also: every `(@ref)` link was removed from this file's docstrings — they pointed at internal bindings absent from `docs/src/api.md` and failed the Documentation job with `Cannot resolve @ref`. `julia --project=docs docs/make.jl` now exits 0.

Re-verified: both lints OK; `julia --project=docs docs/make.jl` exit 0; full `Pkg.test()` green (parallel **1664/1664**, serial **270/270**, covering `test_artifact_id`, `test_cache`, `test_generics`, `test_regressions`).


---

## Update — second Codex review (32731fb) addressed in bd492f4

Both P1 findings fixed in `src/artifact_id.jl` and its tests; still additive, still no call site migrated. Test count is now 168.

1. **Crate inputs come from Cargo, not from a layout guess.** `crate_input_files(dir)` runs `cargo package --list --offline --allow-dirty --manifest-path <Cargo.toml>` — no build, no network — so `build.rs`, `build = "..."`, a `[lib]`/`[[bin]] path` outside `src/`, `#[path = "..."]` modules and `include`/`exclude` handling all reach the digest. If that fails (bare workspace manifest, nothing resolvable offline, cargo unavailable) it walks the package directory instead, skipping `CRATE_INPUT_VCS_DIRS` (`target`, `.git`, `.hg`, `.svn`, `.bzr`, `.jj`, `.pijul`). The strategy name is hashed alongside the file set so the two can never collide, `Cargo.lock` is always included when present, and files Cargo names but does not materialise (`Cargo.toml.orig`) are recorded as `not-on-disk`.
2. **Build-script environment inputs captured.** A second, separately documented allowlist: names `CC CXX AR LD RANLIB STRIP NM CFLAGS CXXFLAGS LDFLAGS ASFLAGS CPPFLAGS`; prefixes `TARGET_ HOST_ PKG_CONFIG CMAKE_ BINDGEN_ LIBCLANG_ CLANG_ CARGO_FEATURE_` (plus `CC_`, `CFLAGS_`, … for cc-rs's `CC_<triple>` spelling); suffixes `_CC _CXX _AR _CFLAGS _CXXFLAGS _LDFLAGS _LINKER` for the `<triple>_CC` spelling. The secret-substring rejection still runs first over both allowlists. The docstring states that this is best-effort by construction — the only complete answer is Cargo's own fingerprint — and that Phase B must treat a captured-set change as **rebuild**, never as grounds to reuse.

Re-verified: both lints OK; `julia --project=docs docs/make.jl` exit 0; full `Pkg.test()` green (parallel **1719/1719**, serial **270/270**, covering `test_artifact_id`, `test_cache`, `test_generics`, `test_regressions`).


---

## Update — third Codex review (bd492f4) addressed in facfe1e

Both P1 findings fixed in `src/artifact_id.jl` and its tests; still additive, still no call site migrated. Test count is now 185.

1. **Crate files: walk-first, `cargo package --list` dropped.** That command enumerates the *distributable* package, not what a local build reads, so a `#[path = "../ignored/mod.rs"]` module, an `include_str!` of a gitignored file and anything removed by `exclude` were compiled but never listed — and a successful listing suppressed the walk. The directory walk is now the only strategy: every regular file under the package directory, excluding `target/` and VCS metadata. `Cargo.lock` is an input like any other file. The docstring records the gap that cannot be closed here — inputs referenced *outside* the package directory are invisible, Cargo's own fingerprint is the only complete answer, and Phase B must treat this digest as a **rebuild trigger, never a proof of freshness**.
2. **Local crates come from Cargo's resolved graph.** `local_path_dependency_dirs` runs `cargo tree --offline --target all --edges normal,build,dev --prefix none --format {p}` and takes every package whose parenthesised location is an existing directory — so path dependencies at any depth from any table, including `[target.'cfg(unix)'.dependencies]` and workspace-inherited ones. (`cargo metadata` reports the same graph but only as JSON, and RustCall.jl has no JSON dependency; adding one is outside this PR's file set. `cargo tree` is line-oriented and equally offline/build-free.) `--locked` is tried first so the common case never writes to the crate directory. The manifest reader remains as the fallback and now covers every `[target.<key>]` table and `workspace = true` inheritance. Per-crate digests are folded in as a sorted set, and both strategy names are hashed.

Re-verified: both lints OK; `julia --project=docs docs/make.jl` exit 0; full `Pkg.test()` green (parallel **1736/1736**, serial **270/270**).


---

## Update — fourth Codex review (facfe1e) addressed in 1524338; rebased onto current `main`

Branch rebased onto `main` (now including #272 and #280) and force-pushed with lease. The one-line conflict in `src/RustCall.jl` was resolved by keeping both new includes after `include("cache.jl")`: `loadpolicy.jl` (#277/#280) then `artifact_id.jl` (#278). The diff against `main` is still exactly three files: `src/RustCall.jl` (+6 lines), `src/artifact_id.jl`, `test/test_artifact_id.jl`. Test count is now 204.

1. **`target` is build output only at the package root.** The exclusion list is split: `CRATE_INPUT_VCS_DIRS_ANY_LEVEL` (`.git`, `.hg`, `.svn`, `.bzr`, `.jj`, `.pijul`) is excluded at any depth, `target` only at the root, and `CRATE_INPUT_VCS_DIRS` is their union. A module directory named `src/target/` is ordinary source and is now hashed.
2. **Workspace-inherited paths resolve against the workspace manifest.** `_workspace_dependency_table` returns the declaring manifest's directory alongside the table, and inherited paths come back already resolved to absolute paths, so `workspace/member` inheriting `shared = { path = "shared" }` finds `workspace/shared` and not `workspace/member/shared`.
3. **`RUSTC_WORKSPACE_WRAPPER`** is in the environment allowlist beside `RUSTC_WRAPPER`, and both wrappers are folded into `artifact_compiler_identity()` — a wrapper stands between Cargo and rustc and changes what is produced.

Re-verified on the rebased tree: both lints OK; `julia --project=docs docs/make.jl` exit 0; `test/test_artifact_id.jl` 204/204; full `Pkg.test()` serial suite 270/270 SUCCESS and the parallel suite 2160/2162.

The two remaining parallel-suite failures are **pre-existing on `main`** and untouched by this branch — both are defect-documentation assertions in `test/test_loadpolicy.jl` (added by #280) that describe a `main` which did not yet contain #272:

- `test_loadpolicy.jl:232` asserts `!occursin("setenv", src/cargobuild.jl)`, but #272 added a `setenv` call there.
- `test_loadpolicy.jl:324` asserts seven `RUST_LIBRARIES[...] =` sites; `git grep` on `origin/main` alone counts eight (generics 1, hot_reload 1, rustmacro 1, ruststr 5).

`src/artifact_id.jl` contains no `RUST_LIBRARIES` write and does not touch `cargobuild.jl`, so neither count changes because of this PR. They need a follow-up on `main` (updating #280's documented numbers to post-#272 reality).
