### PR TITLE
Fix LoadPolicy divergence pins broken by #272 landing after #280

### DIFF
--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -7,7 +7,7 @@
 #      and what the generated `extern "C"` boundary does about it
 #   3. whether the loaded handle is registered in `RUST_LIBRARIES`, under what
 #      kind of key, whether an existing entry is replaced or kept, and whether
-#      `CURRENT_LIB` moves                                            — 7 sites
+#      `CURRENT_LIB` moves                                            — 8 sites
 #   4. the finalizer / ownership policy of the types the artifact produces
 #
 # Because the policy lives at the call site, the same user-visible construct
@@ -87,10 +87,11 @@ every front door keeps a name.
       (`src/cargoproject.jl:126-128`), and the helper library has no profile
       section at all, so the result is *Cargo's default for the profile,
       subject to `CARGO_PROFILE_<PROFILE>_PANIC` from the environment*.
-      `build_cargo_project` (`src/cargobuild.jl:25-67`) and `deps/build.jl`
-      both `run` Cargo without `setenv`, so the Julia process environment is
-      inherited and `CARGO_PROFILE_RELEASE_PANIC=abort` silently produces an
-      aborting artifact.  Resolve it with `effective_panic_strategy`;
+      `build_cargo_project` (`src/cargobuild.jl`) runs Cargo with the Julia
+      process environment unless a captured snapshot is replayed through
+      `setenv` (the `env` keyword, #272), and `deps/build.jl` always inherits,
+      so `CARGO_PROFILE_RELEASE_PANIC=abort` silently produces an aborting
+      artifact.  Resolve it with `effective_panic_strategy`;
     * `:crate_profile` — RustCall does **not** control the build: Cargo runs in
       the *user's* crate, so the effective profile (the crate's own
       `[profile.release]`, a workspace profile, `.cargo/config.toml`, or
@@ -258,8 +259,8 @@ The generated `Cargo.toml` writes only `opt-level`/`lto`
 (`src/cargoproject.jl:126-128`) and never pins `panic`, so the strategy is
 `:cargo_default`: Cargo's release default (`unwind`) *unless*
 `CARGO_PROFILE_RELEASE_PANIC` is set in the Julia process, which
-`build_cargo_project` inherits (`src/cargobuild.jl:25-67` runs Cargo with no
-`setenv`).  Either way the direct `rustc` path aborts and this one may not, and
+`build_cargo_project` inherits (`src/cargobuild.jl` runs Cargo with the
+process environment unless a snapshot `env` is replayed, #272).  Either way the direct `rustc` path aborts and this one may not, and
 no boundary catches an unwind (#244).  Use `effective_panic_strategy` to
 resolve it; Phase B should pin `panic` in the generated manifest.
 """
@@ -579,10 +580,11 @@ Resolve `policy.panic_strategy` against the environment a build would inherit.
 - `:cargo_default` is resolved by reading `cargo_panic_env_var(policy)` out of
   the environment: `"abort"` gives `:abort`, `"unwind"` gives `:unwind`, and
   anything else — unset, empty, unrecognised — gives `:unwind`, Cargo's default
-  for the `release` profile.  Both doors that carry `:cargo_default` run Cargo
-  without `setenv` (`src/cargobuild.jl:25-67`, `deps/build.jl:97-98`), so the
-  Julia process environment reaches the build and
-  `CARGO_PROFILE_RELEASE_PANIC=abort` really does change the artifact.
+  for the `release` profile.  Both doors that carry `:cargo_default` let the
+  Julia process environment reach the build (`src/cargobuild.jl` only calls
+  `setenv` to replay a captured snapshot, #272; `deps/build.jl:97-98` never
+  does), so `CARGO_PROFILE_RELEASE_PANIC=abort` really does change the
+  artifact.
 - `:crate_profile` is returned unchanged: the environment is only one of the
   inputs there, and the user's manifest — which Phase A does not read — can
   pin `panic`.  Still unknowable without reading it.
@@ -729,9 +731,9 @@ Returns `lib_name`.  A no-op returning `lib_name` for policies that do not use
 `RUST_LIBRARIES` (`:module_local`, `:helper_slot`, `:none`), so a Phase B call
 site can call it unconditionally.
 
-Subsumes the seven open-coded `RUST_LIBRARIES[...] = (handle, Dict())` sites:
-`src/ruststr.jl:251`, `:291`, `:389`, `:426`, `:837`, `src/generics.jl:252`,
-`src/hot_reload.jl:210`.  Not called from `src/` yet (Phase A is additive).
+Subsumes the eight open-coded `RUST_LIBRARIES[...] = ...` sites:
+`src/ruststr.jl:335`, `:375`, `:483`, `:520`, `:997`, `src/generics.jl:261`,
+`src/hot_reload.jl:210`, and the reload alias `src/rustmacro.jl:166` (#272).  Not called from `src/` yet (Phase A is additive).
 """
 function register_library!(policy::LoadPolicy, lib_name::AbstractString, handle::Ptr{Cvoid})
     name = String(lib_name)

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -226,10 +226,11 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
 
         # The two Cargo-backed doors RustCall itself drives pin no `panic`, so
         # they take Cargo's release default — and the CARGO_PROFILE_RELEASE_PANIC
-        # override, because neither build calls setenv: src/cargobuild.jl runs
-        # `cargo build` with the inherited environment, as does deps/build.jl.
+        # override. src/cargobuild.jl runs `cargo build` with the inherited
+        # environment unless a captured snapshot is replayed (#272 added the
+        # `env === nothing || setenv` branch); deps/build.jl always inherits.
         # Same source, different artifact depending on the caller's env (#244).
-        @test !occursin("setenv", _src("cargobuild.jl"))
+        @test occursin("env === nothing || (cmd = setenv(cmd, env))", _src("cargobuild.jl"))
         for policy in (RustCall.inline_cargo_policy(), RustCall.helper_library_policy())
             @test policy.panic_strategy === :cargo_default
             @test policy.cargo_profile === :release
@@ -320,8 +321,10 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
             writes += count(_ -> true,
                             eachmatch(r"RUST_LIBRARIES\[[^\]]*\]\s*=", _src(file)))
         end
-        # Seven open-coded registration sites on current main.
-        @test writes == 7
+        # Eight open-coded registration sites on current main: five in
+        # ruststr.jl, generics.jl, hot_reload.jl, and the reload alias that
+        # #272 added in rustmacro.jl (`_alias_reloaded_library`).
+        @test writes == 8
 
         # Each site decides for itself whether CURRENT_LIB moves and what the
         # key looks like; the policies record that disagreement.


### PR DESCRIPTION
`main` is red since #272 and #280 merged back to back: #280's `test/test_loadpolicy.jl` pins facts about `main` that #272 changed.

- `test_loadpolicy.jl:232` asserted `cargobuild.jl` contains no `setenv`; #272 added `env === nothing || (cmd = setenv(cmd, env))` to replay a captured snapshot. The pin now asserts that exact branch.
- `test_loadpolicy.jl:324` asserted seven `RUST_LIBRARIES[...] =` sites; #272's `_alias_reloaded_library` in `rustmacro.jl` is the eighth. The pin now says eight and names it.
- Docstrings in `src/loadpolicy.jl` refreshed (site count, `setenv` wording, cited line numbers).

`test/test_loadpolicy.jl`: 256/256 locally. Both lints pass. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
