### PR TITLE
Make #[julia] additive: original item kept, extern "C" wrapper emitted alongside (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking
-- The FFI manifest schema is now version 2 (`rustcall_core::manifest::SCHEMA_VERSION`,
+- `#[julia]` is **additive**: the annotated item is kept exactly as written
+  (minus the attribute itself) and the `extern "C"` entry point is emitted
+  *next to it* under a distinct symbol
+  ([#279](https://github.com/AtelierArith/RustCall.jl/issues/279)).
+  The export-symbol scheme, documented at the top of
+  `deps/rustcall_core/src/codegen.rs`, is:
+
+  | generated item | symbol |
+  |---|---|
+  | free function `f` | `rustcall_f` |
+  | method / constructor `Struct::m` | `rustcall_Struct_m` |
+  | specialized generic instantiation `f_i32` | `rustcall_f_i32` |
+  | destructor / accessors / clone | `Struct_free`, `Struct_get_x`, `Struct_set_x`, `Struct_clone` (unchanged) |
+  | `Result` / `Option` payloads | `CResult_f`, `COption_f` (unchanged) |
+  | string buffers | `<owner>_RustCallOwnedString`, `<owner>_free_rust_string`, `<owner>_RustCallBorrowedString` (unchanged) |
+
+  Nothing changes for Julia users: `add(1, 2)`, `@rust add(...)`, `@rust_crate`
+  and `write_bindings_to_file` all go through the manifest's `symbol` field.
+  What changes is that `fn shout(s: String) -> String` still *exists* in Rust
+  after expansion, so `#[julia]` now composes with `#[pyfunction]`, with
+  in-crate callers, with `#[test]`s and with `pub use` re-exports. Anyone who
+  `dlsym`ed the Rust name directly must switch to the `rustcall_`-prefixed
+  symbol, and any generated bindings (e.g. a `write_bindings_to_file` module)
+  must be regenerated.
+- The FFI manifest schema is now version 3
+  ([#279](https://github.com/AtelierArith/RustCall.jl/issues/279)):
+  `Function.symbol` and `Method.symbol` differ from `name` for *every* wrapped
+  item, not only for generic instantiations. A RustCall.jl expecting schema 2
+  refuses a version-3 manifest and vice versa. **Rebuild the extractor** with
+  `Pkg.build("RustCall")` after updating.
+- The FFI manifest schema was version 2 (`rustcall_core::manifest::SCHEMA_VERSION`,
   `RustCall.MANIFEST_SCHEMA_VERSION`): the string ABI columns `abi`,
   `return_abi` and the `has_owned_string_helper` / `has_borrowed_string_helper`
   flags change how the exported symbols must be called, so a RustCall.jl that

--- a/deps/juliacall_macros/Cargo.toml
+++ b/deps/juliacall_macros/Cargo.toml
@@ -25,3 +25,7 @@ proc-macro2 = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"
+# `#[julia]` must compose with other proc-macro attributes (#279); the
+# regression test in tests/pyo3_compose.rs stacks it with `#[pyfunction]`.
+# Only the macro machinery is needed, not the extension-module glue.
+pyo3 = { version = "0.29", default-features = false, features = ["macros"] }

--- a/deps/juliacall_macros/examples/pyo3_compose.rs
+++ b/deps/juliacall_macros/examples/pyo3_compose.rs
@@ -1,0 +1,99 @@
+//! `#[julia]` composes with other proc-macro attributes (#279).
+//!
+//! Before #279 `#[julia]` *replaced* the annotated item, so PyO3's generated
+//! wrapper called the transformed signature and stacking the two attributes
+//! failed to compile for every `Result` / `Option` / `String` signature
+//! (see #275). `#[julia]` is now additive: the item stays exactly as written
+//! and the C entry point is emitted next to it as `rustcall_<fn>`.
+//!
+//! This is a **compile** test in both attribute orders. It lives in
+//! `examples/` rather than `tests/` on purpose: `cargo test` and
+//! `cargo clippy --all-targets` build it, but nothing runs it, so the suite
+//! never has to load libpython on a machine that only has the headers.
+//! The runnable assertions live in `tests/additive.rs`, which needs no PyO3.
+
+#![allow(dead_code)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use juliacall_macros::julia;
+use pyo3::prelude::*;
+
+/// The error type is a plain FFI-compatible newtype: RustCall needs a payload
+/// that survives the C ABI, PyO3 needs `Into<PyErr>`.
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Odd(pub i32);
+
+impl From<Odd> for PyErr {
+    fn from(value: Odd) -> PyErr {
+        pyo3::exceptions::PyValueError::new_err(value.0)
+    }
+}
+
+// `Result`, `#[julia]` outermost.
+#[julia]
+#[pyfunction]
+fn checked_halve(x: i32) -> Result<i32, Odd> {
+    if x % 2 == 0 {
+        Ok(x / 2)
+    } else {
+        Err(Odd(x))
+    }
+}
+
+// `Result`, `#[pyfunction]` outermost.
+#[pyfunction]
+#[julia]
+fn checked_halve_flipped(x: i32) -> Result<i32, Odd> {
+    if x % 2 == 0 {
+        Ok(x / 2)
+    } else {
+        Err(Odd(x))
+    }
+}
+
+// `String` in and out, both orders.
+#[julia]
+#[pyfunction]
+fn shout(s: String) -> String {
+    s.to_uppercase()
+}
+
+#[pyfunction]
+#[julia]
+fn shout_flipped(s: String) -> String {
+    s.to_uppercase()
+}
+
+// `Option`, and a signature with nothing to transform.
+#[julia]
+#[pyfunction]
+fn maybe_pred(x: i32) -> Option<i32> {
+    x.checked_sub(1)
+}
+
+#[pyfunction]
+#[julia]
+fn plain_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+/// An ordinary in-crate caller still sees the signature that was written.
+fn in_crate_caller() -> String {
+    format!(
+        "{:?}|{:?}|{}|{}|{:?}|{}",
+        checked_halve(4),
+        checked_halve_flipped(8),
+        shout("hi".to_string()),
+        shout_flipped("hi".to_string()),
+        maybe_pred(3),
+        plain_add(1, 2),
+    )
+}
+
+fn main() {
+    println!("{}", in_crate_caller());
+    // The C entry points live next to the originals.
+    assert!(rustcall_checked_halve(4).is_ok());
+    assert_eq!(rustcall_plain_add(2, 3), 5);
+}

--- a/deps/juliacall_macros/src/lib.rs
+++ b/deps/juliacall_macros/src/lib.rs
@@ -11,7 +11,12 @@
 //!
 //! ## Functions
 //!
-//! The `#[julia]` attribute on functions expands to `#[no_mangle] pub extern "C"`:
+//! `#[julia]` is **additive** (#279): the annotated item is kept exactly as
+//! written and a `#[no_mangle] pub extern "C" fn rustcall_<name>` wrapper that
+//! calls it is emitted next to it. The function therefore still has its own
+//! Rust signature for in-crate callers, `#[test]`s and other proc-macros such
+//! as `#[pyfunction]`, while Julia calls the `rustcall_`-prefixed symbol
+//! recorded in the manifest.
 //!
 //! ```rust,ignore
 //! use juliacall_macros::julia;
@@ -30,8 +35,9 @@
 //! ## Structs
 //!
 //! The `#[julia]` attribute on structs adds `#[repr(C)]` and generates FFI functions
-//! like `Point_free`, getters, and setters. `#[julia]` on an impl block wraps the
-//! methods that are themselves marked `#[julia]` (`Point_new`, `Point_distance`, ...).
+//! like `Point_free`, getters, and setters. `#[julia]` on an impl block leaves the
+//! methods alone and emits a wrapper next to the block for each method that is
+//! itself marked `#[julia]` (`rustcall_Point_new`, `rustcall_Point_distance`, ...).
 
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;

--- a/deps/juliacall_macros/tests/additive.rs
+++ b/deps/juliacall_macros/tests/additive.rs
@@ -1,0 +1,112 @@
+//! `#[julia]` is additive (#279): the annotated item survives unchanged and
+//! the C entry point is emitted next to it under `rustcall_<fn>` /
+//! `rustcall_<Struct>_<method>`.
+//!
+//! The `#[pyfunction]` composition counterpart is `examples/pyo3_compose.rs`.
+
+#![allow(dead_code)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use juliacall_macros::julia;
+
+#[julia]
+fn checked_halve(x: i32) -> Result<i32, i32> {
+    if x % 2 == 0 {
+        Ok(x / 2)
+    } else {
+        Err(x)
+    }
+}
+
+#[julia]
+fn maybe_pred(x: i32) -> Option<i32> {
+    x.checked_sub(1)
+}
+
+#[julia]
+fn shout(s: String) -> String {
+    s.to_uppercase()
+}
+
+#[julia]
+fn byte_len(s: &str) -> usize {
+    s.len()
+}
+
+#[julia]
+fn plain_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+pub struct Counter {
+    value: i32,
+}
+
+#[julia]
+impl Counter {
+    #[julia]
+    pub fn new(value: i32) -> Self {
+        Self { value }
+    }
+
+    #[julia]
+    pub fn bump(&mut self, by: i32) -> i32 {
+        self.value += by;
+        self.value
+    }
+}
+
+/// An ordinary in-crate caller sees the signature that was written.
+fn in_crate_caller() -> String {
+    format!(
+        "{:?}|{}|{}",
+        checked_halve(4),
+        shout("hi".into()),
+        byte_len("abc")
+    )
+}
+
+#[test]
+fn annotated_items_keep_their_rust_signature() {
+    assert_eq!(checked_halve(4), Ok(2));
+    assert_eq!(checked_halve(5), Err(5));
+    assert_eq!(maybe_pred(i32::MIN), None);
+    assert_eq!(shout("hi".to_string()), "HI");
+    assert_eq!(byte_len("abc"), 3);
+    assert_eq!(plain_add(2, 3), 5);
+    assert_eq!(in_crate_caller(), "Ok(2)|HI|3");
+
+    let mut counter = Counter::new(1);
+    assert_eq!(counter.bump(2), 3);
+}
+
+#[test]
+fn the_c_entry_point_is_the_rustcall_symbol() {
+    let ok = rustcall_checked_halve(4);
+    assert!(ok.is_ok());
+    assert_eq!(*ok.ok().unwrap(), 2);
+    let err = rustcall_checked_halve(5);
+    assert!(!err.is_ok());
+    assert_eq!(*err.err().unwrap(), 5);
+
+    let some = rustcall_maybe_pred(3);
+    assert!(some.is_some());
+    assert_eq!(*some.some().unwrap(), 2);
+
+    assert_eq!(rustcall_plain_add(2, 3), 5);
+
+    // `String` / `&str` arguments and returns travel as the byte-pair ABI (#242).
+    let input = "hi";
+    assert_eq!(rustcall_byte_len(input.as_ptr(), input.len()), 2);
+    let out = rustcall_shout(input.as_ptr(), input.len());
+    let bytes = unsafe { std::slice::from_raw_parts(out.ptr, out.len) };
+    assert_eq!(std::str::from_utf8(bytes).unwrap(), "HI");
+    shout_free_rust_string(out.ptr, out.len, out.cap);
+}
+
+#[test]
+fn method_wrappers_are_prefixed_too() {
+    let ptr = rustcall_Counter_new(10);
+    assert_eq!(rustcall_Counter_bump(ptr, 5), 15);
+    unsafe { drop(Box::from_raw(ptr)) };
+}

--- a/deps/juliacall_macros/tests/basic.rs
+++ b/deps/juliacall_macros/tests/basic.rs
@@ -160,32 +160,32 @@ fn main() {
     assert!((TestPoint_get_x(ptr) - 5.0).abs() < 1e-10);
 
     // Verify Counter FFI functions exist
-    let counter_ptr = Counter_new(10);
-    assert_eq!(Counter_get_value(counter_ptr), 10);
-    Counter_increment(counter_ptr);
-    assert_eq!(Counter_get_value(counter_ptr), 11);
+    let counter_ptr = rustcall_Counter_new(10);
+    assert_eq!(rustcall_Counter_get_value(counter_ptr), 10);
+    rustcall_Counter_increment(counter_ptr);
+    assert_eq!(rustcall_Counter_get_value(counter_ptr), 11);
     Counter_free(counter_ptr);
 
     // Test Result<T, E> functions
     println!("Testing Result<T, E> functions...");
 
     // Test divide (success case)
-    let div_result = divide(10.0, 2.0);
+    let div_result = rustcall_divide(10.0, 2.0);
     assert!(div_result.is_ok());
     assert!((*div_result.ok().unwrap() - 5.0).abs() < 1e-10);
 
     // Test divide (error case - division by zero)
-    let div_err = divide(10.0, 0.0);
+    let div_err = rustcall_divide(10.0, 0.0);
     assert!(!div_err.is_ok());
     assert_eq!(*div_err.err().unwrap(), -1);
 
     // Test parse_positive (success case)
-    let parse_result = parse_positive(42);
+    let parse_result = rustcall_parse_positive(42);
     assert!(parse_result.is_ok());
     assert_eq!(*parse_result.ok().unwrap(), 42);
 
     // Test parse_positive (error case)
-    let parse_err = parse_positive(-5);
+    let parse_err = rustcall_parse_positive(-5);
     assert!(!parse_err.is_ok());
     assert_eq!(*parse_err.err().unwrap(), -5);
 
@@ -193,46 +193,58 @@ fn main() {
     println!("Testing Option<T> functions...");
 
     // Test safe_divide (Some case)
-    let opt_result = safe_divide(10.0, 2.0);
+    let opt_result = rustcall_safe_divide(10.0, 2.0);
     assert!(opt_result.is_some());
     assert!((*opt_result.some().unwrap() - 5.0).abs() < 1e-10);
 
     // Test safe_divide (None case)
-    let opt_none = safe_divide(10.0, 0.0);
+    let opt_none = rustcall_safe_divide(10.0, 0.0);
     assert!(!opt_none.is_some());
 
     // Test find_first_positive (Some case - first arg)
-    let find_result = find_first_positive(5, -3);
+    let find_result = rustcall_find_first_positive(5, -3);
     assert!(find_result.is_some());
     assert_eq!(*find_result.some().unwrap(), 5);
 
     // Test find_first_positive (Some case - second arg)
-    let find_result2 = find_first_positive(-1, 10);
+    let find_result2 = rustcall_find_first_positive(-1, 10);
     assert!(find_result2.is_some());
     assert_eq!(*find_result2.some().unwrap(), 10);
 
     // Test find_first_positive (None case)
-    let find_none = find_first_positive(-1, -2);
+    let find_none = rustcall_find_first_positive(-1, -2);
     assert!(!find_none.is_some());
 
     // Test Builder pattern (issue #160)
     println!("Testing builder pattern...");
 
     // Test constructor
-    let builder_ptr = Builder_new();
-    assert_eq!(Builder_get_x(builder_ptr), 0);
+    let builder_ptr = rustcall_Builder_new();
+    assert_eq!(rustcall_Builder_get_x(builder_ptr), 0);
 
     // Test builder method (NOT a constructor — should take a pointer, not return a boxed one)
-    let x_val = Builder_set_x(builder_ptr, 10);
+    let x_val = rustcall_Builder_set_x(builder_ptr, 10);
     assert_eq!(x_val, 10);
-    assert_eq!(Builder_get_x(builder_ptr), 10);
+    assert_eq!(rustcall_Builder_get_x(builder_ptr), 10);
 
     // Test static constructor (create_default returns Self)
-    let builder2_ptr = Builder_create_default();
-    assert_eq!(Builder_get_x(builder2_ptr), 42);
+    let builder2_ptr = rustcall_Builder_create_default();
+    assert_eq!(rustcall_Builder_get_x(builder2_ptr), 42);
 
     Builder_free(builder_ptr);
     Builder_free(builder2_ptr);
+
+    // #279: `#[julia]` is additive, so every annotated item is still callable
+    // from Rust with the signature it was written with.
+    assert_eq!(simple_add(2, 3), 5);
+    assert_eq!(divide(10.0, 2.0), Ok(5.0));
+    assert_eq!(divide(1.0, 0.0), Err(-1));
+    assert_eq!(parse_positive(7), Ok(7u32));
+    assert_eq!(safe_divide(9.0, 3.0), Some(3.0));
+    assert_eq!(find_first_positive(-1, -2), None);
+    let mut counter = Counter::new(1);
+    counter.increment();
+    assert_eq!(counter.get_value(), 2);
 
     println!("All tests passed!");
 }

--- a/deps/rustcall_core/src/attrs.rs
+++ b/deps/rustcall_core/src/attrs.rs
@@ -16,6 +16,40 @@ pub fn is_rustcall_attr(attr: &Attribute) -> bool {
     is_julia_attr(attr) || is_julia_pyo3_attr(attr)
 }
 
+/// Whether the item carries a PyO3 entry-point attribute (`#[pyfunction]`,
+/// `#[pyo3::pyfunction]`, `#[pymethods]`, `#[pyclass]`, ...).
+pub fn is_pyo3_attr(attr: &Attribute) -> bool {
+    attr.path()
+        .segments
+        .last()
+        .map(|s| {
+            let name = s.ident.to_string();
+            matches!(
+                name.as_str(),
+                "pyfunction" | "pymethods" | "pyclass" | "pymodule"
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Whether `#[julia]` owns this item's C entry point.
+///
+/// Since #279 `#[julia]` is additive, so an item may carry both `#[julia]` and
+/// `#[pyfunction]` and get a Julia wrapper *and* a Python one. When both are
+/// present `#[julia]` is authoritative for the C symbol: it already emits
+/// `rustcall_<name>`, so a PyO3-driven scan (#275) must skip the item rather
+/// than emit a second wrapper under the same symbol.
+pub fn julia_owns_entry_point(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(is_julia_attr)
+}
+
+/// Whether a PyO3 scan (#275) should generate a wrapper for this item: it
+/// carries a PyO3 attribute and `#[julia]` has not already claimed it (see
+/// [`julia_owns_entry_point`]).
+pub fn pyo3_scan_selects(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(is_pyo3_attr) && !julia_owns_entry_point(attrs)
+}
+
 /// Which RustCall attribute marks the item, if any.
 pub fn rustcall_attribute(attrs: &[Attribute]) -> ManifestAttribute {
     if attrs.iter().any(is_julia_attr) {

--- a/deps/rustcall_core/src/attrs.rs
+++ b/deps/rustcall_core/src/attrs.rs
@@ -126,3 +126,34 @@ pub fn has_no_mangle(attrs: &[Attribute]) -> bool {
                 && matches!(&a.meta, Meta::List(l) if l.tokens.to_string().contains("no_mangle")))
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attrs_of(source: &str) -> Vec<Attribute> {
+        syn::parse_str::<syn::ItemFn>(source).unwrap().attrs
+    }
+
+    /// An item carrying both attributes is owned by `#[julia]`: it already
+    /// exports `rustcall_<name>`, so the PyO3 scan of #275 must skip it rather
+    /// than emit a second wrapper under the same symbol (#279).
+    #[test]
+    fn julia_wins_over_pyfunction() {
+        let both = attrs_of("#[julia] #[pyfunction] fn f() {}");
+        assert!(julia_owns_entry_point(&both));
+        assert!(!pyo3_scan_selects(&both));
+
+        let flipped = attrs_of("#[pyo3::pyfunction] #[julia] fn f() {}");
+        assert!(julia_owns_entry_point(&flipped));
+        assert!(!pyo3_scan_selects(&flipped));
+
+        let pyo3_only = attrs_of("#[pyfunction] fn f() {}");
+        assert!(!julia_owns_entry_point(&pyo3_only));
+        assert!(pyo3_scan_selects(&pyo3_only));
+
+        let neither = attrs_of("#[inline] fn f() {}");
+        assert!(!julia_owns_entry_point(&neither));
+        assert!(!pyo3_scan_selects(&neither));
+    }
+}

--- a/deps/rustcall_core/src/codegen.rs
+++ b/deps/rustcall_core/src/codegen.rs
@@ -8,9 +8,46 @@
 //! * **inline** codegen, used by the extractor CLI's `expand` command for
 //!   `rust"""` blocks (`inline_struct_wrappers`, `inline_generic_wrappers`).
 //!
-//! `transform_function` is common to both flavours, so `#[julia] fn` behaves
-//! identically in inline blocks and in crates (including the C-compatible
-//! `Result`/`Option` wrappers).
+//! Every `extern "C"` entry point — inline function, crate function,
+//! specialized generic instantiation, inline method, crate method,
+//! `julia_pyo3` function — is produced by the one generator
+//! [`generate_wrapper`]; the public `transform_*` functions are thin adapters
+//! that fill in a [`WrapperSpec`]. Adding a flavour therefore cannot lose the
+//! string ABI, the `#[cfg]` propagation or the receiver handling again (#279).
+//!
+//! # `#[julia]` is additive (#279)
+//!
+//! The annotated item is kept **byte-for-byte**, minus the `#[julia]`
+//! attribute itself, and the FFI entry point is emitted *next to it* under a
+//! distinct symbol. Every in-crate caller, `#[test]`, `pub use` re-export and
+//! other proc-macro (notably `#[pyfunction]`) therefore still sees the Rust
+//! signature that was written.
+//!
+//! # Export-symbol scheme
+//!
+//! | generated item | symbol |
+//! |---|---|
+//! | free function `f` | `rustcall_f` |
+//! | method / constructor `Struct::m` | `rustcall_Struct_m` |
+//! | specialized generic instantiation `f_i32` | `rustcall_f_i32` |
+//! | struct destructor | `Struct_free` |
+//! | field accessors | `Struct_get_x` / `Struct_set_x` |
+//! | clone | `Struct_clone` |
+//! | `Result` / `Option` payload | `CResult_f` / `COption_f` |
+//! | owned string buffer / release | `<owner>_RustCallOwnedString` / `<owner>_free_rust_string` |
+//! | borrowed string view | `<owner>_RustCallBorrowedString` |
+//!
+//! Only the first three wrap a user-written item and so must step aside from
+//! its name; `<owner>` is the free function, `<Struct>_<method>` or `<Struct>`
+//! the buffer belongs to. The remaining items are purely generated and keep
+//! the names they have always had.
+//!
+//! The scheme is stable and part of artifact identity: the manifest carries it
+//! in `Function.symbol` / `Method.symbol` (schema 3) and every Julia-side
+//! `ccall` / `dlsym` goes through those fields, never through the Rust name.
+//! Inline expansion additionally refuses a block in which a user item already
+//! owns a generated symbol (see `crate::expand::symbol_collisions`); the
+//! proc-macro sees one item at a time and cannot make that check.
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -24,36 +61,29 @@ use crate::model::{MethodModel, StructModel};
 use crate::types::{
     extract_option_type, extract_result_type, is_ffi_compatible_type,
     is_inline_accessible_field_type, is_non_ffi_type, is_self_type, is_str_ref_type,
-    is_string_type, is_vec_type, needs_clone_for_getter, unparen, OptionTypeInfo, ResultTypeInfo,
+    is_string_type, is_vec_type, needs_clone_for_getter, unparen,
 };
 
 // ============================================================================
-// Functions (shared)
+// Export-symbol scheme (#279)
 // ============================================================================
 
-/// Transform a `#[julia]` function to FFI-compatible form.
-pub fn transform_function(func: ItemFn) -> TokenStream2 {
-    if func.sig.unsafety.is_some() {
-        return quote! {
-            compile_error!("#[julia] cannot be applied to unsafe functions directly. The function will be made extern \"C\" which has its own safety semantics.");
-        };
-    }
+/// Prefix of every exported symbol that stands in for a user-written item.
+pub const SYMBOL_PREFIX: &str = "rustcall_";
 
-    if let ReturnType::Type(_, ref ret_type) = func.sig.output {
-        if let Some(result_info) = extract_result_type(ret_type) {
-            return transform_result_function(func, result_info);
-        }
-        if let Some(option_info) = extract_option_type(ret_type) {
-            return transform_option_function(func, option_info);
-        }
-    }
-
-    if function_uses_strings(&func.sig) {
-        return transform_string_function(func);
-    }
-
-    transform_simple_function(func)
+/// Exported symbol of the `extern "C"` wrapper of the free function `name`.
+pub fn function_symbol(name: &str) -> String {
+    format!("{SYMBOL_PREFIX}{name}")
 }
+
+/// Exported symbol of the `extern "C"` wrapper of `Struct::method`.
+pub fn method_symbol(struct_name: &str, method: &str) -> String {
+    format!("{SYMBOL_PREFIX}{struct_name}_{method}")
+}
+
+// ============================================================================
+// Signature predicates (shared)
+// ============================================================================
 
 /// Whether a `#[julia]` function takes or returns `String` / `&str` (#242).
 pub fn function_uses_strings(sig: &syn::Signature) -> bool {
@@ -120,8 +150,10 @@ fn fresh_ident(base: &str, taken: &[String]) -> Ident {
     format_ident!("{}", name)
 }
 
-/// Names of every typed argument of a signature (destructuring patterns
-/// rendered as `argN`, see [`normalize_arg_patterns`]).
+/// Names of every typed argument of a signature. A destructuring pattern
+/// (`fn f((a, b): (i32, i32))`) has no name of its own, so the wrapper calls
+/// its argument `argN`; the annotated item keeps the pattern, because the
+/// wrapper passes the arguments on positionally.
 fn typed_arg_names(sig: &syn::Signature) -> Vec<Ident> {
     sig.inputs
         .iter()
@@ -133,6 +165,19 @@ fn typed_arg_names(sig: &syn::Signature) -> Vec<Ident> {
             }),
             FnArg::Receiver(_) => None,
         })
+        .collect()
+}
+
+/// `(name, type)` of every typed argument, in declaration order.
+fn arg_pairs(sig: &syn::Signature) -> Vec<(Ident, Type)> {
+    sig.inputs
+        .iter()
+        .filter_map(|a| match a {
+            FnArg::Typed(pt) => Some((*pt.ty).clone()),
+            FnArg::Receiver(_) => None,
+        })
+        .zip(typed_arg_names(sig))
+        .map(|(ty, name)| (name, ty))
         .collect()
 }
 
@@ -175,102 +220,172 @@ fn string_arg_conversion(
     }
 }
 
-/// Wrapper-side view of a function's arguments (see [`string_arg_conversion`]).
-struct StringArgs {
-    wrapper_args: Vec<TokenStream2>,
-    conversions: Vec<TokenStream2>,
-    call_args: Vec<TokenStream2>,
+// ============================================================================
+// The one wrapper generator (#279)
+// ============================================================================
+
+/// The receiver of a method wrapper: the wrapper takes `*const` / `*mut Struct`
+/// and dereferences it into `self_obj`.
+pub(crate) struct WrapperReceiver {
+    pub ty: Ident,
+    pub mutable: bool,
 }
 
-fn string_arg_conversions(func: &ItemFn, names: &[Ident]) -> StringArgs {
-    let taken: Vec<String> = names.iter().map(ToString::to_string).collect();
+/// The item the wrapper calls. Always the original, under its own name.
+pub(crate) enum CallTarget {
+    /// `f(args)`
+    Free(Ident),
+    /// `Struct::m(args)`
+    Assoc { ty: Ident, method: Ident },
+    /// `self_obj.m(args)`
+    Instance(Ident),
+}
+
+/// How the wrapper hands the value back across the C ABI.
+///
+/// `syn::Type` is a large enum; the variants carry it by value because a
+/// wrapper spec is built once per generated item and immediately consumed.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum WrapperReturn {
+    /// No return value.
+    Unit,
+    /// Returned as written.
+    Plain(Type),
+    /// The value is boxed and returned as `*mut Struct` (constructors and
+    /// anything returning `Self`).
+    Boxed(Ident),
+    /// `<helper> { ptr, len, cap }`, released through `<free>`.
+    OwnedString {
+        helper: Ident,
+        free: Ident,
+        /// Whether this wrapper declares the buffer type and its release
+        /// function (false when a struct-level helper is shared).
+        declare: bool,
+    },
+    /// `<helper> { ptr, len }` borrowed from the callee.
+    BorrowedStr { helper: Ident, declare: bool },
+    /// `CResult_<owner> { is_ok, ok_value, err_value }`.
+    CResult { name: Ident, ok: Type, err: Type },
+    /// `COption_<owner> { is_some, value }`.
+    COption { name: Ident, inner: Type },
+}
+
+/// Everything [`generate_wrapper`] needs: a signature model plus the call
+/// target. Every flavour of `#[julia]` codegen fills this in and so gets
+/// identical lowering by construction (#279).
+pub(crate) struct WrapperSpec {
+    /// Exported symbol, see the module docs.
+    pub symbol: Ident,
+    /// `#[cfg]` / `#[cfg_attr]` attributes replicated onto every generated item.
+    pub cfg_attrs: Vec<Attribute>,
+    pub receiver: Option<WrapperReceiver>,
+    pub args: Vec<(Ident, Type)>,
+    /// Whether `String` / `&str` arguments are lowered to `(ptr, len)` pairs.
+    /// Only `#[julia_pyo3]`, which exports the signature as written, says no.
+    pub lower_strings: bool,
+    pub ret: WrapperReturn,
+    pub target: CallTarget,
+}
+
+/// The single `extern "C"` wrapper generator: every entry point of this module
+/// goes through it, so the string ABI, the `#[cfg]` propagation and the
+/// receiver handling cannot diverge between flavours.
+pub(crate) fn generate_wrapper(spec: WrapperSpec) -> TokenStream2 {
+    let WrapperSpec {
+        symbol,
+        cfg_attrs,
+        receiver,
+        args,
+        lower_strings,
+        ret,
+        target,
+    } = spec;
+
+    let taken: Vec<String> = args.iter().map(|(n, _)| n.to_string()).collect();
+    let ptr = fresh_ident("ptr", &taken);
+    let self_obj = fresh_ident("self_obj", &taken);
+
     let mut wrapper_args: Vec<TokenStream2> = Vec::new();
     let mut conversions: Vec<TokenStream2> = Vec::new();
     let mut call_args: Vec<TokenStream2> = Vec::new();
-    for (arg, name) in func.sig.inputs.iter().zip(names.iter()) {
-        let FnArg::Typed(pat_type) = arg else {
-            continue;
-        };
-        let (args, conversion) = string_arg_conversion(name, &pat_type.ty, &taken);
-        wrapper_args.extend(args);
-        conversions.extend(conversion);
+
+    if let Some(r) = &receiver {
+        let ty = &r.ty;
+        wrapper_args.push(if r.mutable {
+            quote! { #ptr: *mut #ty }
+        } else {
+            quote! { #ptr: *const #ty }
+        });
+    }
+    for (name, ty) in &args {
+        if lower_strings {
+            let (a, conversion) = string_arg_conversion(name, ty, &taken);
+            wrapper_args.extend(a);
+            conversions.extend(conversion);
+        } else {
+            wrapper_args.push(quote! { #name: #ty });
+        }
         call_args.push(quote! { #name });
     }
-    StringArgs {
-        wrapper_args,
-        conversions,
-        call_args,
-    }
-}
 
-/// `#[julia] fn f(s: String, t: &str) -> String` (#242).
-///
-/// Also applied by [`crate::specialize`] to the instantiation of a generic
-/// function whose fixed parameters are strings.
-///
-/// Same ABI as the struct method wrappers: every `String` / `&str` argument
-/// becomes a `(*const u8, usize)` pair (UTF-8, not NUL-terminated); a `String`
-/// return becomes `<fn>_RustCallOwnedString { ptr, len, cap }` released with
-/// `<fn>_free_rust_string(ptr, len, cap)`; a `&str` return becomes
-/// `<fn>_RustCallBorrowedString { ptr, len }` (the caller keeps the borrowed
-/// data alive). The original function is kept as `<fn>_inner`.
-pub fn transform_string_function(func: ItemFn) -> TokenStream2 {
-    let inner_fn = func.clone();
-    let mut func = func;
-    let names = normalize_arg_patterns(&mut func);
-    let func_name = &func.sig.ident;
-    let inner_fn_name = format_ident!("{}_inner", func_name);
-    let inner_fn_args = &inner_fn.sig.inputs;
-    let inner_output = &inner_fn.sig.output;
-    // Lifetime parameters (`fn f<'a>(s: &'a str) -> &'a str`) stay on the inner fn.
-    let inner_generics = &inner_fn.sig.generics;
-    let inner_where = &inner_fn.sig.generics.where_clause;
-    let body = &inner_fn.block;
-    let cfg_attrs = cfg_attrs(&func.attrs);
-    let outer_attrs = &func.attrs;
+    let self_binding = match &receiver {
+        None => quote! {},
+        Some(r) if r.mutable => quote! { let #self_obj = unsafe { &mut *#ptr }; },
+        Some(_) => quote! { let #self_obj = unsafe { &*#ptr }; },
+    };
+    let call = match &target {
+        CallTarget::Free(name) => quote! { #name(#(#call_args),*) },
+        CallTarget::Assoc { ty, method } => quote! { #ty::#method(#(#call_args),*) },
+        CallTarget::Instance(method) => quote! { #self_obj.#method(#(#call_args),*) },
+    };
+    let prologue = quote! { #(#conversions)* #self_binding };
 
-    let StringArgs {
-        wrapper_args,
-        conversions,
-        call_args,
-    } = string_arg_conversions(&func, &names);
-
-    let owned_helper = format_ident!("{}_RustCallOwnedString", func_name);
-    let owned_free = format_ident!("{}_free_rust_string", func_name);
-    let borrowed_helper = format_ident!("{}_RustCallBorrowedString", func_name);
-    let call = quote! { #inner_fn_name(#(#call_args),*) };
-
-    let returns_owned = function_returns_string(&func.sig) || returns_copied_str(&func.sig);
-    let (helpers, wrapper) = if returns_owned {
-        (
+    let mut out = TokenStream2::new();
+    let wrapper = match ret {
+        WrapperReturn::Unit => quote! {
+            #(#cfg_attrs)*
+            #[no_mangle]
+            pub extern "C" fn #symbol(#(#wrapper_args),*) {
+                #prologue
+                #call
+            }
+        },
+        WrapperReturn::Plain(ty) => quote! {
+            #(#cfg_attrs)*
+            #[no_mangle]
+            pub extern "C" fn #symbol(#(#wrapper_args),*) -> #ty {
+                #prologue
+                #call
+            }
+        },
+        WrapperReturn::Boxed(ty) => quote! {
+            #(#cfg_attrs)*
+            #[no_mangle]
+            pub extern "C" fn #symbol(#(#wrapper_args),*) -> *mut #ty {
+                #prologue
+                let obj = #call;
+                Box::into_raw(Box::new(obj))
+            }
+        },
+        WrapperReturn::OwnedString {
+            helper,
+            free,
+            declare,
+        } => {
+            if declare {
+                out.extend(owned_string_helper(&cfg_attrs, &helper, &free));
+            }
             quote! {
                 #(#cfg_attrs)*
-                #[repr(C)]
-                pub struct #owned_helper {
-                    pub ptr: *mut u8,
-                    pub len: usize,
-                    pub cap: usize,
-                }
-
-                #(#cfg_attrs)*
                 #[no_mangle]
-                pub extern "C" fn #owned_free(ptr: *mut u8, len: usize, cap: usize) {
-                    if !ptr.is_null() {
-                        unsafe { drop(Vec::from_raw_parts(ptr, len, cap)); }
-                    }
-                }
-            },
-            quote! {
-                #(#outer_attrs)*
-                #[no_mangle]
-                pub extern "C" fn #func_name(#(#wrapper_args),*) -> #owned_helper {
-                    #(#conversions)*
+                pub extern "C" fn #symbol(#(#wrapper_args),*) -> #helper {
+                    #prologue
                     let rustcall_value = #call;
                     // `ToString` covers both `String` and a `&str` result that
                     // must be copied because it may borrow from a converted
                     // argument (see `returns_copied_str`).
                     let mut rustcall_bytes = ToString::to_string(&rustcall_value).into_bytes();
-                    let rustcall_ret = #owned_helper {
+                    let rustcall_ret = #helper {
                         ptr: rustcall_bytes.as_mut_ptr(),
                         len: rustcall_bytes.len(),
                         cap: rustcall_bytes.capacity(),
@@ -278,76 +393,96 @@ pub fn transform_string_function(func: ItemFn) -> TokenStream2 {
                     std::mem::forget(rustcall_bytes);
                     rustcall_ret
                 }
-            },
-        )
-    } else if returns_borrowed_str(&func.sig) {
-        (
+            }
+        }
+        WrapperReturn::BorrowedStr { helper, declare } => {
+            if declare {
+                out.extend(borrowed_string_helper(&cfg_attrs, &helper));
+            }
             quote! {
                 #(#cfg_attrs)*
-                #[repr(C)]
-                pub struct #borrowed_helper {
-                    pub ptr: *const u8,
-                    pub len: usize,
-                }
-            },
-            quote! {
-                #(#outer_attrs)*
                 #[no_mangle]
-                pub extern "C" fn #func_name(#(#wrapper_args),*) -> #borrowed_helper {
-                    #(#conversions)*
+                pub extern "C" fn #symbol(#(#wrapper_args),*) -> #helper {
+                    #prologue
                     let rustcall_value = #call;
-                    #borrowed_helper {
+                    #helper {
                         ptr: rustcall_value.as_ptr(),
                         len: rustcall_value.len(),
                     }
                 }
-            },
-        )
-    } else {
-        let output = &func.sig.output;
-        (
-            quote! {},
+            }
+        }
+        WrapperReturn::CResult { name, ok, err } => {
+            out.extend(generate_c_result_type(&name, &ok, &err, &cfg_attrs));
             quote! {
-                #(#outer_attrs)*
+                #(#cfg_attrs)*
                 #[no_mangle]
-                pub extern "C" fn #func_name(#(#wrapper_args),*) #output {
-                    #(#conversions)*
-                    #call
+                pub extern "C" fn #symbol(#(#wrapper_args),*) -> #name {
+                    #prologue
+                    #name::new(#call)
                 }
-            },
-        )
+            }
+        }
+        WrapperReturn::COption { name, inner } => {
+            out.extend(generate_c_option_type(&name, &inner, &cfg_attrs));
+            quote! {
+                #(#cfg_attrs)*
+                #[no_mangle]
+                pub extern "C" fn #symbol(#(#wrapper_args),*) -> #name {
+                    #prologue
+                    #name::new(#call)
+                }
+            }
+        }
     };
+    out.extend(wrapper);
+    out
+}
 
+/// The owned string buffer `<name> { ptr, len, cap }` and the `extern "C"`
+/// function that releases it (the Rust `Vec` is reconstructed and dropped).
+fn owned_string_helper(cfg_attrs: &[Attribute], helper: &Ident, free: &Ident) -> TokenStream2 {
     quote! {
-        #helpers
+        #(#cfg_attrs)*
+        #[repr(C)]
+        pub struct #helper {
+            pub ptr: *mut u8,
+            pub len: usize,
+            pub cap: usize,
+        }
 
         #(#cfg_attrs)*
-        #[allow(clippy::ptr_arg)]
-        fn #inner_fn_name #inner_generics (#inner_fn_args) #inner_output #inner_where #body
-
-        #wrapper
+        #[no_mangle]
+        pub extern "C" fn #free(ptr: *mut u8, len: usize, cap: usize) {
+            if !ptr.is_null() {
+                unsafe { drop(Vec::from_raw_parts(ptr, len, cap)); }
+            }
+        }
     }
 }
 
-fn transform_simple_function(mut func: ItemFn) -> TokenStream2 {
-    let no_mangle: Attribute = syn::parse_quote!(#[no_mangle]);
-    func.attrs.insert(0, no_mangle);
-    func.vis = Visibility::Public(syn::token::Pub::default());
-    func.sig.abi = Some(syn::parse_quote!(extern "C"));
-    quote! { #func }
+/// The borrowed string view `<name> { ptr, len }`.
+fn borrowed_string_helper(cfg_attrs: &[Attribute], helper: &Ident) -> TokenStream2 {
+    quote! {
+        #(#cfg_attrs)*
+        #[repr(C)]
+        pub struct #helper {
+            pub ptr: *const u8,
+            pub len: usize,
+        }
+    }
 }
 
 fn generate_c_result_type(
-    func_name: &Ident,
+    name: &Ident,
     ok_type: &Type,
     err_type: &Type,
     cfg_attrs: &[Attribute],
 ) -> TokenStream2 {
-    let result_type_name = format_ident!("CResult_{}", func_name);
     quote! {
         #(#cfg_attrs)*
         #[repr(C)]
-        pub struct #result_type_name {
+        pub struct #name {
             // Private: the discriminant and the payloads must stay consistent,
             // or `ok()` / `err()` would read uninitialized memory. The C layout
             // (u8 followed by both payloads) is unchanged.
@@ -360,7 +495,7 @@ fn generate_c_result_type(
         }
 
         #(#cfg_attrs)*
-        impl #result_type_name {
+        impl #name {
             /// Wrap a `Result` in the C-compatible representation.
             pub fn new(value: Result<#ok_type, #err_type>) -> Self {
                 match value {
@@ -393,15 +528,14 @@ fn generate_c_result_type(
 }
 
 fn generate_c_option_type(
-    func_name: &Ident,
+    name: &Ident,
     inner_type: &Type,
     cfg_attrs: &[Attribute],
 ) -> TokenStream2 {
-    let option_type_name = format_ident!("COption_{}", func_name);
     quote! {
         #(#cfg_attrs)*
         #[repr(C)]
-        pub struct #option_type_name {
+        pub struct #name {
             // Private, see the CResult type: the discriminant guards a
             // `MaybeUninit` payload. The C layout is unchanged.
             is_some: u8,
@@ -410,7 +544,7 @@ fn generate_c_option_type(
         }
 
         #(#cfg_attrs)*
-        impl #option_type_name {
+        impl #name {
             /// Wrap an `Option` in the C-compatible representation.
             pub fn new(value: Option<#inner_type>) -> Self {
                 match value {
@@ -436,129 +570,163 @@ fn generate_c_option_type(
     }
 }
 
-/// Give every typed argument a plain identifier (`argN` for destructuring
-/// patterns) so the outer `extern "C"` signature and the inner call agree.
-fn normalize_arg_patterns(func: &mut ItemFn) -> Vec<Ident> {
-    let mut names = Vec::new();
-    for (i, arg) in func.sig.inputs.iter_mut().enumerate() {
-        if let FnArg::Typed(pat_type) = arg {
-            match pat_type.pat.as_ref() {
-                Pat::Ident(pat_ident) => names.push(pat_ident.ident.clone()),
-                _ => {
-                    let ident = format_ident!("arg{}", i);
-                    *pat_type.pat = syn::parse_quote!(#ident);
-                    names.push(ident);
-                }
-            }
-        }
-    }
-    names
+// ============================================================================
+// Free functions: thin adapters over the generator
+// ============================================================================
+
+/// How a free function is lowered.
+struct FreeFnOptions {
+    /// Wrap a `Result` / `Option` return into `CResult_<fn>` / `COption_<fn>`.
+    wrap_result: bool,
+    /// Lower `String` / `&str` arguments and returns to the byte-pair ABI.
+    lower_strings: bool,
+    /// Extra `#[cfg]` attributes (the `julia_pyo3` non-Python branch).
+    extra_cfg: Vec<Attribute>,
 }
 
-fn transform_result_function(func: ItemFn, result_info: ResultTypeInfo) -> TokenStream2 {
-    let inner_fn = func.clone();
-    let mut func = func;
-    let names = normalize_arg_patterns(&mut func);
-    let func_name = &func.sig.ident;
-    let ok_type = &result_info.ok_type;
-    let err_type = &result_info.err_type;
-
-    if is_non_ffi_type(ok_type) {
-        return quote! {
-            compile_error!(concat!(
-                "#[julia] function `", stringify!(#func_name),
-                "` returns Result with non-FFI-compatible Ok type `", stringify!(#ok_type),
-                "`. Use a primitive or #[repr(C)] type instead."
-            ));
-        };
-    }
-    if is_non_ffi_type(err_type) {
-        return quote! {
-            compile_error!(concat!(
-                "#[julia] function `", stringify!(#func_name),
-                "` returns Result with non-FFI-compatible Err type `", stringify!(#err_type),
-                "`. Use a primitive or #[repr(C)] type instead."
-            ));
-        };
-    }
-
-    let cfg_attrs = cfg_attrs(&func.attrs);
-    let c_result_type = generate_c_result_type(func_name, ok_type, err_type, &cfg_attrs);
-    let result_type_name = format_ident!("CResult_{}", func_name);
-    let StringArgs {
-        wrapper_args: args,
-        conversions,
-        call_args: names,
-    } = string_arg_conversions(&func, &names);
-    let body = &inner_fn.block;
-    let inner_fn_name = format_ident!("{}_inner", func_name);
-    let inner_fn_args = &inner_fn.sig.inputs;
-    let inner_generics = &inner_fn.sig.generics;
-    let inner_where = &inner_fn.sig.generics.where_clause;
-    // `#[cfg]` must gate every generated item (struct, accessor impl, inner
-    // fn, extern fn); other attributes (docs, lints) stay on the exported fn.
-    let outer_attrs = &func.attrs;
-
-    quote! {
-        #c_result_type
-
-        #(#cfg_attrs)*
-        fn #inner_fn_name #inner_generics (#inner_fn_args) -> Result<#ok_type, #err_type> #inner_where #body
-
-        #(#outer_attrs)*
-        #[no_mangle]
-        pub extern "C" fn #func_name(#(#args),*) -> #result_type_name {
-            #(#conversions)*
-            #result_type_name::new(#inner_fn_name(#(#names),*))
+impl Default for FreeFnOptions {
+    fn default() -> Self {
+        FreeFnOptions {
+            wrap_result: true,
+            lower_strings: true,
+            extra_cfg: Vec::new(),
         }
     }
 }
 
-fn transform_option_function(func: ItemFn, option_info: OptionTypeInfo) -> TokenStream2 {
-    let inner_fn = func.clone();
-    let mut func = func;
-    let names = normalize_arg_patterns(&mut func);
-    let func_name = &func.sig.ident;
-    let inner_type = &option_info.inner_type;
+/// The wrapper (and its helpers) of a free function. The function itself is
+/// **not** part of the output: the caller emits the original item next to it.
+fn free_function_wrapper(func: &ItemFn, options: &FreeFnOptions) -> TokenStream2 {
+    let name = func.sig.ident.clone();
+    let symbol = format_ident!("{}", function_symbol(&name.to_string()));
+    let mut cfgs = cfg_attrs(&func.attrs);
+    cfgs.extend(options.extra_cfg.iter().cloned());
 
-    if is_non_ffi_type(inner_type) {
-        return quote! {
-            compile_error!(concat!(
-                "#[julia] function `", stringify!(#func_name),
-                "` returns Option with non-FFI-compatible type `", stringify!(#inner_type),
-                "`. Use a primitive or #[repr(C)] type instead."
-            ));
-        };
-    }
+    let ret = free_fn_return(func, &name, options);
+    generate_wrapper(WrapperSpec {
+        symbol,
+        cfg_attrs: cfgs,
+        receiver: None,
+        args: arg_pairs(&func.sig),
+        lower_strings: options.lower_strings,
+        ret,
+        target: CallTarget::Free(name),
+    })
+}
 
-    let cfg_attrs = cfg_attrs(&func.attrs);
-    let c_option_type = generate_c_option_type(func_name, inner_type, &cfg_attrs);
-    let option_type_name = format_ident!("COption_{}", func_name);
-    let StringArgs {
-        wrapper_args: args,
-        conversions,
-        call_args: names,
-    } = string_arg_conversions(&func, &names);
-    let body = &inner_fn.block;
-    let inner_fn_name = format_ident!("{}_inner", func_name);
-    let inner_fn_args = &inner_fn.sig.inputs;
-    let inner_generics = &inner_fn.sig.generics;
-    let inner_where = &inner_fn.sig.generics.where_clause;
-    let outer_attrs = &func.attrs;
-
-    quote! {
-        #c_option_type
-
-        #(#cfg_attrs)*
-        fn #inner_fn_name #inner_generics (#inner_fn_args) -> Option<#inner_type> #inner_where #body
-
-        #(#outer_attrs)*
-        #[no_mangle]
-        pub extern "C" fn #func_name(#(#args),*) -> #option_type_name {
-            #(#conversions)*
-            #option_type_name::new(#inner_fn_name(#(#names),*))
+fn free_fn_return(func: &ItemFn, name: &Ident, options: &FreeFnOptions) -> WrapperReturn {
+    let ReturnType::Type(_, ty) = &func.sig.output else {
+        return WrapperReturn::Unit;
+    };
+    if options.wrap_result {
+        if let Some(r) = extract_result_type(ty) {
+            return WrapperReturn::CResult {
+                name: format_ident!("CResult_{}", name),
+                ok: r.ok_type,
+                err: r.err_type,
+            };
+        }
+        if let Some(o) = extract_option_type(ty) {
+            return WrapperReturn::COption {
+                name: format_ident!("COption_{}", name),
+                inner: o.inner_type,
+            };
         }
     }
+    if options.lower_strings {
+        if function_returns_string(&func.sig) || returns_copied_str(&func.sig) {
+            return WrapperReturn::OwnedString {
+                helper: format_ident!("{}_RustCallOwnedString", name),
+                free: format_ident!("{}_free_rust_string", name),
+                declare: true,
+            };
+        }
+        if returns_borrowed_str(&func.sig) {
+            return WrapperReturn::BorrowedStr {
+                helper: format_ident!("{}_RustCallBorrowedString", name),
+                declare: true,
+            };
+        }
+    }
+    WrapperReturn::Plain((**ty).clone())
+}
+
+/// Transform a `#[julia]` function: the annotated item is kept as written (the
+/// attribute itself is already gone) and the `extern "C"` entry point is
+/// emitted next to it under `rustcall_<fn>` (#279).
+pub fn transform_function(func: ItemFn) -> TokenStream2 {
+    if func.sig.unsafety.is_some() {
+        return quote! {
+            compile_error!("#[julia] cannot be applied to unsafe functions directly. The function will be made extern \"C\" which has its own safety semantics.");
+        };
+    }
+    if let Some(error) = non_ffi_payload_error(&func) {
+        return error;
+    }
+
+    let wrapper = free_function_wrapper(&func, &FreeFnOptions::default());
+    quote! {
+        #func
+        #wrapper
+    }
+}
+
+/// `Result` / `Option` payloads must survive the C ABI; refuse at compile time
+/// rather than emit a wrapper that cannot be called.
+fn non_ffi_payload_error(func: &ItemFn) -> Option<TokenStream2> {
+    let ReturnType::Type(_, ty) = &func.sig.output else {
+        return None;
+    };
+    let func_name = &func.sig.ident;
+    if let Some(r) = extract_result_type(ty) {
+        let ok_type = &r.ok_type;
+        let err_type = &r.err_type;
+        if is_non_ffi_type(ok_type) {
+            return Some(quote! {
+                compile_error!(concat!(
+                    "#[julia] function `", stringify!(#func_name),
+                    "` returns Result with non-FFI-compatible Ok type `", stringify!(#ok_type),
+                    "`. Use a primitive or #[repr(C)] type instead."
+                ));
+            });
+        }
+        if is_non_ffi_type(err_type) {
+            return Some(quote! {
+                compile_error!(concat!(
+                    "#[julia] function `", stringify!(#func_name),
+                    "` returns Result with non-FFI-compatible Err type `", stringify!(#err_type),
+                    "`. Use a primitive or #[repr(C)] type instead."
+                ));
+            });
+        }
+    }
+    if let Some(o) = extract_option_type(ty) {
+        let inner_type = &o.inner_type;
+        if is_non_ffi_type(inner_type) {
+            return Some(quote! {
+                compile_error!(concat!(
+                    "#[julia] function `", stringify!(#func_name),
+                    "` returns Option with non-FFI-compatible type `", stringify!(#inner_type),
+                    "`. Use a primitive or #[repr(C)] type instead."
+                ));
+            });
+        }
+    }
+    None
+}
+
+/// The wrapper of a function exported with the signature as written: `Result` /
+/// `Option` are not wrapped. Used by [`crate::specialize`] for the
+/// instantiation of a generic function, whose fixed `String` / `&str`
+/// parameters still get the byte-pair ABI (#242).
+pub fn plain_function_wrapper(func: &ItemFn) -> TokenStream2 {
+    free_function_wrapper(
+        func,
+        &FreeFnOptions {
+            wrap_result: false,
+            ..Default::default()
+        },
+    )
 }
 
 // ============================================================================
@@ -673,82 +841,66 @@ pub fn returns_boxed_struct(struct_name: &Ident, method: &syn::ImplItemFn) -> bo
         || matches!(&method.sig.output, ReturnType::Type(_, ty) if is_self_type(ty, struct_name))
 }
 
-/// Whether a method is treated as a constructor: static and either named `new`
-/// or returning `Self` / the struct type.
-pub fn is_constructor(struct_name: &Ident, method: &syn::ImplItemFn, is_static: bool) -> bool {
-    let returns_self = matches!(
-        &method.sig.output,
-        ReturnType::Type(_, ty) if is_self_type(ty, struct_name)
-    );
-    is_static && (method.sig.ident == "new" || returns_self)
-}
-
 /// Generate the FFI wrapper for a method (crate flavour).
 ///
-/// Same wrapper as the inline flavour ([`inline_method_wrapper`]): `String` /
+/// Same generator as the inline flavour ([`inline_method_wrapper`]): `String` /
 /// `&str` arguments arrive as `(ptr, len)` pairs, a string result leaves as an
 /// owned or borrowed buffer. The proc-macro transforms one impl block at a time
 /// and cannot see the struct or sibling impl blocks, so the buffer types are
 /// per method rather than per struct:
 /// `<Struct>_<method>_RustCallOwnedString` released through
 /// `<Struct>_<method>_free_rust_string`, and
-/// `<Struct>_<method>_RustCallBorrowedString`.
+/// `<Struct>_<method>_RustCallBorrowedString`. The method itself is left in the
+/// impl block untouched; the wrapper calls it (#279).
 pub fn generate_method_wrapper_crate(
     struct_name: &Ident,
     method: &syn::ImplItemFn,
 ) -> TokenStream2 {
     let model = MethodModel::from_fn(method);
-    let wrapper_name = format_ident!("{}_{}", struct_name, method.sig.ident);
-    let owned_helper = format_ident!("{}_RustCallOwnedString", wrapper_name);
-    let owned_free = format_ident!("{}_free_rust_string", wrapper_name);
-    let borrowed_helper = format_ident!("{}_RustCallBorrowedString", wrapper_name);
-
-    let mut out = TokenStream2::new();
-    if !inline_method_is_ctor(struct_name, &model) {
-        if method_returns_string(&model) || method_copies_str(&model) {
-            out.extend(owned_string_helper(&owned_helper, &owned_free));
-        } else if method_returns_borrowed_str(&model) {
-            out.extend(borrowed_string_helper(&borrowed_helper));
-        }
-    }
-    out.extend(inline_method_wrapper(
+    let owner = format_ident!("{}_{}", struct_name, method.sig.ident);
+    let owned_helper = format_ident!("{}_RustCallOwnedString", owner);
+    let owned_free = format_ident!("{}_free_rust_string", owner);
+    let borrowed_helper = format_ident!("{}_RustCallBorrowedString", owner);
+    generate_wrapper(method_spec(
         struct_name,
         &model,
         &owned_helper,
+        &owned_free,
         &borrowed_helper,
-    ));
-    out
+        true,
+    ))
 }
 
 // ============================================================================
 // Crate flavour: #[julia_pyo3]
 // ============================================================================
 
+/// `#[julia_pyo3]` keeps its either/or `cfg(feature = "python")` shape, but the
+/// non-Python branch is now "original item + additive wrapper" like `#[julia]`
+/// (#279). The exported signature stays the one that was written — no
+/// `Result` / `Option` wrapping and no string lowering — so the manifest `abi`
+/// this attribute advertises remains honest (pending #275).
 pub fn transform_function_julia_pyo3(func: ItemFn) -> TokenStream2 {
     let func_attrs = &func.attrs;
+    let func_vis = &func.vis;
     let func_sig = &func.sig;
     let func_block = &func.block;
 
-    if let ReturnType::Type(_, ref ret_type) = func.sig.output {
-        if extract_result_type(ret_type).is_some() || extract_option_type(ret_type).is_some() {
-            return quote! {
-                #[cfg(not(feature = "python"))]
-                #(#func_attrs)*
-                #[no_mangle]
-                pub extern "C" #func_sig #func_block
-
-                #[cfg(feature = "python")]
-                #[pyo3::pyfunction]
-                pub #func_sig #func_block
-            };
-        }
-    }
+    let wrapper = free_function_wrapper(
+        &func,
+        &FreeFnOptions {
+            wrap_result: false,
+            lower_strings: false,
+            extra_cfg: vec![syn::parse_quote!(#[cfg(not(feature = "python"))])],
+        },
+    );
 
     quote! {
         #[cfg(not(feature = "python"))]
         #(#func_attrs)*
-        #[no_mangle]
-        pub extern "C" #func_sig #func_block
+        #func_vis #func_sig #func_block
+
+        #wrapper
 
         #[cfg(feature = "python")]
         #[pyo3::pyfunction]
@@ -864,37 +1016,6 @@ fn method_returns_borrowed_str(m: &MethodModel) -> bool {
     returns_borrowed_str(&m.func.sig)
 }
 
-/// The owned string buffer `<name> { ptr, len, cap }` and the `extern "C"`
-/// function that releases it (the Rust `Vec` is reconstructed and dropped).
-fn owned_string_helper(owned_helper: &Ident, owned_free: &Ident) -> TokenStream2 {
-    quote! {
-        #[repr(C)]
-        pub struct #owned_helper {
-            ptr: *mut u8,
-            len: usize,
-            cap: usize,
-        }
-
-        #[no_mangle]
-        pub extern "C" fn #owned_free(ptr: *mut u8, len: usize, cap: usize) {
-            if !ptr.is_null() {
-                unsafe { drop(Vec::from_raw_parts(ptr, len, cap)); }
-            }
-        }
-    }
-}
-
-/// The borrowed string view `<name> { ptr, len }`.
-fn borrowed_string_helper(borrowed_helper: &Ident) -> TokenStream2 {
-    quote! {
-        #[repr(C)]
-        pub struct #borrowed_helper {
-            ptr: *const u8,
-            len: usize,
-        }
-    }
-}
-
 fn inline_method_is_ctor(struct_name: &Ident, m: &MethodModel) -> bool {
     // Historical inline rule: `new`, or any method returning Self / the struct type
     // (static or not) is treated as returning a boxed struct.
@@ -940,18 +1061,20 @@ pub fn inline_struct_wrappers(model: &StructModel) -> (TokenStream2, InlineStruc
 
     if needs_owned {
         meta.has_owned_string_helper = true;
-        out.extend(owned_string_helper(&owned_helper, &owned_free));
+        out.extend(owned_string_helper(&[], &owned_helper, &owned_free));
     }
     if needs_borrowed {
         meta.has_borrowed_string_helper = true;
-        out.extend(borrowed_string_helper(&borrowed_helper));
+        out.extend(borrowed_string_helper(&[], &borrowed_helper));
     }
 
-    // Field accessors (skipped when a method wrapper would take the same symbol).
+    // Field accessors (skipped when a method wrapper would take the same
+    // symbol; since #279 the method wrappers are prefixed, so this can only
+    // happen through a deliberately named accessor-shaped method).
     let method_symbols: Vec<String> = model
         .methods
         .iter()
-        .map(|m| format!("{}_{}", struct_name, m.name()))
+        .map(|m| method_symbol(&struct_name.to_string(), &m.name()))
         .collect();
     for (field_name, field_ty) in &accessible {
         let getter = format_ident!("{}_get_{}", struct_name, field_name);
@@ -1019,6 +1142,7 @@ pub fn inline_struct_wrappers(model: &StructModel) -> (TokenStream2, InlineStruc
             struct_name,
             m,
             &owned_helper,
+            &owned_free,
             &borrowed_helper,
         ));
     }
@@ -1026,129 +1150,84 @@ pub fn inline_struct_wrappers(model: &StructModel) -> (TokenStream2, InlineStruc
     (out, meta)
 }
 
+/// The [`WrapperSpec`] of a struct method, shared by the inline and the crate
+/// flavour: `declare` says whether the string buffer helpers are emitted by
+/// this wrapper (crate flavour, per method) or already exist next to the struct
+/// (inline flavour, per struct).
+fn method_spec(
+    struct_name: &Ident,
+    m: &MethodModel,
+    owned_helper: &Ident,
+    owned_free: &Ident,
+    borrowed_helper: &Ident,
+    declare: bool,
+) -> WrapperSpec {
+    let method_name = m.func.sig.ident.clone();
+    let symbol = format_ident!(
+        "{}",
+        method_symbol(&struct_name.to_string(), &method_name.to_string())
+    );
+    let receiver = (!m.is_static).then(|| WrapperReceiver {
+        ty: struct_name.clone(),
+        mutable: m.is_mutable,
+    });
+    let target = if m.is_static {
+        CallTarget::Assoc {
+            ty: struct_name.clone(),
+            method: method_name,
+        }
+    } else {
+        CallTarget::Instance(method_name)
+    };
+    let ret = if inline_method_is_ctor(struct_name, m) {
+        // `new`, or any method returning `Self` / the struct type, hands Julia
+        // an owning pointer. The string helpers are not involved.
+        WrapperReturn::Boxed(struct_name.clone())
+    } else if method_returns_string(m) || method_copies_str(m) {
+        WrapperReturn::OwnedString {
+            helper: owned_helper.clone(),
+            free: owned_free.clone(),
+            declare,
+        }
+    } else if method_returns_borrowed_str(m) {
+        WrapperReturn::BorrowedStr {
+            helper: borrowed_helper.clone(),
+            declare,
+        }
+    } else {
+        match &m.func.sig.output {
+            ReturnType::Default => WrapperReturn::Unit,
+            ReturnType::Type(_, ty) => WrapperReturn::Plain((**ty).clone()),
+        }
+    };
+    WrapperSpec {
+        symbol,
+        cfg_attrs: cfg_attrs(&m.func.attrs),
+        receiver,
+        args: arg_pairs(&m.func.sig),
+        lower_strings: true,
+        ret,
+        target,
+    }
+}
+
+/// The `extern "C"` wrapper of an inline struct method. The string buffer types
+/// are shared per struct, so the wrapper only refers to them.
 fn inline_method_wrapper(
     struct_name: &Ident,
     m: &MethodModel,
     owned_helper: &Ident,
+    owned_free: &Ident,
     borrowed_helper: &Ident,
 ) -> TokenStream2 {
-    let method_name = &m.func.sig.ident;
-    let wrapper_name = format_ident!("{}_{}", struct_name, method_name);
-    let returns_self = inline_method_is_ctor(struct_name, m);
-
-    // Generated identifiers (the receiver pointer, `self_obj`, `<arg>_ptr`,
-    // ...) must not coincide with the method's own argument names.
-    let names = typed_arg_names(&m.func.sig);
-    let taken: Vec<String> = names.iter().map(ToString::to_string).collect();
-    let ptr = fresh_ident("ptr", &taken);
-    let self_obj = fresh_ident("self_obj", &taken);
-
-    let mut wrapper_args: Vec<TokenStream2> = Vec::new();
-    let mut conversions: Vec<TokenStream2> = Vec::new();
-    let mut call_args: Vec<TokenStream2> = Vec::new();
-
-    if !m.is_static {
-        if m.is_mutable {
-            wrapper_args.push(quote! { #ptr: *mut #struct_name });
-        } else {
-            wrapper_args.push(quote! { #ptr: *const #struct_name });
-        }
-    }
-
-    for (arg, name) in m
-        .func
-        .sig
-        .inputs
-        .iter()
-        .filter(|a| matches!(a, FnArg::Typed(_)))
-        .zip(names.iter())
-    {
-        let FnArg::Typed(pat_type) = arg else {
-            continue;
-        };
-        let (args, conversion) = string_arg_conversion(name, &pat_type.ty, &taken);
-        wrapper_args.extend(args);
-        conversions.extend(conversion);
-        call_args.push(quote! { #name });
-    }
-
-    // A `&str` result of a method that takes string arguments may borrow from a
-    // converted argument, so it is copied into the owned representation.
-    let copies_str = method_copies_str(m);
-
-    let self_binding = if m.is_static {
-        quote! {}
-    } else if m.is_mutable {
-        quote! { let #self_obj = unsafe { &mut *#ptr }; }
-    } else {
-        quote! { let #self_obj = unsafe { &*#ptr }; }
-    };
-    let call = if m.is_static {
-        quote! { #struct_name::#method_name(#(#call_args),*) }
-    } else {
-        quote! { #self_obj.#method_name(#(#call_args),*) }
-    };
-
-    if returns_self {
-        return quote! {
-            #[no_mangle]
-            pub extern "C" fn #wrapper_name(#(#wrapper_args),*) -> *mut #struct_name {
-                #(#conversions)*
-                #self_binding
-                let obj = #call;
-                Box::into_raw(Box::new(obj))
-            }
-        };
-    }
-
-    match &m.func.sig.output {
-        ReturnType::Default => quote! {
-            #[no_mangle]
-            pub extern "C" fn #wrapper_name(#(#wrapper_args),*) {
-                #(#conversions)*
-                #self_binding
-                #call
-            }
-        },
-        ReturnType::Type(_, ty) if is_string_type(ty) || (is_str_ref_type(ty) && copies_str) => {
-            quote! {
-                #[no_mangle]
-                pub extern "C" fn #wrapper_name(#(#wrapper_args),*) -> #owned_helper {
-                    #(#conversions)*
-                    #self_binding
-                    let rustcall_value = #call;
-                    let mut rustcall_bytes = ToString::to_string(&rustcall_value).into_bytes();
-                    let rustcall_ret = #owned_helper {
-                        ptr: rustcall_bytes.as_mut_ptr(),
-                        len: rustcall_bytes.len(),
-                        cap: rustcall_bytes.capacity(),
-                    };
-                    std::mem::forget(rustcall_bytes);
-                    rustcall_ret
-                }
-            }
-        }
-        ReturnType::Type(_, ty) if is_str_ref_type(ty) && !copies_str => quote! {
-            #[no_mangle]
-            pub extern "C" fn #wrapper_name(#(#wrapper_args),*) -> #borrowed_helper {
-                #(#conversions)*
-                #self_binding
-                let rustcall_value = #call;
-                #borrowed_helper {
-                    ptr: rustcall_value.as_ptr(),
-                    len: rustcall_value.len(),
-                }
-            }
-        },
-        ReturnType::Type(_, ty) => quote! {
-            #[no_mangle]
-            pub extern "C" fn #wrapper_name(#(#wrapper_args),*) -> #ty {
-                #(#conversions)*
-                #self_binding
-                #call
-            }
-        },
-    }
+    generate_wrapper(method_spec(
+        struct_name,
+        m,
+        owned_helper,
+        owned_free,
+        borrowed_helper,
+        false,
+    ))
 }
 
 /// Generics for a generic-struct method wrapper: the enclosing impl block's

--- a/deps/rustcall_core/src/expand.rs
+++ b/deps/rustcall_core/src/expand.rs
@@ -187,7 +187,69 @@ fn expand_items(
         }
     }
 
+    for name in symbol_collisions(items, &out) {
+        let msg = format!(
+            "RustCall generates an item named `{name}` in this module, but the block already \
+             defines one. `#[julia]` keeps the annotated item and emits its `extern \"C\"` entry \
+             point next to it (`rustcall_<fn>`, `rustcall_<Struct>_<method>`, `<Struct>_free`, \
+             `<Struct>_get_<field>`, `CResult_<fn>`, `<fn>_RustCallOwnedString`, ...), so rename \
+             the conflicting item (#279)."
+        );
+        out.insert(0, syn::parse_quote! { compile_error!(#msg); });
+    }
+
     Ok(out)
+}
+
+/// Rust name-resolution namespace of an item: `struct Foo` and `fn Foo` may
+/// coexist, `fn Foo` and `const Foo` may not.
+fn item_key(item: &Item) -> Option<(u8, String)> {
+    const TYPE_NS: u8 = 0;
+    const VALUE_NS: u8 = 1;
+    match item {
+        Item::Fn(f) => Some((VALUE_NS, f.sig.ident.to_string())),
+        Item::Const(c) => Some((VALUE_NS, c.ident.to_string())),
+        Item::Static(s) => Some((VALUE_NS, s.ident.to_string())),
+        Item::Struct(s) => Some((TYPE_NS, s.ident.to_string())),
+        Item::Enum(e) => Some((TYPE_NS, e.ident.to_string())),
+        Item::Union(u) => Some((TYPE_NS, u.ident.to_string())),
+        Item::Trait(t) => Some((TYPE_NS, t.ident.to_string())),
+        Item::Type(t) => Some((TYPE_NS, t.ident.to_string())),
+        Item::Mod(m) => Some((TYPE_NS, m.ident.to_string())),
+        _ => None,
+    }
+}
+
+fn key_counts(items: &[Item]) -> std::collections::HashMap<(u8, String), usize> {
+    let mut counts = std::collections::HashMap::new();
+    for item in items {
+        if let Some(key) = item_key(item) {
+            *counts.entry(key).or_insert(0) += 1;
+        }
+    }
+    counts
+}
+
+/// Names that the wrappers generated for one module level would take away from
+/// an item the user wrote there.
+///
+/// `#[julia]` is additive (#279), so the exported symbols are chosen not to
+/// collide with the annotated items themselves (`rustcall_<fn>`); a *different*
+/// user item may still happen to carry a generated name. Inline expansion sees
+/// the whole module and can say so precisely, which is worth a clear error
+/// rather than a duplicate-definition diagnostic pointing at generated code.
+/// The proc-macro sees one item at a time and cannot make this check.
+fn symbol_collisions(original: &[Item], expanded: &[Item]) -> Vec<String> {
+    let before = key_counts(original);
+    let after = key_counts(expanded);
+    let mut clashes: Vec<String> = after
+        .iter()
+        .filter(|(key, count)| **count > before.get(*key).copied().unwrap_or(0))
+        .filter(|(key, _)| before.contains_key(*key))
+        .map(|((_, name), _)| name.clone())
+        .collect();
+    clashes.sort();
+    clashes
 }
 
 fn methods_of(model: &StructModel, symbols: bool) -> Vec<Method> {
@@ -203,7 +265,7 @@ fn methods_of(model: &StructModel, symbols: bool) -> Vec<Method> {
             Method {
                 name: m.name(),
                 symbol: if symbols {
-                    format!("{}_{}", struct_name, m.name())
+                    crate::codegen::method_symbol(&struct_name.to_string(), &m.name())
                 } else {
                     String::new()
                 },

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -120,9 +120,19 @@ pub fn function_entry(func: &ItemFn, attribute: Attribute, wrapped: bool) -> Fun
                 .map(|n| n.value() == "C")
                 .unwrap_or(false)
     };
+    let name = func.sig.ident.to_string();
+    // `#[julia]` / `#[julia_pyo3]` are additive: the item keeps its name and
+    // the exported entry point is the wrapper next to it (#279). A plain
+    // `#[no_mangle] extern "C"` function is exported under its own name.
+    let symbol = match attribute {
+        Attribute::Julia | Attribute::JuliaPyo3 if !is_generic => {
+            crate::codegen::function_symbol(&name)
+        }
+        _ => name.clone(),
+    };
     Function {
-        name: func.sig.ident.to_string(),
-        symbol: func.sig.ident.to_string(),
+        name,
+        symbol,
         attribute,
         exported,
         cfg: predicate_string(&func.attrs),
@@ -232,7 +242,7 @@ fn crate_struct_entry(model: &StructModel) -> Struct {
         .iter()
         .map(|m| Method {
             name: m.name(),
-            symbol: format!("{}_{}", struct_name, m.name()),
+            symbol: crate::codegen::method_symbol(&struct_name.to_string(), &m.name()),
             is_static: m.is_static,
             is_mutable: m.is_mutable,
             is_constructor: returns_boxed_struct(struct_name, &m.func),

--- a/deps/rustcall_core/src/lib.rs
+++ b/deps/rustcall_core/src/lib.rs
@@ -58,7 +58,7 @@ mod tests {
         assert_eq!(add.args.len(), 2);
         assert!(e
             .source
-            .contains("pub extern \"C\" fn add(a: i32, b: i32) -> i32"));
+            .contains("pub extern \"C\" fn rustcall_add(a: i32, b: i32) -> i32"));
 
         let div = m.functions.iter().find(|f| f.name == "safe_div").unwrap();
         assert_eq!(div.return_kind, manifest::ReturnKind::Option);
@@ -88,7 +88,7 @@ mod tests {
         assert_eq!(names, vec!["new", "norm"]);
         assert!(p.methods[0].is_constructor);
         assert!(e.source.contains("pub extern \"C\" fn Point_free"));
-        assert!(e.source.contains("pub extern \"C\" fn Point_new"));
+        assert!(e.source.contains("pub extern \"C\" fn rustcall_Point_new"));
         assert!(e.source.contains("pub extern \"C\" fn Point_get_x"));
         assert!(!e.source.contains("#[julia]"));
     }
@@ -170,7 +170,7 @@ mod tests {
         let c = &m.structs[0];
         let names: Vec<_> = c.methods.iter().map(|m| m.name.clone()).collect();
         assert_eq!(names, vec!["new", "increment"]);
-        assert_eq!(c.methods[0].symbol, "Counter_new");
+        assert_eq!(c.methods[0].symbol, "rustcall_Counter_new");
         assert!(c.fields.iter().all(|f| f.ffi_compatible));
     }
 
@@ -205,7 +205,7 @@ mod tests {
         .unwrap();
         assert!(sp
             .source
-            .contains("pub extern \"C\" fn Pair_first_i32(ptr: *const Pair<i32>) -> i32"));
+            .contains("pub extern \"C\" fn rustcall_Pair_first_i32(ptr: *const Pair<i32>) -> i32"));
 
         let full = format!("{}\n{}", s.context_source, s.generic_wrappers[0].source);
         let sp = specialize::specialize(
@@ -215,9 +215,9 @@ mod tests {
             "Pair_new_i32",
         )
         .unwrap();
-        assert!(sp
-            .source
-            .contains("pub extern \"C\" fn Pair_new_i32(a: i32, b: i32) -> *mut Pair<i32>"));
+        assert!(sp.source.contains(
+            "pub extern \"C\" fn rustcall_Pair_new_i32(a: i32, b: i32) -> *mut Pair<i32>"
+        ));
     }
 
     #[test]
@@ -244,8 +244,8 @@ mod tests {
         assert_eq!(e.manifest.functions[1].module_path, vec!["api", "deep"]);
         assert_eq!(e.manifest.structs[0].name, "P");
         assert_eq!(e.manifest.structs[0].module_path, vec!["api"]);
-        assert!(e.source.contains("pub extern \"C\" fn inner_add"));
-        assert!(e.source.contains("pub extern \"C\" fn P_new"));
+        assert!(e.source.contains("pub extern \"C\" fn rustcall_inner_add"));
+        assert!(e.source.contains("pub extern \"C\" fn rustcall_P_new"));
         assert!(!e.source.contains("#[julia]"));
         assert!(e.source.contains("mod external;"));
 

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -21,7 +21,13 @@ use serde::{Deserialize, Serialize};
 ///   how a consumer must call the exported symbols (`(ptr, len)` pairs and
 ///   `<name>_RustCallOwnedString` buffers), so a version-1 consumer must not
 ///   load a version-2 manifest, nor the reverse.
-pub const SCHEMA_VERSION: u32 = 2;
+/// * 3: additive `#[julia]` (#279): the annotated item keeps its name and the
+///   exported entry point is a wrapper emitted next to it, so `Function.symbol`
+///   and `Method.symbol` now differ from `name` for *every* wrapped item
+///   (`rustcall_<fn>` / `rustcall_<Struct>_<method>`), not only for generic
+///   instantiations. A version-2 consumer would `dlsym` the Rust name and find
+///   nothing.
+pub const SCHEMA_VERSION: u32 = 3;
 
 /// Which pipeline produced the manifest.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -102,7 +108,9 @@ pub struct TypeParam {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Function {
     pub name: String,
-    /// Exported C symbol. Equal to `name` for non-generic functions.
+    /// Exported C symbol. `#[julia]` is additive, so a wrapped function is
+    /// exported as `rustcall_<name>` and never under `name` itself (#279); a
+    /// plain `#[no_mangle] extern "C"` function keeps its own name.
     pub symbol: String,
     pub attribute: Attribute,
     /// True when the generated code carries `#[no_mangle] extern "C"`.
@@ -176,8 +184,9 @@ pub struct Field {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Method {
     pub name: String,
-    /// Exported C symbol of the wrapper (`Struct_method`). Empty for generic
-    /// structs, whose wrappers are registered for monomorphization instead.
+    /// Exported C symbol of the wrapper (`rustcall_<Struct>_<method>`, #279).
+    /// Empty for generic structs, whose wrappers are registered for
+    /// monomorphization instead.
     pub symbol: String,
     pub is_static: bool,
     pub is_mutable: bool,

--- a/deps/rustcall_core/src/specialize.rs
+++ b/deps/rustcall_core/src/specialize.rs
@@ -18,8 +18,8 @@ use syn::{GenericParam, Item, ItemFn, Path, PathArguments, Type, WherePredicate}
 
 use crate::cfg::body_has_cfg;
 use crate::codegen::{
-    function_returns_string, function_uses_strings, returns_borrowed_str, returns_copied_str,
-    transform_string_function,
+    function_returns_string, function_symbol, plain_function_wrapper, returns_borrowed_str,
+    returns_copied_str,
 };
 use crate::manifest::{Arg, Attribute, Function, Manifest, Mode, ReturnKind};
 use crate::types::{return_type_to_string, type_to_string};
@@ -311,21 +311,21 @@ pub fn specialize(
     let mut entry = function_entry(&func);
     entry.module_path = module_path.iter().map(|s| s.to_string()).collect();
 
-    // Fixed `String` / `&str` parameters or returns get the same `(ptr, len)`
-    // wrapper as a non-generic `#[julia]` function (#242); the manifest
-    // records the helpers so the caller uses the string ABI.
-    let new_items: Vec<Item> = if function_uses_strings(&func.sig) {
-        entry.has_owned_string_helper =
-            function_returns_string(&func.sig) || returns_copied_str(&func.sig);
-        entry.has_borrowed_string_helper = returns_borrowed_str(&func.sig);
-        let file: syn::File = syn::parse2(transform_string_function(func))
-            .map_err(|e| SpecializeError::Parse(e.to_string()))?;
-        file.items
-    } else {
-        func.attrs.insert(0, syn::parse_quote!(#[no_mangle]));
+    // The instantiation is emitted the same way `#[julia]` emits a function
+    // (#279): the plain Rust function under `new_name`, and the `extern "C"`
+    // entry point next to it under `rustcall_<new_name>`. Fixed `String` /
+    // `&str` parameters or returns get the `(ptr, len)` ABI (#242); the
+    // manifest records the helpers so the caller uses the string ABI.
+    entry.has_owned_string_helper =
+        function_returns_string(&func.sig) || returns_copied_str(&func.sig);
+    entry.has_borrowed_string_helper = returns_borrowed_str(&func.sig);
+    let new_items: Vec<Item> = {
         func.vis = syn::Visibility::Public(Default::default());
-        func.sig.abi = Some(syn::parse_quote!(extern "C"));
-        vec![Item::Fn(func)]
+        let wrapper: syn::File = syn::parse2(plain_function_wrapper(&func))
+            .map_err(|e| SpecializeError::Parse(e.to_string()))?;
+        let mut items = vec![Item::Fn(func)];
+        items.extend(wrapper.items);
+        items
     };
     let items = locate_items(&mut file.items, module_path).expect("module path resolved above");
     for (offset, item) in new_items.into_iter().enumerate() {
@@ -379,7 +379,9 @@ fn function_entry(func: &ItemFn) -> Function {
     Function {
         cfg: crate::cfg::predicate_string(&func.attrs),
         name: func.sig.ident.to_string(),
-        symbol: func.sig.ident.to_string(),
+        // The exported entry point is the additive wrapper, not the
+        // instantiation itself (#279).
+        symbol: function_symbol(&func.sig.ident.to_string()),
         attribute: Attribute::None,
         exported: true,
         is_generic: false,
@@ -420,7 +422,7 @@ mod tests {
         assert!(out.source.contains("#[no_mangle]"));
         assert!(out
             .source
-            .contains("pub extern \"C\" fn identity_i32(x: i32) -> i32"));
+            .contains("pub extern \"C\" fn rustcall_identity_i32(x: i32) -> i32"));
         assert!(!out.source.contains("identity_i32<"));
         assert!(out.source.contains("let y: i32 = x;"));
         // The generic original stays next to the instantiation.
@@ -457,7 +459,7 @@ mod tests {
         assert!(out.source.contains("pub struct Point<T>"));
         assert!(out
             .source
-            .contains("pub extern \"C\" fn Point_new_i64(x: i64) -> *mut Point<i64>"));
+            .contains("pub extern \"C\" fn rustcall_Point_new_i64(x: i64) -> *mut Point<i64>"));
     }
 
     #[test]
@@ -474,7 +476,7 @@ mod tests {
         assert!(out.source.contains("mod api {"));
         assert!(out
             .source
-            .contains("pub extern \"C\" fn f_i32(x: i32) -> i32"));
+            .contains("pub extern \"C\" fn rustcall_f_i32(x: i32) -> i32"));
         assert!(out.source.contains("pub fn f<T>"));
         assert_eq!(out.manifest.functions[0].module_path, vec!["api"]);
         assert!(matches!(
@@ -494,7 +496,7 @@ mod tests {
         assert!(out.source.contains("pub fn f<T: Copy>(x: T) -> T"));
         assert!(out
             .source
-            .contains("pub extern \"C\" fn f_i32(x: i32) -> i32"));
+            .contains("pub extern \"C\" fn rustcall_f_i32(x: i32) -> i32"));
         assert!(out.source.contains("fn helper() -> i32 {"));
         let f_pos = out.source.find("pub fn f<T: Copy>").unwrap();
         let s_pos = out.source.find("fn f_i32").unwrap();
@@ -508,7 +510,7 @@ mod tests {
         let out = specialize(src, "outer", &[("T".into(), "i32".into())], "outer_i32").unwrap();
         assert!(out
             .source
-            .contains("pub extern \"C\" fn outer_i32(x: i32) -> i32"));
+            .contains("pub extern \"C\" fn rustcall_outer_i32(x: i32) -> i32"));
         assert!(out.source.contains("fn inner<T>(x: T) -> T"));
         assert!(out.source.contains("struct Local<T>(T);"));
         // A nested item that does not redeclare T still sees the substitution.
@@ -553,9 +555,9 @@ mod tests {
         let src = "pub fn tag<T: std::fmt::Display>(x: T, label: String) -> String { format!(\"{label}{x}\") }";
         let out = specialize(src, "tag", &[("T".into(), "i32".into())], "tag_i32").unwrap();
         let source = flat(&out.source);
-        assert!(source.contains("fn tag_i32_inner(x: i32, label: String) -> String"));
+        assert!(source.contains("pub fn tag_i32(x: i32, label: String) -> String"));
         assert!(
-            source.contains("pub extern \"C\" fn tag_i32(x: i32, label_ptr: *const u8, label_len: usize) -> tag_i32_RustCallOwnedString"),
+            source.contains("pub extern \"C\" fn rustcall_tag_i32(x: i32, label_ptr: *const u8, label_len: usize) -> tag_i32_RustCallOwnedString"),
             "{source}"
         );
         assert!(source.contains("pub extern \"C\" fn tag_i32_free_rust_string("));
@@ -572,7 +574,7 @@ mod tests {
         let source = flat(&out.source);
         assert!(
             source.contains(
-                "pub extern \"C\" fn count_i32(x: i32, s_ptr: *const u8, s_len: usize) -> usize"
+                "pub extern \"C\" fn rustcall_count_i32(x: i32, s_ptr: *const u8, s_len: usize) -> usize"
             ),
             "{source}"
         );
@@ -585,7 +587,7 @@ mod tests {
         let source = flat(&out.source);
         assert!(
             source.contains(
-                "pub extern \"C\" fn label_i32(_x: i32) -> label_i32_RustCallBorrowedString"
+                "pub extern \"C\" fn rustcall_label_i32(_x: i32) -> label_i32_RustCallBorrowedString"
             ),
             "{source}"
         );

--- a/deps/rustcall_core/tests/corpus/cfg_items.crate.toml
+++ b/deps/rustcall_core/tests/corpus/cfg_items.crate.toml
@@ -1,9 +1,9 @@
-schema_version = 2
+schema_version = 3
 mode = "crate"
 
 [[functions]]
 name = "unix_only"
-symbol = "unix_only"
+symbol = "rustcall_unix_only"
 attribute = "julia"
 exported = true
 cfg = "unix"
@@ -28,7 +28,7 @@ abi = ""
 
 [[functions]]
 name = "windows_wide"
-symbol = "windows_wide"
+symbol = "rustcall_windows_wide"
 attribute = "julia"
 exported = true
 cfg = 'all(windows, feature = "wide")'
@@ -49,7 +49,7 @@ module_path = []
 
 [[functions]]
 name = "maybe"
-symbol = "maybe"
+symbol = "rustcall_maybe"
 attribute = "julia"
 exported = true
 cfg = 'not(target_os = "freebsd")'
@@ -74,7 +74,7 @@ abi = ""
 
 [[functions]]
 name = "bonus"
-symbol = "bonus"
+symbol = "rustcall_bonus"
 attribute = "julia"
 exported = true
 cfg = ""

--- a/deps/rustcall_core/tests/corpus/cfg_items.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/cfg_items.expanded.rs
@@ -1,10 +1,18 @@
 //! `#[cfg]` predicates are recorded in the manifest. Without a configuration
 //! (as here, in the golden run) every item is reported; the CLI with
 //! `--cfg-file` drops the inactive ones.
-#[no_mangle]
 #[cfg(unix)]
-pub extern "C" fn unix_only(x: i32) -> i32 {
+pub fn unix_only(x: i32) -> i32 {
     x + 1
+}
+#[cfg(unix)]
+#[no_mangle]
+pub extern "C" fn rustcall_unix_only(x: i32) -> i32 {
+    unix_only(x)
+}
+#[cfg(all(windows, feature = "wide"))]
+pub fn windows_wide() -> Result<u32, i32> {
+    Ok(1)
 }
 #[cfg(all(windows, feature = "wide"))]
 #[repr(C)]
@@ -59,13 +67,13 @@ impl CResult_windows_wide {
     }
 }
 #[cfg(all(windows, feature = "wide"))]
-fn windows_wide_inner() -> Result<u32, i32> {
-    Ok(1)
-}
-#[cfg(all(windows, feature = "wide"))]
 #[no_mangle]
-pub extern "C" fn windows_wide() -> CResult_windows_wide {
-    CResult_windows_wide::new(windows_wide_inner())
+pub extern "C" fn rustcall_windows_wide() -> CResult_windows_wide {
+    CResult_windows_wide::new(windows_wide())
+}
+#[cfg(not(target_os = "freebsd"))]
+pub fn maybe(x: f64) -> Option<f64> {
+    if x > 0.0 { Some(x) } else { None }
 }
 #[cfg(not(target_os = "freebsd"))]
 #[repr(C)]
@@ -107,13 +115,9 @@ impl COption_maybe {
     }
 }
 #[cfg(not(target_os = "freebsd"))]
-fn maybe_inner(x: f64) -> Option<f64> {
-    if x > 0.0 { Some(x) } else { None }
-}
-#[cfg(not(target_os = "freebsd"))]
 #[no_mangle]
-pub extern "C" fn maybe(x: f64) -> COption_maybe {
-    COption_maybe::new(maybe_inner(x))
+pub extern "C" fn rustcall_maybe(x: f64) -> COption_maybe {
+    COption_maybe::new(maybe(x))
 }
 #[cfg(unix)]
 pub struct Handle {
@@ -150,12 +154,13 @@ pub extern "C" fn Handle_set_epoll(ptr: *mut Handle, value: i32) {
     }
 }
 #[no_mangle]
-pub extern "C" fn Handle_fd(ptr: *const Handle) -> i32 {
+pub extern "C" fn rustcall_Handle_fd(ptr: *const Handle) -> i32 {
     let self_obj = unsafe { &*ptr };
     self_obj.fd()
 }
+#[cfg(target_os = "linux")]
 #[no_mangle]
-pub extern "C" fn Handle_epoll(ptr: *const Handle) -> i32 {
+pub extern "C" fn rustcall_Handle_epoll(ptr: *const Handle) -> i32 {
     let self_obj = unsafe { &*ptr };
     self_obj.epoll()
 }
@@ -170,8 +175,11 @@ impl Handle {
 }
 #[cfg(feature = "extra")]
 mod extra {
-    #[no_mangle]
-    pub extern "C" fn bonus() -> i32 {
+    pub fn bonus() -> i32 {
         42
+    }
+    #[no_mangle]
+    pub extern "C" fn rustcall_bonus() -> i32 {
+        bonus()
     }
 }

--- a/deps/rustcall_core/tests/corpus/cfg_items.inline.toml
+++ b/deps/rustcall_core/tests/corpus/cfg_items.inline.toml
@@ -1,9 +1,9 @@
-schema_version = 2
+schema_version = 3
 mode = "inline"
 
 [[functions]]
 name = "unix_only"
-symbol = "unix_only"
+symbol = "rustcall_unix_only"
 attribute = "julia"
 exported = true
 cfg = "unix"
@@ -28,7 +28,7 @@ abi = ""
 
 [[functions]]
 name = "windows_wide"
-symbol = "windows_wide"
+symbol = "rustcall_windows_wide"
 attribute = "julia"
 exported = true
 cfg = 'all(windows, feature = "wide")'
@@ -49,7 +49,7 @@ module_path = []
 
 [[functions]]
 name = "maybe"
-symbol = "maybe"
+symbol = "rustcall_maybe"
 attribute = "julia"
 exported = true
 cfg = 'not(target_os = "freebsd")'
@@ -74,7 +74,7 @@ abi = ""
 
 [[functions]]
 name = "bonus"
-symbol = "bonus"
+symbol = "rustcall_bonus"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -123,7 +123,7 @@ setter = "Handle_set_epoll"
 
 [[structs.methods]]
 name = "fd"
-symbol = "Handle_fd"
+symbol = "rustcall_Handle_fd"
 is_static = false
 is_mutable = false
 is_constructor = false
@@ -134,7 +134,7 @@ generic_wrapper = ""
 
 [[structs.methods]]
 name = "epoll"
-symbol = "Handle_epoll"
+symbol = "rustcall_Handle_epoll"
 is_static = false
 is_mutable = false
 is_constructor = false

--- a/deps/rustcall_core/tests/corpus/generics_and_crate.crate.toml
+++ b/deps/rustcall_core/tests/corpus/generics_and_crate.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 2
+schema_version = 3
 mode = "crate"
 
 [[functions]]
@@ -75,7 +75,7 @@ setter = ""
 
 [[structs.methods]]
 name = "new"
-symbol = "Pair_new"
+symbol = "rustcall_Pair_new"
 is_static = true
 is_mutable = false
 is_constructor = true
@@ -95,7 +95,7 @@ abi = ""
 
 [[structs.methods]]
 name = "first"
-symbol = "Pair_first"
+symbol = "rustcall_Pair_first"
 is_static = false
 is_mutable = false
 is_constructor = false

--- a/deps/rustcall_core/tests/corpus/generics_and_crate.inline.toml
+++ b/deps/rustcall_core/tests/corpus/generics_and_crate.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 2
+schema_version = 3
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3.crate.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3.crate.toml
@@ -1,9 +1,9 @@
-schema_version = 2
+schema_version = 3
 mode = "crate"
 
 [[functions]]
 name = "dual_add"
-symbol = "dual_add"
+symbol = "rustcall_dual_add"
 attribute = "julia_pyo3"
 exported = true
 cfg = ""
@@ -33,7 +33,7 @@ abi = ""
 
 [[functions]]
 name = "dual_len"
-symbol = "dual_len"
+symbol = "rustcall_dual_len"
 attribute = "julia_pyo3"
 exported = true
 cfg = ""
@@ -79,7 +79,7 @@ setter = "DualCounter_set_value"
 
 [[structs.methods]]
 name = "new"
-symbol = "DualCounter_new"
+symbol = "rustcall_DualCounter_new"
 is_static = true
 is_mutable = false
 is_constructor = true
@@ -94,7 +94,7 @@ abi = ""
 
 [[structs.methods]]
 name = "increment"
-symbol = "DualCounter_increment"
+symbol = "rustcall_DualCounter_increment"
 is_static = false
 is_mutable = true
 is_constructor = false

--- a/deps/rustcall_core/tests/corpus/pyo3.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/pyo3.expanded.rs
@@ -1,6 +1,9 @@
-#[no_mangle]
-pub extern "C" fn dual_add(left: i32, right: i32) -> i32 {
+pub fn dual_add(left: i32, right: i32) -> i32 {
     left + right
+}
+#[no_mangle]
+pub extern "C" fn rustcall_dual_add(left: i32, right: i32) -> i32 {
+    dual_add(left, right)
 }
 pub struct DualCounter {
     pub value: i32,
@@ -24,12 +27,12 @@ pub extern "C" fn DualCounter_set_value(ptr: *mut DualCounter, value: i32) {
     }
 }
 #[no_mangle]
-pub extern "C" fn DualCounter_new(value: i32) -> *mut DualCounter {
+pub extern "C" fn rustcall_DualCounter_new(value: i32) -> *mut DualCounter {
     let obj = DualCounter::new(value);
     Box::into_raw(Box::new(obj))
 }
 #[no_mangle]
-pub extern "C" fn DualCounter_increment(ptr: *mut DualCounter, amount: i32) {
+pub extern "C" fn rustcall_DualCounter_increment(ptr: *mut DualCounter, amount: i32) {
     let self_obj = unsafe { &mut *ptr };
     self_obj.increment(amount)
 }
@@ -41,15 +44,14 @@ impl DualCounter {
         self.value += amount;
     }
 }
-#[allow(clippy::ptr_arg)]
-fn dual_len_inner(s: String) -> usize {
+pub fn dual_len(s: String) -> usize {
     s.len()
 }
 #[no_mangle]
-pub extern "C" fn dual_len(s_ptr: *const u8, s_len: usize) -> usize {
+pub extern "C" fn rustcall_dual_len(s_ptr: *const u8, s_len: usize) -> usize {
     let s = unsafe {
         let slice = std::slice::from_raw_parts(s_ptr, s_len);
         String::from_utf8_lossy(slice).into_owned()
     };
-    dual_len_inner(s)
+    dual_len(s)
 }

--- a/deps/rustcall_core/tests/corpus/pyo3.inline.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3.inline.toml
@@ -1,9 +1,9 @@
-schema_version = 2
+schema_version = 3
 mode = "inline"
 
 [[functions]]
 name = "dual_add"
-symbol = "dual_add"
+symbol = "rustcall_dual_add"
 attribute = "julia_pyo3"
 exported = true
 cfg = ""
@@ -33,7 +33,7 @@ abi = ""
 
 [[functions]]
 name = "dual_len"
-symbol = "dual_len"
+symbol = "rustcall_dual_len"
 attribute = "julia_pyo3"
 exported = true
 cfg = ""
@@ -79,7 +79,7 @@ setter = "DualCounter_set_value"
 
 [[structs.methods]]
 name = "new"
-symbol = "DualCounter_new"
+symbol = "rustcall_DualCounter_new"
 is_static = true
 is_mutable = false
 is_constructor = true
@@ -94,7 +94,7 @@ abi = ""
 
 [[structs.methods]]
 name = "increment"
-symbol = "DualCounter_increment"
+symbol = "rustcall_DualCounter_increment"
 is_static = false
 is_mutable = true
 is_constructor = false

--- a/deps/rustcall_core/tests/corpus/strings.crate.toml
+++ b/deps/rustcall_core/tests/corpus/strings.crate.toml
@@ -1,9 +1,9 @@
-schema_version = 2
+schema_version = 3
 mode = "crate"
 
 [[functions]]
 name = "shout"
-symbol = "shout"
+symbol = "rustcall_shout"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -28,7 +28,7 @@ abi = "string"
 
 [[functions]]
 name = "concat"
-symbol = "concat"
+symbol = "rustcall_concat"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -63,7 +63,7 @@ abi = ""
 
 [[functions]]
 name = "byte_len"
-symbol = "byte_len"
+symbol = "rustcall_byte_len"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -88,7 +88,7 @@ abi = "str"
 
 [[functions]]
 name = "greeting"
-symbol = "greeting"
+symbol = "rustcall_greeting"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -109,7 +109,7 @@ module_path = []
 
 [[functions]]
 name = "unix_name"
-symbol = "unix_name"
+symbol = "rustcall_unix_name"
 attribute = "julia"
 exported = true
 cfg = "unix"
@@ -134,7 +134,7 @@ abi = "string"
 
 [[functions]]
 name = "consume"
-symbol = "consume"
+symbol = "rustcall_consume"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -159,7 +159,7 @@ abi = "string"
 
 [[functions]]
 name = "paren_ref"
-symbol = "paren_ref"
+symbol = "rustcall_paren_ref"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -184,7 +184,7 @@ abi = "str"
 
 [[functions]]
 name = "collide"
-symbol = "collide"
+symbol = "rustcall_collide"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -235,7 +235,7 @@ setter = "Greeter_set_count"
 
 [[structs.methods]]
 name = "new"
-symbol = "Greeter_new"
+symbol = "rustcall_Greeter_new"
 is_static = true
 is_mutable = false
 is_constructor = true
@@ -250,7 +250,7 @@ abi = ""
 
 [[structs.methods]]
 name = "shout"
-symbol = "Greeter_shout"
+symbol = "rustcall_Greeter_shout"
 is_static = false
 is_mutable = false
 is_constructor = false
@@ -265,7 +265,7 @@ abi = "str"
 
 [[structs.methods]]
 name = "label"
-symbol = "Greeter_label"
+symbol = "rustcall_Greeter_label"
 is_static = false
 is_mutable = false
 is_constructor = false
@@ -276,7 +276,7 @@ generic_wrapper = ""
 
 [[structs.methods]]
 name = "take"
-symbol = "Greeter_take"
+symbol = "rustcall_Greeter_take"
 is_static = false
 is_mutable = true
 is_constructor = false

--- a/deps/rustcall_core/tests/corpus/strings.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/strings.expanded.rs
@@ -1,4 +1,7 @@
 //! `String` / `&str` arguments and returns on `#[julia]` free functions (#242).
+pub fn shout(input: String) -> String {
+    input.to_uppercase()
+}
 #[repr(C)]
 pub struct shout_RustCallOwnedString {
     pub ptr: *mut u8,
@@ -13,12 +16,8 @@ pub extern "C" fn shout_free_rust_string(ptr: *mut u8, len: usize, cap: usize) {
         }
     }
 }
-#[allow(clippy::ptr_arg)]
-fn shout_inner(input: String) -> String {
-    input.to_uppercase()
-}
 #[no_mangle]
-pub extern "C" fn shout(
+pub extern "C" fn rustcall_shout(
     input_ptr: *const u8,
     input_len: usize,
 ) -> shout_RustCallOwnedString {
@@ -26,7 +25,7 @@ pub extern "C" fn shout(
         let slice = std::slice::from_raw_parts(input_ptr, input_len);
         String::from_utf8_lossy(slice).into_owned()
     };
-    let rustcall_value = shout_inner(input);
+    let rustcall_value = shout(input);
     let mut rustcall_bytes = ToString::to_string(&rustcall_value).into_bytes();
     let rustcall_ret = shout_RustCallOwnedString {
         ptr: rustcall_bytes.as_mut_ptr(),
@@ -35,6 +34,14 @@ pub extern "C" fn shout(
     };
     std::mem::forget(rustcall_bytes);
     rustcall_ret
+}
+pub fn concat(a: &str, b: &str, times: u32) -> String {
+    let mut out = String::new();
+    for _ in 0..times {
+        out.push_str(a);
+        out.push_str(b);
+    }
+    out
 }
 #[repr(C)]
 pub struct concat_RustCallOwnedString {
@@ -50,17 +57,8 @@ pub extern "C" fn concat_free_rust_string(ptr: *mut u8, len: usize, cap: usize) 
         }
     }
 }
-#[allow(clippy::ptr_arg)]
-fn concat_inner(a: &str, b: &str, times: u32) -> String {
-    let mut out = String::new();
-    for _ in 0..times {
-        out.push_str(a);
-        out.push_str(b);
-    }
-    out
-}
 #[no_mangle]
-pub extern "C" fn concat(
+pub extern "C" fn rustcall_concat(
     a_ptr: *const u8,
     a_len: usize,
     b_ptr: *const u8,
@@ -73,7 +71,7 @@ pub extern "C" fn concat(
     let b_bytes = unsafe { std::slice::from_raw_parts(b_ptr, b_len) };
     let b_cow = String::from_utf8_lossy(b_bytes);
     let b: &str = &b_cow;
-    let rustcall_value = concat_inner(a, b, times);
+    let rustcall_value = concat(a, b, times);
     let mut rustcall_bytes = ToString::to_string(&rustcall_value).into_bytes();
     let rustcall_ret = concat_RustCallOwnedString {
         ptr: rustcall_bytes.as_mut_ptr(),
@@ -83,33 +81,35 @@ pub extern "C" fn concat(
     std::mem::forget(rustcall_bytes);
     rustcall_ret
 }
-#[allow(clippy::ptr_arg)]
-fn byte_len_inner(s: &str) -> usize {
+pub fn byte_len(s: &str) -> usize {
     s.len()
 }
 #[no_mangle]
-pub extern "C" fn byte_len(s_ptr: *const u8, s_len: usize) -> usize {
+pub extern "C" fn rustcall_byte_len(s_ptr: *const u8, s_len: usize) -> usize {
     let s_bytes = unsafe { std::slice::from_raw_parts(s_ptr, s_len) };
     let s_cow = String::from_utf8_lossy(s_bytes);
     let s: &str = &s_cow;
-    byte_len_inner(s)
+    byte_len(s)
+}
+pub fn greeting() -> &'static str {
+    "hello"
 }
 #[repr(C)]
 pub struct greeting_RustCallBorrowedString {
     pub ptr: *const u8,
     pub len: usize,
 }
-#[allow(clippy::ptr_arg)]
-fn greeting_inner() -> &'static str {
-    "hello"
-}
 #[no_mangle]
-pub extern "C" fn greeting() -> greeting_RustCallBorrowedString {
-    let rustcall_value = greeting_inner();
+pub extern "C" fn rustcall_greeting() -> greeting_RustCallBorrowedString {
+    let rustcall_value = greeting();
     greeting_RustCallBorrowedString {
         ptr: rustcall_value.as_ptr(),
         len: rustcall_value.len(),
     }
+}
+#[cfg(unix)]
+pub fn unix_name(s: String) -> String {
+    s
 }
 #[cfg(unix)]
 #[repr(C)]
@@ -128,13 +128,8 @@ pub extern "C" fn unix_name_free_rust_string(ptr: *mut u8, len: usize, cap: usiz
     }
 }
 #[cfg(unix)]
-#[allow(clippy::ptr_arg)]
-fn unix_name_inner(s: String) -> String {
-    s
-}
-#[cfg(unix)]
 #[no_mangle]
-pub extern "C" fn unix_name(
+pub extern "C" fn rustcall_unix_name(
     s_ptr: *const u8,
     s_len: usize,
 ) -> unix_name_RustCallOwnedString {
@@ -142,7 +137,7 @@ pub extern "C" fn unix_name(
         let slice = std::slice::from_raw_parts(s_ptr, s_len);
         String::from_utf8_lossy(slice).into_owned()
     };
-    let rustcall_value = unix_name_inner(s);
+    let rustcall_value = unix_name(s);
     let mut rustcall_bytes = ToString::to_string(&rustcall_value).into_bytes();
     let rustcall_ret = unix_name_RustCallOwnedString {
         ptr: rustcall_bytes.as_mut_ptr(),
@@ -152,40 +147,41 @@ pub extern "C" fn unix_name(
     std::mem::forget(rustcall_bytes);
     rustcall_ret
 }
-#[allow(clippy::ptr_arg)]
-fn consume_inner(s: (String)) -> usize {
+pub fn consume(s: (String)) -> usize {
     s.len()
 }
 #[no_mangle]
-pub extern "C" fn consume(s_ptr: *const u8, s_len: usize) -> usize {
+pub extern "C" fn rustcall_consume(s_ptr: *const u8, s_len: usize) -> usize {
     let s = unsafe {
         let slice = std::slice::from_raw_parts(s_ptr, s_len);
         String::from_utf8_lossy(slice).into_owned()
     };
-    consume_inner(s)
+    consume(s)
 }
-#[allow(clippy::ptr_arg)]
-fn paren_ref_inner(s: &(str)) -> (usize) {
+pub fn paren_ref(s: &(str)) -> (usize) {
     s.len()
 }
 #[no_mangle]
-pub extern "C" fn paren_ref(s_ptr: *const u8, s_len: usize) -> (usize) {
+pub extern "C" fn rustcall_paren_ref(s_ptr: *const u8, s_len: usize) -> (usize) {
     let s_bytes = unsafe { std::slice::from_raw_parts(s_ptr, s_len) };
     let s_cow = String::from_utf8_lossy(s_bytes);
     let s: &str = &s_cow;
-    paren_ref_inner(s)
+    paren_ref(s)
 }
-#[allow(clippy::ptr_arg)]
-fn collide_inner(s: String, s_ptr: usize) -> usize {
+pub fn collide(s: String, s_ptr: usize) -> usize {
     s.len() + s_ptr
 }
 #[no_mangle]
-pub extern "C" fn collide(s_ptr_: *const u8, s_len: usize, s_ptr: usize) -> usize {
+pub extern "C" fn rustcall_collide(
+    s_ptr_: *const u8,
+    s_len: usize,
+    s_ptr: usize,
+) -> usize {
     let s = unsafe {
         let slice = std::slice::from_raw_parts(s_ptr_, s_len);
         String::from_utf8_lossy(slice).into_owned()
     };
-    collide_inner(s, s_ptr)
+    collide(s, s_ptr)
 }
 pub struct Greeter {
     pub count: u32,
@@ -200,9 +196,9 @@ pub extern "C" fn Greeter_free(ptr: *mut Greeter) {
 }
 #[repr(C)]
 pub struct Greeter_RustCallOwnedString {
-    ptr: *mut u8,
-    len: usize,
-    cap: usize,
+    pub ptr: *mut u8,
+    pub len: usize,
+    pub cap: usize,
 }
 #[no_mangle]
 pub extern "C" fn Greeter_free_rust_string(ptr: *mut u8, len: usize, cap: usize) {
@@ -214,8 +210,8 @@ pub extern "C" fn Greeter_free_rust_string(ptr: *mut u8, len: usize, cap: usize)
 }
 #[repr(C)]
 pub struct Greeter_RustCallBorrowedString {
-    ptr: *const u8,
-    len: usize,
+    pub ptr: *const u8,
+    pub len: usize,
 }
 #[no_mangle]
 pub extern "C" fn Greeter_get_count(ptr: *const Greeter) -> u32 {
@@ -228,12 +224,12 @@ pub extern "C" fn Greeter_set_count(ptr: *mut Greeter, value: u32) {
     }
 }
 #[no_mangle]
-pub extern "C" fn Greeter_new(count: u32) -> *mut Greeter {
+pub extern "C" fn rustcall_Greeter_new(count: u32) -> *mut Greeter {
     let obj = Greeter::new(count);
     Box::into_raw(Box::new(obj))
 }
 #[no_mangle]
-pub extern "C" fn Greeter_shout(
+pub extern "C" fn rustcall_Greeter_shout(
     ptr: *const Greeter,
     suffix_ptr: *const u8,
     suffix_len: usize,
@@ -253,7 +249,9 @@ pub extern "C" fn Greeter_shout(
     rustcall_ret
 }
 #[no_mangle]
-pub extern "C" fn Greeter_label(ptr: *const Greeter) -> Greeter_RustCallBorrowedString {
+pub extern "C" fn rustcall_Greeter_label(
+    ptr: *const Greeter,
+) -> Greeter_RustCallBorrowedString {
     let self_obj = unsafe { &*ptr };
     let rustcall_value = self_obj.label();
     Greeter_RustCallBorrowedString {
@@ -262,7 +260,7 @@ pub extern "C" fn Greeter_label(ptr: *const Greeter) -> Greeter_RustCallBorrowed
     }
 }
 #[no_mangle]
-pub extern "C" fn Greeter_take(
+pub extern "C" fn rustcall_Greeter_take(
     ptr: *mut Greeter,
     s_ptr: *const u8,
     s_len: usize,

--- a/deps/rustcall_core/tests/corpus/strings.inline.toml
+++ b/deps/rustcall_core/tests/corpus/strings.inline.toml
@@ -1,9 +1,9 @@
-schema_version = 2
+schema_version = 3
 mode = "inline"
 
 [[functions]]
 name = "shout"
-symbol = "shout"
+symbol = "rustcall_shout"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -28,7 +28,7 @@ abi = "string"
 
 [[functions]]
 name = "concat"
-symbol = "concat"
+symbol = "rustcall_concat"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -63,7 +63,7 @@ abi = ""
 
 [[functions]]
 name = "byte_len"
-symbol = "byte_len"
+symbol = "rustcall_byte_len"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -88,7 +88,7 @@ abi = "str"
 
 [[functions]]
 name = "greeting"
-symbol = "greeting"
+symbol = "rustcall_greeting"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -109,7 +109,7 @@ module_path = []
 
 [[functions]]
 name = "unix_name"
-symbol = "unix_name"
+symbol = "rustcall_unix_name"
 attribute = "julia"
 exported = true
 cfg = "unix"
@@ -134,7 +134,7 @@ abi = "string"
 
 [[functions]]
 name = "consume"
-symbol = "consume"
+symbol = "rustcall_consume"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -159,7 +159,7 @@ abi = "string"
 
 [[functions]]
 name = "paren_ref"
-symbol = "paren_ref"
+symbol = "rustcall_paren_ref"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -184,7 +184,7 @@ abi = "str"
 
 [[functions]]
 name = "collide"
-symbol = "collide"
+symbol = "rustcall_collide"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -235,7 +235,7 @@ setter = "Greeter_set_count"
 
 [[structs.methods]]
 name = "new"
-symbol = "Greeter_new"
+symbol = "rustcall_Greeter_new"
 is_static = true
 is_mutable = false
 is_constructor = true
@@ -250,7 +250,7 @@ abi = ""
 
 [[structs.methods]]
 name = "shout"
-symbol = "Greeter_shout"
+symbol = "rustcall_Greeter_shout"
 is_static = false
 is_mutable = false
 is_constructor = false
@@ -265,7 +265,7 @@ abi = "str"
 
 [[structs.methods]]
 name = "label"
-symbol = "Greeter_label"
+symbol = "rustcall_Greeter_label"
 is_static = false
 is_mutable = false
 is_constructor = false
@@ -276,7 +276,7 @@ generic_wrapper = ""
 
 [[structs.methods]]
 name = "take"
-symbol = "Greeter_take"
+symbol = "rustcall_Greeter_take"
 is_static = false
 is_mutable = true
 is_constructor = false

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.crate.toml
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.crate.toml
@@ -1,10 +1,10 @@
-schema_version = 2
+schema_version = 3
 mode = "crate"
 structs = []
 
 [[functions]]
 name = "checked_double"
-symbol = "checked_double"
+symbol = "rustcall_checked_double"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -29,7 +29,7 @@ abi = ""
 
 [[functions]]
 name = "positive"
-symbol = "positive"
+symbol = "rustcall_positive"
 attribute = "julia"
 exported = true
 cfg = ""

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
@@ -13,9 +13,9 @@ pub extern "C" fn Greeter_free(ptr: *mut Greeter) {
 }
 #[repr(C)]
 pub struct Greeter_RustCallOwnedString {
-    ptr: *mut u8,
-    len: usize,
-    cap: usize,
+    pub ptr: *mut u8,
+    pub len: usize,
+    pub cap: usize,
 }
 #[no_mangle]
 pub extern "C" fn Greeter_free_rust_string(ptr: *mut u8, len: usize, cap: usize) {
@@ -27,8 +27,8 @@ pub extern "C" fn Greeter_free_rust_string(ptr: *mut u8, len: usize, cap: usize)
 }
 #[repr(C)]
 pub struct Greeter_RustCallBorrowedString {
-    ptr: *const u8,
-    len: usize,
+    pub ptr: *const u8,
+    pub len: usize,
 }
 #[no_mangle]
 pub extern "C" fn Greeter_get_name(ptr: *const Greeter) -> Greeter_RustCallOwnedString {
@@ -62,7 +62,10 @@ pub extern "C" fn Greeter_clone(ptr: *const Greeter) -> *mut Greeter {
     unsafe { Box::into_raw(Box::new((*ptr).clone())) }
 }
 #[no_mangle]
-pub extern "C" fn Greeter_new(name_ptr: *const u8, name_len: usize) -> *mut Greeter {
+pub extern "C" fn rustcall_Greeter_new(
+    name_ptr: *const u8,
+    name_len: usize,
+) -> *mut Greeter {
     let name = unsafe {
         let slice = std::slice::from_raw_parts(name_ptr, name_len);
         String::from_utf8_lossy(slice).into_owned()
@@ -71,7 +74,7 @@ pub extern "C" fn Greeter_new(name_ptr: *const u8, name_len: usize) -> *mut Gree
     Box::into_raw(Box::new(obj))
 }
 #[no_mangle]
-pub extern "C" fn Greeter_rename(
+pub extern "C" fn rustcall_Greeter_rename(
     ptr: *mut Greeter,
     name_ptr: *const u8,
     name_len: usize,
@@ -84,7 +87,7 @@ pub extern "C" fn Greeter_rename(
     self_obj.rename(name)
 }
 #[no_mangle]
-pub extern "C" fn Greeter_greet(
+pub extern "C" fn rustcall_Greeter_greet(
     ptr: *const Greeter,
     prefix_ptr: *const u8,
     prefix_len: usize,
@@ -104,7 +107,9 @@ pub extern "C" fn Greeter_greet(
     rustcall_ret
 }
 #[no_mangle]
-pub extern "C" fn Greeter_name(ptr: *const Greeter) -> Greeter_RustCallBorrowedString {
+pub extern "C" fn rustcall_Greeter_name(
+    ptr: *const Greeter,
+) -> Greeter_RustCallBorrowedString {
     let self_obj = unsafe { &*ptr };
     let rustcall_value = self_obj.name();
     Greeter_RustCallBorrowedString {
@@ -125,6 +130,9 @@ impl Greeter {
     pub fn name(&self) -> &str {
         &self.name
     }
+}
+pub fn checked_double(value: i32) -> Result<i32, i32> {
+    value.checked_mul(2).ok_or(value)
 }
 #[repr(C)]
 pub struct CResult_checked_double {
@@ -176,12 +184,12 @@ impl CResult_checked_double {
         }
     }
 }
-fn checked_double_inner(value: i32) -> Result<i32, i32> {
-    value.checked_mul(2).ok_or(value)
-}
 #[no_mangle]
-pub extern "C" fn checked_double(value: i32) -> CResult_checked_double {
-    CResult_checked_double::new(checked_double_inner(value))
+pub extern "C" fn rustcall_checked_double(value: i32) -> CResult_checked_double {
+    CResult_checked_double::new(checked_double(value))
+}
+pub fn positive(value: i32) -> Option<i32> {
+    (value > 0).then_some(value)
 }
 #[repr(C)]
 pub struct COption_positive {
@@ -220,10 +228,7 @@ impl COption_positive {
         }
     }
 }
-fn positive_inner(value: i32) -> Option<i32> {
-    (value > 0).then_some(value)
-}
 #[no_mangle]
-pub extern "C" fn positive(value: i32) -> COption_positive {
-    COption_positive::new(positive_inner(value))
+pub extern "C" fn rustcall_positive(value: i32) -> COption_positive {
+    COption_positive::new(positive(value))
 }

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.inline.toml
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.inline.toml
@@ -1,9 +1,9 @@
-schema_version = 2
+schema_version = 3
 mode = "inline"
 
 [[functions]]
 name = "checked_double"
-symbol = "checked_double"
+symbol = "rustcall_checked_double"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -28,7 +28,7 @@ abi = ""
 
 [[functions]]
 name = "positive"
-symbol = "positive"
+symbol = "rustcall_positive"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -81,7 +81,7 @@ setter = "Greeter_set_visits"
 
 [[structs.methods]]
 name = "new"
-symbol = "Greeter_new"
+symbol = "rustcall_Greeter_new"
 is_static = true
 is_mutable = false
 is_constructor = true
@@ -96,7 +96,7 @@ abi = "string"
 
 [[structs.methods]]
 name = "rename"
-symbol = "Greeter_rename"
+symbol = "rustcall_Greeter_rename"
 is_static = false
 is_mutable = true
 is_constructor = false
@@ -111,7 +111,7 @@ abi = "string"
 
 [[structs.methods]]
 name = "greet"
-symbol = "Greeter_greet"
+symbol = "rustcall_Greeter_greet"
 is_static = false
 is_mutable = false
 is_constructor = false
@@ -126,7 +126,7 @@ abi = "str"
 
 [[structs.methods]]
 name = "name"
-symbol = "Greeter_name"
+symbol = "rustcall_Greeter_name"
 is_static = false
 is_mutable = false
 is_constructor = false

--- a/deps/rustcall_core/tests/corpus/syntax_stress.crate.toml
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 2
+schema_version = 3
 mode = "crate"
 structs = []
 
@@ -48,7 +48,7 @@ abi = ""
 
 [[functions]]
 name = "const_expression"
-symbol = "const_expression"
+symbol = "rustcall_const_expression"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -73,7 +73,7 @@ abi = ""
 
 [[functions]]
 name = "raw_braces"
-symbol = "raw_braces"
+symbol = "rustcall_raw_braces"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -94,7 +94,7 @@ module_path = []
 
 [[functions]]
 name = "cfg_disabled"
-symbol = "cfg_disabled"
+symbol = "rustcall_cfg_disabled"
 attribute = "julia"
 exported = true
 cfg = "any()"

--- a/deps/rustcall_core/tests/corpus/syntax_stress.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.expanded.rs
@@ -7,23 +7,27 @@ where
 {
     value.len()
 }
-#[no_mangle]
-pub extern "C" fn const_expression(value: [u8; { if 1 < 2 { 3 } else { 4 } }]) -> u8 {
+fn const_expression(value: [u8; { if 1 < 2 { 3 } else { 4 } }]) -> u8 {
     value[0]
+}
+#[no_mangle]
+pub extern "C" fn rustcall_const_expression(
+    value: [u8; { if 1 < 2 { 3 } else { 4 } }],
+) -> u8 {
+    const_expression(value)
+}
+/// The raw string deliberately contains braces that are not Rust blocks.
+fn raw_braces() -> &'static str {
+    r##"left { middle } right"##
 }
 #[repr(C)]
 pub struct raw_braces_RustCallBorrowedString {
     pub ptr: *const u8,
     pub len: usize,
 }
-#[allow(clippy::ptr_arg)]
-fn raw_braces_inner() -> &'static str {
-    r##"left { middle } right"##
-}
-/// The raw string deliberately contains braces that are not Rust blocks.
 #[no_mangle]
-pub extern "C" fn raw_braces() -> raw_braces_RustCallBorrowedString {
-    let rustcall_value = raw_braces_inner();
+pub extern "C" fn rustcall_raw_braces() -> raw_braces_RustCallBorrowedString {
+    let rustcall_value = raw_braces();
     raw_braces_RustCallBorrowedString {
         ptr: rustcall_value.as_ptr(),
         len: rustcall_value.len(),
@@ -36,8 +40,12 @@ fn marker_in_string_is_not_an_attribute() -> &'static str {
 fn borrow_for<'a>(value: &'a str, fallback: &'a str) -> &'a str {
     if value.is_empty() { fallback } else { value }
 }
-#[no_mangle]
 #[cfg(any())]
-pub extern "C" fn cfg_disabled() -> i32 {
+fn cfg_disabled() -> i32 {
     7
+}
+#[cfg(any())]
+#[no_mangle]
+pub extern "C" fn rustcall_cfg_disabled() -> i32 {
+    cfg_disabled()
 }

--- a/deps/rustcall_core/tests/corpus/syntax_stress.inline.toml
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 2
+schema_version = 3
 mode = "inline"
 structs = []
 
@@ -48,7 +48,7 @@ abi = ""
 
 [[functions]]
 name = "const_expression"
-symbol = "const_expression"
+symbol = "rustcall_const_expression"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -73,7 +73,7 @@ abi = ""
 
 [[functions]]
 name = "raw_braces"
-symbol = "raw_braces"
+symbol = "rustcall_raw_braces"
 attribute = "julia"
 exported = true
 cfg = ""
@@ -145,7 +145,7 @@ abi = "str"
 
 [[functions]]
 name = "cfg_disabled"
-symbol = "cfg_disabled"
+symbol = "rustcall_cfg_disabled"
 attribute = "julia"
 exported = true
 cfg = "any()"

--- a/deps/rustcall_core/tests/strings.rs
+++ b/deps/rustcall_core/tests/strings.rs
@@ -36,44 +36,54 @@ fn string_functions_get_ptr_len_wrappers() {
         .replace("( ", "(")
         .replace(", )", ")")
         .replace(" )", ")");
-    assert!(src.contains("pub extern \"C\" fn shout(input_ptr: *const u8, input_len: usize) -> shout_RustCallOwnedString"), "{src}");
+    assert!(src.contains("pub extern \"C\" fn rustcall_shout(input_ptr: *const u8, input_len: usize) -> shout_RustCallOwnedString"), "{src}");
     assert!(src.contains(
         "pub extern \"C\" fn shout_free_rust_string(ptr: *mut u8, len: usize, cap: usize)"
     ));
-    assert!(src.contains("fn shout_inner(input: String) -> String"));
-    assert!(src.contains("pub extern \"C\" fn concat(a_ptr: *const u8, a_len: usize, b_ptr: *const u8, b_len: usize, times: u32) -> concat_RustCallOwnedString"), "{src}");
-    assert!(src.contains("pub extern \"C\" fn byte_len(s_ptr: *const u8, s_len: usize) -> usize"));
-    assert!(src.contains("pub extern \"C\" fn greeting() -> greeting_RustCallBorrowedString"));
+    // The annotated item survives verbatim next to the wrapper (#279).
+    assert!(src.contains("fn shout(input: String) -> String"));
+    assert!(!src.contains("shout_inner"));
+    assert!(src.contains("pub extern \"C\" fn rustcall_concat(a_ptr: *const u8, a_len: usize, b_ptr: *const u8, b_len: usize, times: u32) -> concat_RustCallOwnedString"), "{src}");
+    assert!(src.contains(
+        "pub extern \"C\" fn rustcall_byte_len(s_ptr: *const u8, s_len: usize) -> usize"
+    ));
+    assert!(
+        src.contains("pub extern \"C\" fn rustcall_greeting() -> greeting_RustCallBorrowedString")
+    );
     assert!(!src.contains("greeting_free_rust_string"));
-    assert!(src.contains("pub extern \"C\" fn plain(x: i32) -> i32"));
+    assert!(src.contains("pub extern \"C\" fn rustcall_plain(x: i32) -> i32"));
     // Result / Option functions convert string arguments too.
     assert!(
         src.contains(
-            "pub extern \"C\" fn parse_num(s_ptr: *const u8, s_len: usize) -> CResult_parse_num"
+            "pub extern \"C\" fn rustcall_parse_num(s_ptr: *const u8, s_len: usize) -> CResult_parse_num"
         ),
         "{src}"
     );
     assert!(
         src.contains(
-            "pub extern \"C\" fn first_char(s_ptr: *const u8, s_len: usize) -> COption_first_char"
+            "pub extern \"C\" fn rustcall_first_char(s_ptr: *const u8, s_len: usize) -> COption_first_char"
         ),
         "{src}"
     );
     // Lifetime-qualified &str is a string argument as well. Because the result
     // may borrow from the converted argument, it is copied into an owned buffer.
-    assert!(src.contains("pub extern \"C\" fn identity(s_ptr: *const u8, s_len: usize) -> identity_RustCallOwnedString"), "{src}");
+    assert!(src.contains("pub extern \"C\" fn rustcall_identity(s_ptr: *const u8, s_len: usize) -> identity_RustCallOwnedString"), "{src}");
     assert!(src.contains("pub extern \"C\" fn identity_free_rust_string"));
     // `greeting()` takes no strings, so its &str result stays borrowed.
-    assert!(src.contains("pub extern \"C\" fn greeting() -> greeting_RustCallBorrowedString"));
-    // Qualified std::string::String is a string type too.
-    assert!(src.contains("pub extern \"C\" fn qualified(s_ptr: *const u8, s_len: usize) -> qualified_RustCallOwnedString"), "{src}");
     assert!(
-        src.contains("pub extern \"C\" fn qualified2(s_ptr: *const u8, s_len: usize) -> usize"),
+        src.contains("pub extern \"C\" fn rustcall_greeting() -> greeting_RustCallBorrowedString")
+    );
+    // Qualified std::string::String is a string type too.
+    assert!(src.contains("pub extern \"C\" fn rustcall_qualified(s_ptr: *const u8, s_len: usize) -> qualified_RustCallOwnedString"), "{src}");
+    assert!(
+        src.contains(
+            "pub extern \"C\" fn rustcall_qualified2(s_ptr: *const u8, s_len: usize) -> usize"
+        ),
         "{src}"
     );
     // The lifetime parameter stays on the inner fn.
     assert!(
-        src.contains("fn identity_inner<'a>(s: &'a str) -> &'a str"),
+        src.contains("fn identity<'a>(s: &'a str) -> &'a str"),
         "{src}"
     );
     // No unchecked UTF-8 construction anywhere.
@@ -135,20 +145,24 @@ pub fn paren_res(s: (String)) -> (Result<i32, i32>) { s.parse().map_err(|_| -1) 
     let e = expand(src).unwrap();
     let source = flat(&e.source);
     assert!(
-        source.contains("pub extern \"C\" fn consume(s_ptr: *const u8, s_len: usize) -> usize"),
-        "{source}"
-    );
-    assert!(
-        source.contains("pub extern \"C\" fn paren_ref(s_ptr: *const u8, s_len: usize) -> (usize)"),
-        "{source}"
-    );
-    assert!(
-        source.contains("pub extern \"C\" fn paren_ret(s_ptr: *const u8, s_len: usize) -> paren_ret_RustCallOwnedString"),
+        source.contains(
+            "pub extern \"C\" fn rustcall_consume(s_ptr: *const u8, s_len: usize) -> usize"
+        ),
         "{source}"
     );
     assert!(
         source.contains(
-            "pub extern \"C\" fn paren_res(s_ptr: *const u8, s_len: usize) -> CResult_paren_res"
+            "pub extern \"C\" fn rustcall_paren_ref(s_ptr: *const u8, s_len: usize) -> (usize)"
+        ),
+        "{source}"
+    );
+    assert!(
+        source.contains("pub extern \"C\" fn rustcall_paren_ret(s_ptr: *const u8, s_len: usize) -> paren_ret_RustCallOwnedString"),
+        "{source}"
+    );
+    assert!(
+        source.contains(
+            "pub extern \"C\" fn rustcall_paren_res(s_ptr: *const u8, s_len: usize) -> CResult_paren_res"
         ),
         "{source}"
     );
@@ -187,13 +201,13 @@ impl Holder {
     let source = flat(&e.source);
     assert!(
         source.contains(
-            "pub extern \"C\" fn f(s_ptr_: *const u8, s_len: usize, s_ptr: usize) -> usize"
+            "pub extern \"C\" fn rustcall_f(s_ptr_: *const u8, s_len: usize, s_ptr: usize) -> usize"
         ),
         "{source}"
     );
-    assert!(source.contains("fn f_inner(s: String, s_ptr: usize) -> usize"));
+    assert!(source.contains("fn f(s: String, s_ptr: usize) -> usize"));
     assert!(
-        source.contains("pub extern \"C\" fn g(s_ptr: *const u8, s_len_: usize, s_bytes: i32, s_cow: i32, s_len: i32) -> i32"),
+        source.contains("pub extern \"C\" fn rustcall_g(s_ptr: *const u8, s_len_: usize, s_bytes: i32, s_cow: i32, s_len: i32) -> i32"),
         "{source}"
     );
     assert!(
@@ -204,19 +218,17 @@ impl Holder {
         source.contains("let s_cow_ = String::from_utf8_lossy(s_bytes_);"),
         "{source}"
     );
-    assert!(
-        source.contains("g_inner(s, s_bytes, s_cow, s_len)"),
-        "{source}"
-    );
+    assert!(source.contains("g(s, s_bytes, s_cow, s_len)"), "{source}");
     // The user owns `s_ptr_`; the generated `s_ptr` is free and keeps its name.
-    assert!(source.contains("h_inner(s_ptr_, s)"), "{source}");
+    assert!(source.contains("h(s_ptr_, s)"), "{source}");
     assert!(
-        source
-            .contains("pub extern \"C\" fn h(s_ptr_: u8, s_ptr: *const u8, s_len: usize) -> usize"),
+        source.contains(
+            "pub extern \"C\" fn rustcall_h(s_ptr_: u8, s_ptr: *const u8, s_len: usize) -> usize"
+        ),
         "{source}"
     );
     assert!(
-        source.contains("pub extern \"C\" fn Holder_m(ptr_: *const Holder, ptr: u32, self_obj: u32, s_ptr: *const u8, s_len: usize, s_bytes: u32) -> u32"),
+        source.contains("pub extern \"C\" fn rustcall_Holder_m(ptr_: *const Holder, ptr: u32, self_obj: u32, s_ptr: *const u8, s_len: usize, s_bytes: u32) -> u32"),
         "{source}"
     );
     assert!(
@@ -299,7 +311,7 @@ impl<T: Copy> Tagged<T> {
     .unwrap();
     assert!(out.manifest.functions[0].has_borrowed_string_helper);
     assert!(
-        flat(&out.source).contains("pub extern \"C\" fn Tagged_tag_ref_i32(ptr: *const Tagged<i32>) -> Tagged_tag_ref_i32_RustCallBorrowedString"),
+        flat(&out.source).contains("pub extern \"C\" fn rustcall_Tagged_tag_ref_i32(ptr: *const Tagged<i32>) -> Tagged_tag_ref_i32_RustCallBorrowedString"),
         "{}",
         flat(&out.source)
     );
@@ -352,11 +364,11 @@ impl Greeter {
     let file: syn::File = syn::parse2(out).unwrap();
     let source = flat(&prettyplease::unparse(&file));
     assert!(
-        source.contains("pub extern \"C\" fn Greeter_new(count: u32) -> *mut Greeter"),
+        source.contains("pub extern \"C\" fn rustcall_Greeter_new(count: u32) -> *mut Greeter"),
         "{source}"
     );
     assert!(
-        source.contains("pub extern \"C\" fn Greeter_shout(ptr: *const Greeter, suffix_ptr: *const u8, suffix_len: usize) -> Greeter_shout_RustCallOwnedString"),
+        source.contains("pub extern \"C\" fn rustcall_Greeter_shout(ptr: *const Greeter, suffix_ptr: *const u8, suffix_len: usize) -> Greeter_shout_RustCallOwnedString"),
         "{source}"
     );
     assert!(source.contains("pub struct Greeter_shout_RustCallOwnedString"));
@@ -364,22 +376,22 @@ impl Greeter {
         "pub extern \"C\" fn Greeter_shout_free_rust_string(ptr: *mut u8, len: usize, cap: usize)"
     ));
     assert!(
-        source.contains("pub extern \"C\" fn Greeter_label(ptr: *const Greeter) -> Greeter_label_RustCallBorrowedString"),
+        source.contains("pub extern \"C\" fn rustcall_Greeter_label(ptr: *const Greeter) -> Greeter_label_RustCallBorrowedString"),
         "{source}"
     );
     assert!(!source.contains("Greeter_label_free_rust_string"));
     // A &str result that may borrow from a converted argument is copied.
     assert!(
-        source.contains("pub extern \"C\" fn Greeter_echo(ptr: *const Greeter, s_ptr: *const u8, s_len: usize) -> Greeter_echo_RustCallOwnedString"),
+        source.contains("pub extern \"C\" fn rustcall_Greeter_echo(ptr: *const Greeter, s_ptr: *const u8, s_len: usize) -> Greeter_echo_RustCallOwnedString"),
         "{source}"
     );
     assert!(
-        source.contains("pub extern \"C\" fn Greeter_take(ptr: *mut Greeter, s_ptr: *const u8, s_len: usize) -> usize"),
+        source.contains("pub extern \"C\" fn rustcall_Greeter_take(ptr: *mut Greeter, s_ptr: *const u8, s_len: usize) -> usize"),
         "{source}"
     );
-    assert!(
-        source.contains("pub extern \"C\" fn Greeter_plain(ptr: *const Greeter, x: i32) -> i32")
-    );
+    assert!(source.contains(
+        "pub extern \"C\" fn rustcall_Greeter_plain(ptr: *const Greeter, x: i32) -> i32"
+    ));
     assert!(!source.contains("from_utf8_unchecked"));
 
     // The crate manifest describes exactly that ABI.
@@ -409,7 +421,7 @@ impl Greeter {
     assert_eq!(method("echo").return_abi, "string");
     assert_eq!(method("take").args[0].abi, "string");
     assert_eq!(method("take").return_abi, "");
-    assert_eq!(method("new").symbol, "Greeter_new");
+    assert_eq!(method("new").symbol, "rustcall_Greeter_new");
 
     // `#[julia_pyo3] impl` methods go through the same wrapper generator, so
     // their manifest entries keep the string ABI.
@@ -420,7 +432,7 @@ impl Greeter {
     let py_file: syn::File = syn::parse2(transform_impl_julia_pyo3(py_impl)).unwrap();
     let py = flat(&prettyplease::unparse(&py_file));
     assert!(
-        py.contains("pub extern \"C\" fn DualCounter_describe(ptr: *const DualCounter, s_ptr: *const u8, s_len: usize) -> DualCounter_describe_RustCallOwnedString"),
+        py.contains("pub extern \"C\" fn rustcall_DualCounter_describe(ptr: *const DualCounter, s_ptr: *const u8, s_len: usize) -> DualCounter_describe_RustCallOwnedString"),
         "{py}"
     );
 }

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -98,7 +98,9 @@ RustCall.suggest_fix_for_error
 ### Strings in `#[julia]` functions
 
 `#[julia]` free functions may take `String` / `&str` arguments and return
-`String` / `&str` (#242). The generated `extern "C"` wrapper receives every
+`String` / `&str` (#242). The generated `extern "C"` wrapper — `rustcall_<fn>`,
+emitted next to the function, which is itself left untouched (#279) —
+receives every
 string as a `(ptr, len)` UTF-8 byte pair (no NUL terminator, embedded NULs
 allowed), returns `String` as an owned buffer that the Julia wrapper copies
 and releases through `<fn>_free_rust_string`, and returns `&str` as a

--- a/docs/src/crate_bindings.md
+++ b/docs/src/crate_bindings.md
@@ -149,9 +149,17 @@ impl Counter {
 }
 ```
 
-This generates FFI wrappers:
-- `Counter_new(initial)` - Returns `*mut Counter`
-- `Counter_get(ptr)` - Takes `*const Counter`, returns `i32`
+`#[julia]` is additive (#279): the `impl` block above is left exactly as
+written — `Counter::new` and `Counter::get` keep their Rust signatures for
+other callers, `#[test]`s and other proc-macros — and the FFI wrappers are
+emitted next to it under `rustcall_`-prefixed symbols:
+
+- `rustcall_Counter_new(initial)` - Returns `*mut Counter`
+- `rustcall_Counter_get(ptr)` - Takes `*const Counter`, returns `i32`
+
+The generated Julia bindings keep the Rust names (`Counter(1)`, `get(c)`);
+they resolve the exported symbol through the manifest, so nothing in the Julia
+API changes.
 
 ## Property Access Syntax
 

--- a/docs/src/generics.md
+++ b/docs/src/generics.md
@@ -290,13 +290,16 @@ registered source, the function name and `T = i32`-style bindings it:
    generics and comments are handled correctly),
 2. replaces the type parameters in the signature and body at the AST level,
 3. drops the bound generic parameters and their `where` predicates,
-4. renames the function (e.g. `identity_i32`) and marks it `#[no_mangle] pub extern "C"`,
+4. renames the function (e.g. `identity_i32`) and emits a
+   `#[no_mangle] pub extern "C" fn rustcall_identity_i32` wrapper next to it
+   (#279),
 5. reports the resulting argument and return types in a manifest that Julia
    uses to build the `ccall`.
 
 Struct definitions and impl blocks in the registered context are kept
 unchanged, so generic struct wrappers such as `Point_new<T>` become
-`Point_new_i32(x: i32) -> *mut Point<i32>` while `struct Point<T>` stays generic.
+`Point_new_i32(x: i32) -> *mut Point<i32>`, exported as
+`rustcall_Point_new_i32`, while `struct Point<T>` stays generic.
 
 ### Monomorphization Process
 

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -95,7 +95,7 @@ println(result)  # => 35
 
 #### Why `@rust` here?
 
-`#[julia]` exposes a Rust function through a C-compatible ABI and also generates a Julia wrapper, so you can call `add(10, 20)` directly from Julia.
+`#[julia]` exposes a Rust function through a C-compatible ABI and also generates a Julia wrapper, so you can call `add(10, 20)` directly from Julia. The attribute is *additive*: your `fn add` is kept exactly as written and the C entry point is emitted next to it as `rustcall_add`, so the function still composes with other proc-macros (`#[pyfunction]`), in-crate callers and `#[test]`s.
 
 By contrast, `#[no_mangle] pub extern "C"` only exports a symbol from the Rust library. Julia does not automatically get a function named `multiply`, so `@rust` is the bridge that finds the exported symbol, converts the arguments, and performs the call.
 

--- a/examples/sample_crate_pyo3/main.jl
+++ b/examples/sample_crate_pyo3/main.jl
@@ -39,6 +39,16 @@ fib20 = SampleCratePyo3.fibonacci(20)
 println("fibonacci(20) = $fib20")
 @assert fib20 == 6765
 
+# `#[julia]` stacked with `#[pyfunction]` (#279): one definition, one Julia
+# binding, and a Python binding under `--features python`.
+shouted = SampleCratePyo3.shout("hello")
+println("shout(\"hello\") = $shouted")
+@assert shouted == "HELLO"
+
+twice = SampleCratePyo3.shout_twice("hi")
+println("shout_twice(\"hi\") = $twice")
+@assert twice == "HI HI"
+
 println("\n✅ Basic functions work!\n")
 
 # ============================================================================
@@ -101,6 +111,8 @@ Summary of available bindings (all from #[julia_pyo3]):
   Functions:
     - add(a, b) -> Int32
     - fibonacci(n) -> UInt64
+    - shout(s) -> String            (#[julia] + #[pyfunction], #279)
+    - shout_twice(s) -> String
 
   Point struct:
     - Point(x::Float64, y::Float64) -> Point

--- a/examples/sample_crate_pyo3/src/lib.rs
+++ b/examples/sample_crate_pyo3/src/lib.rs
@@ -6,7 +6,11 @@
 //! This example demonstrates the unified `#[julia_pyo3]` macro that generates
 //! both Julia FFI bindings and Python/PyO3 bindings from a single definition.
 
-use juliacall_macros::julia_pyo3;
+// The generated `extern "C"` wrappers take the raw `*const Struct` / `*mut
+// Struct` pointers Julia hands back; that is the FFI contract, not an oversight.
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use juliacall_macros::{julia, julia_pyo3};
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -37,6 +41,40 @@ fn fibonacci(n: u32) -> u64 {
             }
             b
         }
+    }
+}
+
+// ============================================================================
+// Stacking `#[julia]` with `#[pyfunction]` directly (#279)
+//
+// `#[julia]` is additive: it keeps `shout` exactly as written and emits the C
+// entry point `rustcall_shout` next to it. PyO3's own wrapper therefore still
+// sees `fn shout(String) -> String`, and so does the in-crate caller below.
+// This is what makes `#[julia_pyo3]` redundant (#275 Phase 3).
+// ============================================================================
+
+#[julia]
+#[cfg_attr(feature = "python", pyo3::pyfunction)]
+pub fn shout(s: String) -> String {
+    s.to_uppercase()
+}
+
+/// A plain in-crate caller of the annotated function.
+#[julia]
+pub fn shout_twice(s: String) -> String {
+    format!("{} {}", shout(s.clone()), shout(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The annotated items keep their Rust signature for `#[test]` too (#279).
+    #[test]
+    fn annotated_functions_are_callable_from_rust() {
+        assert_eq!(shout("hi".to_string()), "HI");
+        assert_eq!(shout_twice("hi".to_string()), "HI HI");
+        assert_eq!(add(2, 3), 5);
     }
 }
 
@@ -92,6 +130,7 @@ impl Point {
 fn sample_crate_pyo3(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(add, m)?)?;
     m.add_function(wrap_pyfunction!(fibonacci, m)?)?;
+    m.add_function(wrap_pyfunction!(shout, m)?)?;
     m.add_class::<Point>()?;
     Ok(())
 }

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -48,6 +48,53 @@ Maps (library name, function name) to return type.
 const FUNCTION_RETURN_TYPES_BY_LIB = Dict{Tuple{String, String}, Type}()
 
 """
+Rust item name to exported C symbol, per library.
+
+`#[julia]` is additive since #279: the annotated function keeps its own name
+and the library exports the wrapper `rustcall_<name>` next to it. `@rust
+add(1, 2)` names the *Rust function*, so the lookup has to go through this
+mapping, which is filled from the manifest (`Function.symbol`) — never by
+string surgery on the name.
+"""
+const FUNCTION_SYMBOLS_BY_LIB = Dict{Tuple{String, String}, String}()
+
+"""
+Library-agnostic fallback of `FUNCTION_SYMBOLS_BY_LIB`, mirroring the other
+registries so that `@rust` keeps working across `rust\"\"\"` blocks.
+"""
+const FUNCTION_SYMBOLS = Dict{String, String}()
+
+"""
+    register_function_symbol(lib_name, name, symbol)
+
+Record that the Rust item `name` of `lib_name` is exported as `symbol`.
+A symbol equal to the name is not recorded.
+"""
+function register_function_symbol(lib_name::AbstractString, name::AbstractString,
+                                  symbol::AbstractString)
+    (isempty(symbol) || symbol == name) && return nothing
+    lock(REGISTRY_LOCK) do
+        FUNCTION_SYMBOLS_BY_LIB[(String(lib_name), String(name))] = String(symbol)
+        FUNCTION_SYMBOLS[String(name)] = String(symbol)
+    end
+    return nothing
+end
+
+"""
+    exported_symbol(lib_name, name) -> String
+
+The exported C symbol of the Rust item `name`, or `name` itself when nothing
+was recorded (a plain `#[no_mangle] extern "C"` function, or a symbol that is
+already the exported one).
+"""
+function exported_symbol(lib_name::AbstractString, name::AbstractString)
+    lock(REGISTRY_LOCK) do
+        get(FUNCTION_SYMBOLS_BY_LIB, (String(lib_name), String(name)),
+            get(FUNCTION_SYMBOLS, String(name), String(name)))
+    end
+end
+
+"""
     register_function(name::String, lib_name::String, ret_type::Type, arg_types::Vector{Type})
 
 Register a function with its type signature for later calling.

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -48,34 +48,38 @@ Maps (library name, function name) to return type.
 const FUNCTION_RETURN_TYPES_BY_LIB = Dict{Tuple{String, String}, Type}()
 
 """
-Rust item name to exported C symbol, per library.
+Rust item name to exported C symbol, keyed by `(library name, Rust name)`.
 
 `#[julia]` is additive since #279: the annotated function keeps its own name
 and the library exports the wrapper `rustcall_<name>` next to it. `@rust
 add(1, 2)` names the *Rust function*, so the lookup has to go through this
 mapping, which is filled from the manifest (`Function.symbol`) — never by
 string surgery on the name.
+
+The mapping is strictly **per library**, and identity mappings are recorded
+too. One library exporting `#[julia] fn f` as `rustcall_f` must not decide how
+`f` resolves in another library that exports a plain `#[no_mangle] fn f` under
+its own name; a library with no entry for a name resolves it to the name
+itself. Entries are dropped with the library (`clear_function_symbols!`), so an
+unloaded library cannot leave a stale mapping behind.
+
+Guarded by `REGISTRY_LOCK`.
 """
 const FUNCTION_SYMBOLS_BY_LIB = Dict{Tuple{String, String}, String}()
-
-"""
-Library-agnostic fallback of `FUNCTION_SYMBOLS_BY_LIB`, mirroring the other
-registries so that `@rust` keeps working across `rust\"\"\"` blocks.
-"""
-const FUNCTION_SYMBOLS = Dict{String, String}()
 
 """
     register_function_symbol(lib_name, name, symbol)
 
 Record that the Rust item `name` of `lib_name` is exported as `symbol`.
-A symbol equal to the name is not recorded.
+Identity mappings are recorded as well: a plain `#[no_mangle] extern "C" fn f`
+is explicitly `f => f` for its own library, which is what keeps another
+library's `f => rustcall_f` from leaking into it.
 """
 function register_function_symbol(lib_name::AbstractString, name::AbstractString,
                                   symbol::AbstractString)
-    (isempty(symbol) || symbol == name) && return nothing
+    isempty(symbol) && return nothing
     lock(REGISTRY_LOCK) do
         FUNCTION_SYMBOLS_BY_LIB[(String(lib_name), String(name))] = String(symbol)
-        FUNCTION_SYMBOLS[String(name)] = String(symbol)
     end
     return nothing
 end
@@ -83,15 +87,33 @@ end
 """
     exported_symbol(lib_name, name) -> String
 
-The exported C symbol of the Rust item `name`, or `name` itself when nothing
-was recorded (a plain `#[no_mangle] extern "C"` function, or a symbol that is
-already the exported one).
+The exported C symbol of the Rust item `name` **in `lib_name`**, or `name`
+itself when that library recorded nothing for it (a library loaded outside the
+manifest pipeline, or a `name` that is already the exported symbol). Never
+consults another library's mapping.
 """
 function exported_symbol(lib_name::AbstractString, name::AbstractString)
     lock(REGISTRY_LOCK) do
-        get(FUNCTION_SYMBOLS_BY_LIB, (String(lib_name), String(name)),
-            get(FUNCTION_SYMBOLS, String(name), String(name)))
+        get(FUNCTION_SYMBOLS_BY_LIB, (String(lib_name), String(name)), String(name))
     end
+end
+
+"""
+    clear_function_symbols!(lib_name)
+
+Drop every name-to-symbol mapping of `lib_name`. Called wherever a library
+leaves `RUST_LIBRARIES` or is replaced under the same name (unload, hot
+reload, re-registration of a `rust\"\"\"` block), so a stale mapping can never
+redirect a later lookup to a symbol that is no longer loaded.
+"""
+function clear_function_symbols!(lib_name::AbstractString)
+    name = String(lib_name)
+    lock(REGISTRY_LOCK) do
+        for key in collect(keys(FUNCTION_SYMBOLS_BY_LIB))
+            first(key) == name && delete!(FUNCTION_SYMBOLS_BY_LIB, key)
+        end
+    end
+    return nothing
 end
 
 """

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -391,6 +391,9 @@ end
 function _generate_crate_function_wrapper(func::RustFunctionSignature)
     func_name = Symbol(func.name)
     func_name_str = func.name
+    # The Julia wrapper keeps the Rust name; the exported symbol it calls is
+    # `rustcall_<name>` since #279 (the helper types stay name-derived).
+    symbol_str = func.symbol
 
     # Build argument list
     arg_syms = [Symbol(name) for name in func.arg_names]
@@ -416,7 +419,7 @@ function _generate_crate_function_wrapper(func::RustFunctionSignature)
         ptr_sym = _generated_local("func_ptr", func.arg_names)
         quote
             function $func_name($(arg_syms...))
-                $ptr_sym = _get_func_ptr($func_name_str)
+                $ptr_sym = _get_func_ptr($symbol_str)
                 call_rust_function($ptr_sym, $julia_ret_type, $(converted_args...))
             end
             export $func_name
@@ -435,15 +438,18 @@ Wrapper for a `#[julia]` function with `String` / `&str` arguments or return
 function _generate_string_function_wrapper(func::RustFunctionSignature, arg_syms::Vector{Symbol})
     func_name = Symbol(func.name)
     func_name_str = func.name
+    # The Julia wrapper keeps the Rust name; the exported symbol it calls is
+    # `rustcall_<name>` since #279 (the helper types stay name-derived).
+    symbol_str = func.symbol
     bindings, preserved, call_args = _string_arg_plan(func, identity)
     call = if func.has_owned_string_helper
-        free_name = func_name_str * "_free_rust_string"
-        :(_call_rust_owned_string_ptr(_get_func_ptr($func_name_str), _get_func_ptr($free_name), $(call_args...)))
+        free_name = ffi_free_symbol(func_name_str)
+        :(_call_rust_owned_string_ptr(_get_func_ptr($symbol_str), _get_func_ptr($free_name), $(call_args...)))
     elseif func.has_borrowed_string_helper
-        :(_call_rust_borrowed_string_ptr(_get_func_ptr($func_name_str), $(call_args...)))
+        :(_call_rust_borrowed_string_ptr(_get_func_ptr($symbol_str), $(call_args...)))
     else
         ret = something(_rust_type_to_julia_type_symbol(func.return_type), :Any)
-        :(call_rust_function(_get_func_ptr($func_name_str), $ret, $(call_args...)))
+        :(call_rust_function(_get_func_ptr($symbol_str), $ret, $(call_args...)))
     end
     quote
         function $func_name($(arg_syms...))
@@ -466,6 +472,9 @@ function _generate_result_function_wrapper(func::RustFunctionSignature, arg_syms
                                            bindings::Vector, preserved::Vector, converted_args::Vector)
     func_name = Symbol(func.name)
     func_name_str = func.name
+    # The Julia wrapper keeps the Rust name; the exported symbol it calls is
+    # `rustcall_<name>` since #279 (the helper types stay name-derived).
+    symbol_str = func.symbol
 
     # Get Julia types for ok and err
     ok_julia_type = _rust_type_to_julia_type_symbol(func.ok_type)
@@ -495,7 +504,7 @@ function _generate_result_function_wrapper(func::RustFunctionSignature, arg_syms
             # String arguments are converted first: an argument may be called
             # `func_ptr`, so the pointer local is resolved only afterwards.
             $(bindings...)
-            $ptr_sym = _get_func_ptr($func_name_str)
+            $ptr_sym = _get_func_ptr($symbol_str)
             $c_sym = GC.@preserve $(preserved...) call_rust_function($ptr_sym, $c_result_struct_name, $(converted_args...))
             # Convert to RustResult
             if $c_sym.is_ok == 1
@@ -518,6 +527,9 @@ function _generate_option_function_wrapper(func::RustFunctionSignature, arg_syms
                                            bindings::Vector, preserved::Vector, converted_args::Vector)
     func_name = Symbol(func.name)
     func_name_str = func.name
+    # The Julia wrapper keeps the Rust name; the exported symbol it calls is
+    # `rustcall_<name>` since #279 (the helper types stay name-derived).
+    symbol_str = func.symbol
 
     # Get Julia type for inner type
     inner_julia_type = _rust_type_to_julia_type_symbol(func.inner_type)
@@ -542,7 +554,7 @@ function _generate_option_function_wrapper(func::RustFunctionSignature, arg_syms
             # String arguments are converted first: an argument may be called
             # `func_ptr`, so the pointer local is resolved only afterwards.
             $(bindings...)
-            $ptr_sym = _get_func_ptr($func_name_str)
+            $ptr_sym = _get_func_ptr($symbol_str)
             $c_sym = GC.@preserve $(preserved...) call_rust_function($ptr_sym, $c_option_struct_name, $(converted_args...))
             # Convert to RustOption
             if $c_sym.is_some == 1
@@ -736,7 +748,10 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
     struct_name = Symbol(info.name)
     struct_name_str = info.name
     method_name = Symbol(method.name)
-    wrapper_name = "$(struct_name_str)_$(method.name)"
+    # Exported symbol of the method wrapper (`rustcall_<Struct>_<method>`, #279);
+    # the per-method string buffers stay named after the method itself.
+    wrapper_name = method.symbol
+    helper_owner = "$(struct_name_str)_$(method.name)"
 
     arg_syms = [Symbol(name) for name in method.arg_names]
 
@@ -750,7 +765,7 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
     # Crate method wrappers return strings through per-method buffers:
     # `<Struct>_<method>_RustCallOwnedString`, released with
     # `<Struct>_<method>_free_rust_string` (see rustcall_core::codegen).
-    free_name = wrapper_name * "_free_rust_string"
+    free_name = ffi_free_symbol(helper_owner)
 
     all_args = Any[]
     method.is_static || push!(all_args, :(getfield(self, :ptr)))
@@ -1459,6 +1474,9 @@ Generate Julia code for a function wrapper as a string.
 """
 function _emit_function_code(func::RustFunctionSignature)
     func_name = func.name
+    # The generated Julia function keeps the Rust name; the symbol it looks up
+    # is the additive wrapper `rustcall_<name>` (#279).
+    sym = func.symbol
     arg_names = func.arg_names
 
     # Build argument conversions (string arguments become (ptr, len) pairs)
@@ -1474,13 +1492,13 @@ function _emit_function_code(func::RustFunctionSignature)
     elseif func.has_owned_string_helper
         return """
 function $func_name($arg_syms)
-$(prologue)    GC.@preserve $preserve_str _call_rust_owned_string_ptr(_get_func_ptr("$func_name"), _get_func_ptr("$(func_name)_free_rust_string"), $converted_args_str)
+$(prologue)    GC.@preserve $preserve_str _call_rust_owned_string_ptr(_get_func_ptr("$sym"), _get_func_ptr("$(ffi_free_symbol(func_name))"), $converted_args_str)
 end
 export $func_name"""
     elseif func.has_borrowed_string_helper
         return """
 function $func_name($arg_syms)
-$(prologue)    GC.@preserve $preserve_str _call_rust_borrowed_string_ptr(_get_func_ptr("$func_name"), $converted_args_str)
+$(prologue)    GC.@preserve $preserve_str _call_rust_borrowed_string_ptr(_get_func_ptr("$sym"), $converted_args_str)
 end
 export $func_name"""
     else
@@ -1491,7 +1509,7 @@ export $func_name"""
         ptr_var = _generated_local("func_ptr", func.arg_names)
         return """
 function $func_name($arg_syms)
-$(prologue)    $ptr_var = _get_func_ptr("$func_name")
+$(prologue)    $ptr_var = _get_func_ptr("$sym")
     GC.@preserve $preserve_str call_rust_function($ptr_var, $ret_type_str, $converted_args_str)
 end
 export $func_name"""
@@ -1505,6 +1523,7 @@ function _emit_result_function_code(func::RustFunctionSignature, arg_syms::Strin
     err_julia_type = _rust_type_to_julia_type_symbol(func.err_type)
     ok_type_str = ok_julia_type !== nothing ? string(ok_julia_type) : "Any"
     err_type_str = err_julia_type !== nothing ? string(err_julia_type) : "Any"
+    sym = func.symbol
     c_result_struct_name = "CResult_$func_name"
     ptr_var = _generated_local("func_ptr", func.arg_names)
     c_var = _generated_local("c_result", func.arg_names)
@@ -1517,7 +1536,7 @@ struct $c_result_struct_name
 end
 
 function $func_name($arg_syms)
-$(prologue)    $ptr_var = _get_func_ptr("$func_name")
+$(prologue)    $ptr_var = _get_func_ptr("$sym")
     $c_var = GC.@preserve $preserve_str call_rust_function($ptr_var, $c_result_struct_name, $converted_args_str)
     if $c_var.is_ok == 1
         RustResult{$ok_type_str, $err_type_str}(true, $c_var.ok_value)
@@ -1533,6 +1552,7 @@ function _emit_option_function_code(func::RustFunctionSignature, arg_syms::Strin
     func_name = func.name
     inner_julia_type = _rust_type_to_julia_type_symbol(func.inner_type)
     inner_type_str = inner_julia_type !== nothing ? string(inner_julia_type) : "Any"
+    sym = func.symbol
     c_option_struct_name = "COption_$func_name"
     ptr_var = _generated_local("func_ptr", func.arg_names)
     c_var = _generated_local("c_option", func.arg_names)
@@ -1544,7 +1564,7 @@ struct $c_option_struct_name
 end
 
 function $func_name($arg_syms)
-$(prologue)    $ptr_var = _get_func_ptr("$func_name")
+$(prologue)    $ptr_var = _get_func_ptr("$sym")
     $c_var = GC.@preserve $preserve_str call_rust_function($ptr_var, $c_option_struct_name, $converted_args_str)
     if $c_var.is_some == 1
         RustOption{$inner_type_str}(true, $c_var.value)
@@ -1663,7 +1683,10 @@ Generate Julia code for a method wrapper as a string.
 function _emit_method_code(struct_info::RustStructInfo, method::RustMethod)
     struct_name = struct_info.name
     method_name = method.name
-    wrapper_name = "$(struct_name)_$(method_name)"
+    # Exported symbol (`rustcall_<Struct>_<method>`, #279); the per-method
+    # string buffers stay named after the method itself.
+    wrapper_name = method.symbol
+    helper_owner = "$(struct_name)_$(method_name)"
 
     arg_syms = join(method.arg_names, ", ")
 
@@ -1676,7 +1699,7 @@ function _emit_method_code(struct_info::RustStructInfo, method::RustMethod)
     # object, which the finalizer of a temporary could free mid-call.
     method.is_static || (preserve_str = strip("self " * preserve_str))
     ptr_var = _generated_local("func_ptr", method.arg_names)
-    free_name = wrapper_name * "_free_rust_string"
+    free_name = ffi_free_symbol(helper_owner)
 
     all_args = String[]
     method.is_static || push!(all_args, "getfield(self, :ptr)")

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -262,10 +262,13 @@ function monomorphize_function(func_name::String, type_params::Dict{Symbol, <:Ty
             end
         end
 
-        func_ptr = Libdl.dlsym(lib_handle, specialized_name; throw_error=false)
+        # The exported symbol is the additive wrapper the extractor emitted
+        # next to the instantiation, never the instantiation's own name (#279).
+        specialized_symbol = specialized.symbol
+        func_ptr = Libdl.dlsym(lib_handle, specialized_symbol; throw_error=false)
         if func_ptr === nothing || func_ptr == C_NULL
             error("""
-            Function '$specialized_name' not found in library '$lib_path'.
+            Function '$(specialized_symbol)' not found in library '$lib_path'.
 
             Specialized code was:
             $specialized_code
@@ -274,7 +277,7 @@ function monomorphize_function(func_name::String, type_params::Dict{Symbol, <:Ty
 
         lock(REGISTRY_LOCK) do
             _, func_cache = RUST_LIBRARIES[lib_name]
-            func_cache[specialized_name] = func_ptr
+            func_cache[specialized_symbol] = func_ptr
         end
 
         # Return and argument types come from the manifest of the specialized
@@ -291,7 +294,8 @@ function monomorphize_function(func_name::String, type_params::Dict{Symbol, <:Ty
         if specialized.has_owned_string_helper
             string_return = :owned
             ret_type = String
-            free_name = specialized_name * "_free_rust_string"
+            # The string helpers keep the instantiation's own name (#279).
+            free_name = ffi_free_symbol(specialized.name)
             free_ptr = Libdl.dlsym(lib_handle, free_name; throw_error=false)
             if free_ptr === nothing || free_ptr == C_NULL
                 error("Function '$free_name' not found in library '$lib_path'")
@@ -302,7 +306,7 @@ function monomorphize_function(func_name::String, type_params::Dict{Symbol, <:Ty
         end
 
         # Create FunctionInfo
-        info = FunctionInfo(specialized_name, lib_name, ret_type, arg_types, func_ptr,
+        info = FunctionInfo(specialized_symbol, lib_name, ret_type, arg_types, func_ptr,
                             specialized.arg_abis, string_return, free_ptr)
 
         # Cache the monomorphized function

--- a/src/hot_reload.jl
+++ b/src/hot_reload.jl
@@ -175,6 +175,9 @@ function _reload_library_locked(state::HotReloadState)
             if haskey(RUST_LIBRARIES, state.lib_name)
                 lib_handle, _ = RUST_LIBRARIES[state.lib_name]
                 delete!(RUST_LIBRARIES, state.lib_name)
+                # The rebuilt library re-registers its own mappings; a stale
+                # entry would redirect a lookup to the unloaded handle (#279).
+                clear_function_symbols!(state.lib_name)
                 if CURRENT_LIB[] == state.lib_name
                     CURRENT_LIB[] = ""
                 end

--- a/src/julia_functions.jl
+++ b/src/julia_functions.jl
@@ -224,8 +224,10 @@ Generate a Julia wrapper function for a single Rust function signature.
 Uses direct function call instead of @rust macro for better scope handling.
 """
 function _generate_single_wrapper(sig::RustFunctionSignature)
-    func_name_str = sig.name
-    func_name = esc(Symbol(func_name_str))
+    # The Julia wrapper keeps the Rust *name* (`add(1, 2)`); the call goes to
+    # the exported *symbol*, which since #279 is `rustcall_add`.
+    func_name = esc(Symbol(sig.name))
+    symbol_str = sig.symbol
 
     # Build argument list with conversion (string arguments become (ptr, len)
     # pairs kept alive with GC.@preserve, see `_string_arg_plan`)
@@ -233,11 +235,11 @@ function _generate_single_wrapper(sig::RustFunctionSignature)
     bindings, preserved, converted_args = _string_arg_plan(sig, esc)
 
     if sig.return_kind == :result
-        return _generate_inline_result_wrapper(sig, func_name, func_name_str, arg_syms, bindings, preserved, converted_args)
+        return _generate_inline_result_wrapper(sig, func_name, symbol_str, arg_syms, bindings, preserved, converted_args)
     elseif sig.return_kind == :option
-        return _generate_inline_option_wrapper(sig, func_name, func_name_str, arg_syms, bindings, preserved, converted_args)
+        return _generate_inline_option_wrapper(sig, func_name, symbol_str, arg_syms, bindings, preserved, converted_args)
     elseif _uses_string_ffi(sig)
-        return _generate_inline_string_wrapper(sig, func_name, func_name_str, arg_syms)
+        return _generate_inline_string_wrapper(sig, func_name, symbol_str, arg_syms)
     end
 
     # Get Julia return type
@@ -253,7 +255,7 @@ function _generate_single_wrapper(sig::RustFunctionSignature)
     return quote
         function $func_name($(arg_syms...))
             $lib_sym = RustCall.get_current_library()
-            $ptr_sym = RustCall.get_function_pointer($lib_sym, $func_name_str)
+            $ptr_sym = RustCall.get_function_pointer($lib_sym, $symbol_str)
             RustCall.call_rust_function($ptr_sym, $julia_ret_type, $(converted_args...))
         end
     end
@@ -263,17 +265,18 @@ end
 # byte pairs kept alive with GC.@preserve; a `String` return is an owned
 # `<fn>_RustCallOwnedString` released through `<fn>_free_rust_string`, a `&str`
 # return a borrowed `<fn>_RustCallBorrowedString`.
-function _generate_inline_string_wrapper(sig, func_name, func_name_str, arg_syms)
+function _generate_inline_string_wrapper(sig, func_name, symbol_str, arg_syms)
     bindings, preserved, call_args = _string_arg_plan(sig, esc)
     lib_sym = _generated_local("lib_name", sig.arg_names)
     call = if sig.has_owned_string_helper
-        free_name = func_name_str * "_free_rust_string"
-        :(RustCall._call_rust_owned_string($lib_sym, $func_name_str, $free_name, $(call_args...)))
+        # The string helpers are named after the Rust item, not the symbol.
+        free_name = ffi_free_symbol(sig.name)
+        :(RustCall._call_rust_owned_string($lib_sym, $symbol_str, $free_name, $(call_args...)))
     elseif sig.has_borrowed_string_helper
-        :(RustCall._call_rust_borrowed_string($lib_sym, $func_name_str, $(call_args...)))
+        :(RustCall._call_rust_borrowed_string($lib_sym, $symbol_str, $(call_args...)))
     else
         ret = something(_rust_type_to_julia_type_symbol(sig.return_type), :Any)
-        :(RustCall.call_rust_function(RustCall.get_function_pointer($lib_sym, $func_name_str), $ret, $(call_args...)))
+        :(RustCall.call_rust_function(RustCall.get_function_pointer($lib_sym, $symbol_str), $ret, $(call_args...)))
     end
     quote
         function $func_name($(arg_syms...))
@@ -289,7 +292,7 @@ end
 # Result<T, E> / Option<T> returning #[julia] functions in inline blocks: the
 # extractor generates `CResult_<fn>` / `COption_<fn>` on the Rust side; the
 # wrapper reads that struct and converts it to RustResult / RustOption.
-function _generate_inline_result_wrapper(sig, func_name, func_name_str, arg_syms, bindings, preserved, converted_args)
+function _generate_inline_result_wrapper(sig, func_name, symbol_str, arg_syms, bindings, preserved, converted_args)
     ok_t = something(_rust_type_to_julia_type_symbol(sig.ok_type), :Any)
     err_t = something(_rust_type_to_julia_type_symbol(sig.err_type), :Any)
     lib_sym = _generated_local("lib_name", sig.arg_names)
@@ -299,14 +302,14 @@ function _generate_inline_result_wrapper(sig, func_name, func_name_str, arg_syms
         function $func_name($(arg_syms...))
             $(bindings...)
             $lib_sym = RustCall.get_current_library()
-            $ptr_sym = RustCall.get_function_pointer($lib_sym, $func_name_str)
+            $ptr_sym = RustCall.get_function_pointer($lib_sym, $symbol_str)
             $c_sym = GC.@preserve $(preserved...) RustCall.call_rust_function($ptr_sym, RustCall.CResultType{$ok_t, $err_t}, $(converted_args...))
             RustCall.convert_c_result_to_rust_result($c_sym, $ok_t, $err_t)
         end
     end
 end
 
-function _generate_inline_option_wrapper(sig, func_name, func_name_str, arg_syms, bindings, preserved, converted_args)
+function _generate_inline_option_wrapper(sig, func_name, symbol_str, arg_syms, bindings, preserved, converted_args)
     inner_t = something(_rust_type_to_julia_type_symbol(sig.inner_type), :Any)
     lib_sym = _generated_local("lib_name", sig.arg_names)
     ptr_sym = _generated_local("func_ptr", sig.arg_names)
@@ -315,7 +318,7 @@ function _generate_inline_option_wrapper(sig, func_name, func_name_str, arg_syms
         function $func_name($(arg_syms...))
             $(bindings...)
             $lib_sym = RustCall.get_current_library()
-            $ptr_sym = RustCall.get_function_pointer($lib_sym, $func_name_str)
+            $ptr_sym = RustCall.get_function_pointer($lib_sym, $symbol_str)
             $c_sym = GC.@preserve $(preserved...) RustCall.call_rust_function($ptr_sym, RustCall.COptionType{$inner_t}, $(converted_args...))
             RustCall.convert_c_option_to_rust_option($c_sym, $inner_t)
         end

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -757,10 +757,15 @@ end
 """
     unregister_library!(policy::LoadPolicy, lib_name::AbstractString) -> Bool
 
-Remove the `RUST_LIBRARIES` entry and its function-pointer cache under
+Remove the `RUST_LIBRARIES` entry, its function-pointer cache and the
+library's name-to-symbol mappings (`clear_function_symbols!`, #279) under
 `REGISTRY_LOCK`, clearing `CURRENT_LIB[]` if it pointed at `lib_name`.
 Returns whether an entry was removed.  Does not `dlclose`: Phase B decides that
 together with the unload purge described in #250.
+
+Not called from `src/` yet, so the live unload paths purge the symbol mappings
+themselves (`unload_library` in `src/ruststr.jl`, `_reload_library_locked` in
+`src/hot_reload.jl`); Phase B (#277) folds them into this one hook.
 """
 function unregister_library!(policy::LoadPolicy, lib_name::AbstractString)
     name = String(lib_name)
@@ -770,6 +775,7 @@ function unregister_library!(policy::LoadPolicy, lib_name::AbstractString)
         if removed
             delete!(RUST_LIBRARIES, name)
         end
+        clear_function_symbols!(name)
         if CURRENT_LIB[] == name
             CURRENT_LIB[] = ""
         end

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -13,9 +13,10 @@ using SHA: sha256
 """
 Manifest schema version this version of RustCall.jl understands. Must match
 `rustcall_core::manifest::SCHEMA_VERSION` (2: string ABI columns `abi`,
-`return_abi` and the string helper flags, #242).
+`return_abi` and the string helper flags, #242; 3: `#[julia]` is additive, so
+`symbol` differs from `name` for every wrapped function and method, #279).
 """
-const MANIFEST_SCHEMA_VERSION = 2
+const MANIFEST_SCHEMA_VERSION = 3
 
 """
     ExtractorError <: Exception
@@ -548,6 +549,7 @@ Result of instantiating a generic function via `rustcall-extract specialize`.
 struct SpecializedFunction
     source::String
     name::String
+    symbol::String                    # exported C symbol, `rustcall_<name>` (#279)
     arg_types::Vector{String}
     return_type::String
     arg_abis::Vector{String}          # manifest `abi` per argument ("string", "str" or "")
@@ -581,6 +583,7 @@ function specialize_generic(source::String, fn_name::String,
         SpecializedFunction(
             out,
             String(fn["name"]),
+            _mstr(fn, "symbol"),
             String[String(a["rust_type"]) for a in args],
             String(fn["return_type"]),
             String[_mstr(a, "abi") for a in args],

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -291,18 +291,22 @@ function _rust_call_dynamic(lib_name::String, func_name::String, args...)
     end
 
     # Regular function - use existing logic
+    # `@rust f(...)` names the Rust function; `#[julia]` exports the additive
+    # wrapper next to it (#279), and every registry is keyed by that symbol.
+    symbol = exported_symbol(lib_name, func_name)
+
     # Get function pointer
-    @debug "Calling function '$func_name' from library '$lib_name'"
-    func_ptr = get_function_pointer(lib_name, func_name)
+    @debug "Calling function '$func_name' (symbol '$symbol') from library '$lib_name'"
+    func_ptr = get_function_pointer(lib_name, symbol)
 
     # Try to get type info from registered function info
-    func_info = get_function_info(lib_name, func_name)
+    func_info = get_function_info(lib_name, symbol)
     if func_info !== nothing && func_info.return_type !== Any
         return call_rust_function(func_ptr, func_info.return_type, args...)
     end
 
     # Try to get return type from registries (library-scoped first, then fallback)
-    ret_type = get_function_return_type(lib_name, func_name)
+    ret_type = get_function_return_type(lib_name, symbol)
     if ret_type !== nothing
         @debug "Using registered return type for $func_name: $ret_type"
         return call_rust_function(func_ptr, ret_type, args...)

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -292,21 +292,21 @@ function _rust_call_dynamic(lib_name::String, func_name::String, args...)
 
     # Regular function - use existing logic
     # `@rust f(...)` names the Rust function; `#[julia]` exports the additive
-    # wrapper next to it (#279), and every registry is keyed by that symbol.
-    symbol = exported_symbol(lib_name, func_name)
-
+    # wrapper `rustcall_f` next to it (#279). `get_function_pointer` resolves
+    # that per library, and the return-type registry is keyed by both the name
+    # and the symbol, so the source-level name is what we pass around here.
     # Get function pointer
-    @debug "Calling function '$func_name' (symbol '$symbol') from library '$lib_name'"
-    func_ptr = get_function_pointer(lib_name, symbol)
+    @debug "Calling function '$func_name' from library '$lib_name'"
+    func_ptr = get_function_pointer(lib_name, func_name)
 
     # Try to get type info from registered function info
-    func_info = get_function_info(lib_name, symbol)
+    func_info = get_function_info(lib_name, func_name)
     if func_info !== nothing && func_info.return_type !== Any
         return call_rust_function(func_ptr, func_info.return_type, args...)
     end
 
     # Try to get return type from registries (library-scoped first, then fallback)
-    ret_type = get_function_return_type(lib_name, symbol)
+    ret_type = get_function_return_type(lib_name, func_name)
     if ret_type !== nothing
         @debug "Using registered return type for $func_name: $ret_type"
         return call_rust_function(func_ptr, ret_type, args...)

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -60,26 +60,29 @@ loaded libraries as a fallback. This enables using functions from multiple
 `rust\"\"\"` blocks.
 """
 function get_function_pointer(lib_name::String, func_name::String)
-    # `#[julia]` is additive (#279): a Rust item named `add` is exported as
-    # `rustcall_add`. Resolve the manifest-recorded symbol first; an unmapped
-    # name (a plain `#[no_mangle]` function, or an already-resolved symbol) is
-    # looked up as given.
-    func_name = exported_symbol(lib_name, func_name)
     lock(REGISTRY_LOCK) do
+        # `#[julia]` is additive (#279): a Rust item named `add` may be exported
+        # as `rustcall_add`. The name-to-symbol mapping is per library, so it is
+        # resolved separately for every library searched below — one library's
+        # `#[julia] fn f` must never redirect the lookup of another library's
+        # plain `#[no_mangle] fn f`. A library with no entry for the name looks
+        # it up as given.
+
         # First, try the specified library
         if haskey(RUST_LIBRARIES, lib_name)
+            symbol = exported_symbol(lib_name, func_name)
             lib_handle, func_cache = RUST_LIBRARIES[lib_name]
 
             # Check cache first
-            if haskey(func_cache, func_name)
-                return func_cache[func_name]
+            if haskey(func_cache, symbol)
+                return func_cache[symbol]
             end
 
             # Look up the function
-            func_ptr = Libdl.dlsym(lib_handle, func_name; throw_error=false)
+            func_ptr = Libdl.dlsym(lib_handle, symbol; throw_error=false)
             if func_ptr !== nothing && func_ptr != C_NULL
                 # Cache it
-                func_cache[func_name] = func_ptr
+                func_cache[symbol] = func_ptr
                 return func_ptr
             end
         end
@@ -92,19 +95,20 @@ function get_function_pointer(lib_name::String, func_name::String)
             if other_lib_name == lib_name
                 continue  # Already checked
             end
+            symbol = exported_symbol(other_lib_name, func_name)
 
             # Check cache first
-            if haskey(other_func_cache, func_name)
+            if haskey(other_func_cache, symbol)
                 push!(found_libs, other_lib_name)
-                found_ptr = other_func_cache[func_name]
+                found_ptr = other_func_cache[symbol]
                 continue
             end
 
             # Look up the function
-            func_ptr = Libdl.dlsym(other_lib_handle, func_name; throw_error=false)
+            func_ptr = Libdl.dlsym(other_lib_handle, symbol; throw_error=false)
             if func_ptr !== nothing && func_ptr != C_NULL
                 # Cache it
-                other_func_cache[func_name] = func_ptr
+                other_func_cache[symbol] = func_ptr
                 push!(found_libs, other_lib_name)
                 found_ptr = func_ptr
             end
@@ -622,6 +626,10 @@ Register everything the manifest of a compiled block tells us:
 """
 function _register_manifest(expanded, lib_name::String; compiler = nothing, cargo_backed::Bool = false)
     manifest = expanded.manifest
+    # This library's name-to-symbol mappings are rebuilt from scratch: a block
+    # re-registered under the same library name must not keep the entries of
+    # functions it no longer defines (#279).
+    clear_function_symbols!(lib_name)
     for info in manifest_struct_infos(manifest)
         register_generic_struct_wrappers(info, expanded.source; compiler)
     end
@@ -650,7 +658,9 @@ function _register_manifest(expanded, lib_name::String; compiler = nothing, carg
         elseif sig.exported
             # `@rust f(...)` names the Rust function; the library exports the
             # additive wrapper (#279), so record the mapping before anything
-            # tries to resolve it.
+            # tries to resolve it. Identity mappings are recorded too, so a
+            # plain `#[no_mangle] fn f` here is explicitly `f => f` for this
+            # library and cannot pick up another library's `f => rustcall_f`.
             register_function_symbol(lib_name, sig.name, sig.symbol)
             _register_return_type(sig, lib_name)
         end
@@ -679,9 +689,15 @@ function _register_return_type(sig, lib_name::String)
         nothing
     end
     ret_type === nothing && return nothing
-    FUNCTION_RETURN_TYPES_BY_LIB[(lib_name, sig.symbol)] = ret_type
-    FUNCTION_RETURN_TYPES[sig.symbol] = ret_type
-    @debug "Registered return type for function: $(sig.symbol) => $ret_type (library: $lib_name)"
+    # Recorded under both the Rust name and the exported symbol: `@rust f(...)`
+    # names the function, while a caller that already resolved the symbol (or a
+    # generated wrapper) asks for `rustcall_f`. Unlike the symbol mapping, this
+    # is only a type hint, so the pre-#279 unscoped name key stays.
+    for key in unique((sig.name, sig.symbol))
+        FUNCTION_RETURN_TYPES_BY_LIB[(lib_name, key)] = ret_type
+        FUNCTION_RETURN_TYPES[key] = ret_type
+    end
+    @debug "Registered return type for function: $(sig.name) (symbol $(sig.symbol)) => $ret_type (library: $lib_name)"
     return nothing
 end
 
@@ -754,6 +770,9 @@ function unload_library(lib_name::String)
         end
         lib_handle, _ = RUST_LIBRARIES[lib_name]
         delete!(RUST_LIBRARIES, lib_name)
+        # A stale name-to-symbol mapping would keep redirecting lookups to a
+        # symbol that is no longer loaded (#279).
+        clear_function_symbols!(lib_name)
         if CURRENT_LIB[] == lib_name
             CURRENT_LIB[] = ""
         end

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -60,6 +60,11 @@ loaded libraries as a fallback. This enables using functions from multiple
 `rust\"\"\"` blocks.
 """
 function get_function_pointer(lib_name::String, func_name::String)
+    # `#[julia]` is additive (#279): a Rust item named `add` is exported as
+    # `rustcall_add`. Resolve the manifest-recorded symbol first; an unmapped
+    # name (a plain `#[no_mangle]` function, or an already-resolved symbol) is
+    # looked up as given.
+    func_name = exported_symbol(lib_name, func_name)
     lock(REGISTRY_LOCK) do
         # First, try the specified library
         if haskey(RUST_LIBRARIES, lib_name)
@@ -643,6 +648,10 @@ function _register_manifest(expanded, lib_name::String; compiler = nothing, carg
                                       path = qualified_name(sig.module_path, sig.name), compiler, blocked)
             @debug "Registered generic function: $(sig.name)" type_params = sig.type_params
         elseif sig.exported
+            # `@rust f(...)` names the Rust function; the library exports the
+            # additive wrapper (#279), so record the mapping before anything
+            # tries to resolve it.
+            register_function_symbol(lib_name, sig.name, sig.symbol)
             _register_return_type(sig, lib_name)
         end
     end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -317,7 +317,8 @@ function emit_julia_definitions(info::RustStructInfo)
     # 2. Add constructors and methods
     for m in info.methods
         fname = esc(Symbol(m.name))
-        wrapper_name = struct_name_str * "_" * m.name
+        # Exported symbol of the method wrapper, `rustcall_<Struct>_<method>` (#279).
+        wrapper_name = m.symbol
 
         is_ctor = m.is_constructor
 

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -142,7 +142,7 @@ const SAMPLE_CRATE_PYO3_PATH = joinpath(dirname(@__DIR__), "examples", "sample_c
             @test s.field_setters["count"] == "Counter_set_count"
             @test [m.name for m in s.methods] == ["new", "increment"]
             @test s.methods[1].is_constructor
-            @test s.methods[1].symbol == "Counter_new"
+            @test s.methods[1].symbol == "rustcall_Counter_new"
             @test s.methods[2].is_mutable
         end
     end
@@ -713,10 +713,10 @@ end
     # The source-file emitter (write_bindings_to_file) uses the same ABI.
     info = RustCall.scan_crate(SAMPLE_CRATE_PATH)
     code = RustCall.emit_crate_module_code(info, "/tmp/libsample.so")
-    @test occursin("_call_rust_owned_string_ptr(_get_func_ptr(\"shout\"), _get_func_ptr(\"shout_free_rust_string\")", code)
+    @test occursin("_call_rust_owned_string_ptr(_get_func_ptr(\"rustcall_shout\"), _get_func_ptr(\"shout_free_rust_string\")", code)
     @test occursin("__rustcall_str_input = String(input)", code)
     @test occursin("GC.@preserve __rustcall_str_input", code)
-    @test occursin("_call_rust_borrowed_string_ptr(_get_func_ptr(\"crate_greeting\")", code)
+    @test occursin("_call_rust_borrowed_string_ptr(_get_func_ptr(\"rustcall_crate_greeting\")", code)
     @test occursin("GC.@preserve __rustcall_str_s call_rust_function(func_ptr, CResult_parse_int, pointer(__rustcall_str_s), sizeof(__rustcall_str_s) % Csize_t)", code)
     @test occursin("GC.@preserve  call_rust_function(func_ptr, Int32, Int32(a), Int32(b))", code)
     # and the emitted module parses
@@ -732,28 +732,28 @@ end
     # Plain return, string arguments named func_ptr / lib_name
     @test occursin("__rustcall_str_func_ptr = String(func_ptr)", code)
     @test occursin("__rustcall_str_lib_name = String(lib_name)", code)
-    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"shadow_str_len\")", code)
+    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"rustcall_shadow_str_len\")", code)
     @test occursin("call_rust_function(__rustcall_func_ptr, Csize_t, pointer(__rustcall_str_func_ptr)", code)
     # The conversions come before the pointer lookup
     @test findfirst("__rustcall_str_func_ptr = String(func_ptr)", code).start <
-          findfirst("__rustcall_func_ptr = _get_func_ptr(\"shadow_str_len\")", code).start
+          findfirst("__rustcall_func_ptr = _get_func_ptr(\"rustcall_shadow_str_len\")", code).start
 
     # Result return: func_ptr and c_result are both argument names
-    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"shadow_parse_int\")", code)
+    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"rustcall_shadow_parse_int\")", code)
     @test occursin("__rustcall_c_result = GC.@preserve __rustcall_str_func_ptr call_rust_function(__rustcall_func_ptr, CResult_shadow_parse_int,", code)
     @test occursin("if __rustcall_c_result.is_ok == 1", code)
 
     # Option return: func_ptr and c_option are both argument names
-    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"shadow_first_char\")", code)
+    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"rustcall_shadow_first_char\")", code)
     @test occursin("__rustcall_c_option = GC.@preserve __rustcall_str_func_ptr call_rust_function(__rustcall_func_ptr, COption_shadow_first_char,", code)
     @test occursin("if __rustcall_c_option.is_some == 1", code)
 
     # No strings, but still a colliding argument name
-    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"shadow_double\")", code)
+    @test occursin("__rustcall_func_ptr = _get_func_ptr(\"rustcall_shadow_double\")", code)
     @test occursin("call_rust_function(__rustcall_func_ptr, Int32, Int32(func_ptr))", code)
 
     # Names that do not collide keep their readable form
-    @test occursin("func_ptr = _get_func_ptr(\"parse_int\")", code)
+    @test occursin("func_ptr = _get_func_ptr(\"rustcall_parse_int\")", code)
 
     @test Meta.parse(code) isa Expr
 

--- a/test/test_generics.jl
+++ b/test/test_generics.jl
@@ -178,7 +178,8 @@ end
         @test specialized.name == "pair_i32_f64"
         @test specialized.arg_types == ["i32", "f64"]
         @test specialized.return_type == "i32"
-        @test occursin("pub extern \"C\" fn pair_i32_f64", specialized.source)
+        @test specialized.symbol == "rustcall_pair_i32_f64"
+        @test occursin("pub extern \"C\" fn rustcall_pair_i32_f64", specialized.source)
         # the generic original is kept so that other callers in the block still compile
         @test occursin("fn pair<T", specialized.source)
     end
@@ -234,7 +235,7 @@ end
         )
 
         mono = RustCall.monomorphize_function("test_identity", Dict(:T => Int32))
-        @test mono.name == "test_identity_i32"
+        @test mono.name == "rustcall_test_identity_i32"
         @test mono.return_type == Int32
         @test mono.arg_types == [Int32]
         @test mono.func_ptr != C_NULL
@@ -287,7 +288,9 @@ end
     @test specialized.has_owned_string_helper
     @test !specialized.has_borrowed_string_helper
     @test occursin("tag_i32_free_rust_string", specialized.source)
-    @test occursin("tag_i32_inner", specialized.source)
+    # The instantiation keeps its own plain signature next to the wrapper (#279).
+    @test occursin("pub fn tag_i32(x: i32, label: String) -> String", specialized.source)
+    @test occursin("pub extern \"C\" fn rustcall_tag_i32", specialized.source)
     borrowed = RustCall.specialize_generic("pub fn kind_of<T>(_x: T) -> &'static str { \"generic\" }",
                                            "kind_of", ["T" => "i64"], "kind_of_i64")
     @test borrowed.has_borrowed_string_helper && !borrowed.has_owned_string_helper

--- a/test/test_julia_attribute.jl
+++ b/test/test_julia_attribute.jl
@@ -1,6 +1,7 @@
 # Test cases for #[julia] attribute support (Phase 5)
 using RustCall
 using Test
+using Libdl
 
 @testset "Julia Attribute Support" begin
 
@@ -21,7 +22,7 @@ using Test
         sigs = RustCall.manifest_function_signatures(RustCall.extract_manifest(code1; mode = "inline"))
         @test length(sigs) == 1
         @test sigs[1].name == "add"
-        @test sigs[1].symbol == "add"
+        @test sigs[1].symbol == "rustcall_add"
         @test sigs[1].arg_names == ["a", "b"]
         @test sigs[1].arg_types == ["i32", "i32"]
         @test sigs[1].return_type == "i32"
@@ -128,16 +129,19 @@ using Test
         code1 = "#[julia]\nfn add(a: i32, b: i32) -> i32 { a + b }"
         result1 = RustCall.expand_inline(code1).source
         @test occursin("#[no_mangle]", result1)
-        @test occursin("pub extern \"C\" fn add", result1)
+        # #[julia] is additive (#279): the item stays, the wrapper is added.
+        @test occursin("fn add(a: i32, b: i32) -> i32", result1)
+        @test occursin("pub extern \"C\" fn rustcall_add", result1)
         @test !occursin("#[julia]", result1)
 
         code2 = "#[julia]\npub fn multiply(x: f64) -> f64 { x * 2.0 }"
         result2 = RustCall.expand_inline(code2).source
         @test occursin("#[no_mangle]", result2)
-        @test occursin("pub extern \"C\" fn multiply", result2)
+        @test occursin("pub fn multiply(x: f64) -> f64", result2)
+        @test occursin("pub extern \"C\" fn rustcall_multiply", result2)
 
         code3 = "#[julia] fn inline_fn(a: i32) -> i32 { a }"
-        @test occursin("pub extern \"C\" fn inline_fn", RustCall.expand_inline(code3).source)
+        @test occursin("pub extern \"C\" fn rustcall_inline_fn", RustCall.expand_inline(code3).source)
 
         code4 = """
         #[julia]
@@ -147,24 +151,25 @@ using Test
         pub extern "C" fn already_ffi(b: i32) -> i32 { b }
         """
         result4 = RustCall.expand_inline(code4).source
-        @test occursin("pub extern \"C\" fn with_julia", result4)
+        @test occursin("pub extern \"C\" fn rustcall_with_julia", result4)
         @test occursin("pub extern \"C\" fn already_ffi", result4)  # unchanged
 
         # Result-returning #[julia] functions get a C-compatible wrapper struct
         code5 = "#[julia]\nfn d(a: f64) -> Result<f64, i32> { Ok(a) }"
         result5 = RustCall.expand_inline(code5).source
         @test occursin("CResult_d", result5)
-        @test occursin("pub extern \"C\" fn d(a: f64) -> CResult_d", result5)
+        @test occursin("pub extern \"C\" fn rustcall_d(a: f64) -> CResult_d", result5)
 
         # Expansion is memoized per source text
         @test RustCall.expand_inline(code1) === RustCall.expand_inline(code1)
     end
 
     @testset "manifest: schema version guard" begin
-        @test RustCall.MANIFEST_SCHEMA_VERSION == 2
-        @test RustCall._parse_manifest("schema_version = 2\nmode = \"inline\"\n")["schema_version"] == 2
+        @test RustCall.MANIFEST_SCHEMA_VERSION == 3
+        @test RustCall._parse_manifest("schema_version = 3\nmode = \"inline\"\n")["schema_version"] == 3
         # Schema 1 predates the string ABI columns (`abi`, `return_abi`, the
-        # helper flags); a consumer must not fall back to the one-word ABI.
+        # helper flags) and schema 2 predates the additive `symbol` semantics
+        # (#279); a consumer must not fall back to either.
         err = try
             RustCall._parse_manifest("schema_version = 1\nmode = \"inline\"\n")
             nothing
@@ -173,7 +178,8 @@ using Test
         end
         @test err isa RustCall.ExtractorError
         @test occursin("schema 1", sprint(showerror, err))
-        @test occursin("expects 2", sprint(showerror, err))
+        @test occursin("expects 3", sprint(showerror, err))
+        @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 2\nmode = \"inline\"\n")
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 999\nmode = \"inline\"\n")
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("mode = \"inline\"\n")
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("not = [valid toml")
@@ -601,4 +607,38 @@ end
     @test !py["py_len"].has_owned_string_helper
     @test !RustCall._uses_string_ffi(py["py_len"])
     @test py["py_plain"].arg_abis == [""]
+
+    # #279: `#[julia]` is additive. The compiled block exports the wrapper
+    # `rustcall_<fn>`; the Rust name is *not* a C symbol any more, while the
+    # generated Julia function still goes by that name.
+    @testset "additive #[julia]: exported symbol is rustcall_<fn> (#279)" begin
+        code = """
+        #[julia]
+        pub fn additive_probe(x: i32) -> i32 { x + 1 }
+        """
+        expanded = RustCall.expand_inline(code)
+        sig = only(RustCall.manifest_function_signatures(expanded.manifest))
+        @test sig.name == "additive_probe"
+        @test sig.symbol == "rustcall_additive_probe"
+        # The annotated item survives verbatim next to the wrapper.
+        @test occursin("pub fn additive_probe(x: i32) -> i32", expanded.source)
+
+        lib_path = RustCall.compile_rust_to_shared_lib(expanded.source)
+        handle = Libdl.dlopen(lib_path, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+        try
+            @test Libdl.dlsym(handle, "rustcall_additive_probe"; throw_error = false) !== nothing
+            @test Libdl.dlsym(handle, "additive_probe"; throw_error = false) === nothing
+        finally
+            Libdl.dlclose(handle)
+        end
+
+        # End to end: the Julia wrapper keeps the Rust name and calls the
+        # prefixed symbol.
+        rust"""
+        #[julia]
+        pub fn additive_roundtrip(x: i32) -> i32 { x * 3 }
+        """
+        @test additive_roundtrip(Int32(4)) == 4 * 3
+        @test (@rust additive_roundtrip(Int32(5))::Int32) == 15
+    end
 end

--- a/test/test_parsing_generics_hotreload_fixes.jl
+++ b/test/test_parsing_generics_hotreload_fixes.jl
@@ -75,7 +75,7 @@ using RustCall
         infos = RustCall.manifest_struct_infos(RustCall.extract_manifest(code_no_where; mode = "inline"))
         @test infos[1].name == "Plain"
         @test isempty(infos[1].type_params)
-        @test infos[1].methods[1].symbol == "Plain_new"
+        @test infos[1].methods[1].symbol == "rustcall_Plain_new"
         @test infos[1].methods[1].is_constructor
     end
 

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -141,7 +141,7 @@ signature_for(code, name; mode = "inline") = only(
         @test sig.name == "nested_comments"
         @test sig.arg_types == ["i32"]
         @test sig.return_type == "i32"
-        @test occursin("pub extern \"C\" fn nested_comments", expanded.source)
+        @test occursin("pub extern \"C\" fn rustcall_nested_comments", expanded.source)
     end
 
     @testset "derive(JuliaStruct) multiline/order metadata" begin
@@ -220,7 +220,7 @@ signature_for(code, name; mode = "inline") = only(
         )
         @test specialized.arg_types == ["i32"]
         @test specialized.return_type == "i32"
-        @test occursin("pub extern \"C\" fn identity_i32", specialized.source)
+        @test occursin("pub extern \"C\" fn rustcall_identity_i32", specialized.source)
     end
 
     @testset "Const expressions containing comparison operators (#233)" begin

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -2,6 +2,7 @@
 
 using RustCall
 using Test
+using Libdl
 
 all_signatures(code; mode = "inline") = RustCall.manifest_function_signatures(
     RustCall.extract_manifest(code; mode = mode); only_attributed = false
@@ -510,5 +511,75 @@ end
         @test length(checksum) == 64
         @test checksum == RustCall._compute_file_checksum(tmp)
         rm(tmp)
+    end
+end
+
+# Since #279 a Rust item and the C symbol that exposes it can differ, and the
+# mapping between them is recorded per library. It must stay that way: a
+# library exporting `#[julia] fn f` as `rustcall_f` must not decide how a
+# *different* library's plain `#[no_mangle] fn f` resolves, and unloading the
+# first must not leave a mapping that redirects later lookups to a symbol that
+# is gone.
+@testset "#279: name -> symbol resolution is scoped to one library" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping per-library symbol resolution test"
+        return
+    end
+
+    # Library A: `#[julia]`, so the C entry point is `rustcall_scoped_probe`
+    # and the Rust name is not exported at all.
+    expanded_a = RustCall.expand_inline("""
+    #[julia]
+    pub fn scoped_probe(x: i32) -> i32 { x + 1 }
+    """)
+    # Library B: a plain `#[no_mangle]` function of the same Rust name,
+    # exported under that name.
+    expanded_b = RustCall.expand_inline("""
+    #[no_mangle]
+    pub extern "C" fn scoped_probe(x: i32) -> i32 { x + 100 }
+    """)
+
+    path_a = RustCall.compile_rust_to_shared_lib(expanded_a.source)
+    path_b = RustCall.compile_rust_to_shared_lib(expanded_b.source)
+    lib_a = "test279_a_" * string(hash(path_a), base = 16)
+    lib_b = "test279_b_" * string(hash(path_b), base = 16)
+    handle_a = Libdl.dlopen(path_a, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+    handle_b = Libdl.dlopen(path_b, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+    unloaded = Set{String}()
+    unload!(name) = (name in unloaded || (push!(unloaded, name); RustCall.unload_library(name)))
+
+    try
+        lock(RustCall.REGISTRY_LOCK) do
+            RustCall.RUST_LIBRARIES[lib_a] = (handle_a, Dict{String, Ptr{Cvoid}}())
+            RustCall.RUST_LIBRARIES[lib_b] = (handle_b, Dict{String, Ptr{Cvoid}}())
+        end
+        RustCall._register_manifest(expanded_a, lib_a)
+        RustCall._register_manifest(expanded_b, lib_b)
+
+        # The mapping is not visible across libraries, and a library that
+        # recorded nothing resolves the name to itself.
+        @test RustCall.exported_symbol(lib_a, "scoped_probe") == "rustcall_scoped_probe"
+        @test RustCall.exported_symbol(lib_b, "scoped_probe") == "scoped_probe"
+        @test RustCall.exported_symbol("test279_unknown_lib", "scoped_probe") == "scoped_probe"
+        # A's Rust name really is not a C symbol; B's really is.
+        @test Libdl.dlsym(handle_a, "scoped_probe"; throw_error = false) === nothing
+        @test Libdl.dlsym(handle_b, "rustcall_scoped_probe"; throw_error = false) === nothing
+
+        # Both are callable and each resolves to its own library's symbol.
+        ptr_a = RustCall.get_function_pointer(lib_a, "scoped_probe")
+        ptr_b = RustCall.get_function_pointer(lib_b, "scoped_probe")
+        @test ptr_a != ptr_b
+        @test RustCall.call_rust_function(ptr_a, Int32, Int32(1)) == Int32(2)
+        @test RustCall.call_rust_function(ptr_b, Int32, Int32(1)) == Int32(101)
+
+        # Unloading A drops its mapping; B keeps resolving.
+        unload!(lib_a)
+        @test RustCall.exported_symbol(lib_a, "scoped_probe") == "scoped_probe"
+        @test RustCall.exported_symbol(lib_b, "scoped_probe") == "scoped_probe"
+        ptr_b_again = RustCall.get_function_pointer(lib_b, "scoped_probe")
+        @test RustCall.call_rust_function(ptr_b_again, Int32, Int32(1)) == Int32(101)
+    finally
+        unload!(lib_a)
+        unload!(lib_b)
     end
 end


### PR DESCRIPTION
`#[julia]` used to **replace** the annotated item. For anything it had to
transform — `Result` / `Option` returns, `String` / `&str` parameters (#242),
struct methods — the user's `fn shout(s: String) -> String` no longer existed
after expansion, so the attribute composed with nothing: other proc-macros
(`#[pyfunction]`), in-crate callers, `#[test]`s and `pub use` re-exports all
saw the rewritten `extern "C"` signature.

`#[julia]` is now **additive**: the annotated item is kept byte-for-byte
(minus the attribute itself) and the FFI entry point is emitted next to it.

## Symbol scheme

Documented at the top of `deps/rustcall_core/src/codegen.rs`:

| generated item | symbol |
|---|---|
| free function `f` | `rustcall_f` |
| method / constructor `Struct::m` | `rustcall_Struct_m` |
| specialized generic instantiation `f_i32` | `rustcall_f_i32` |
| struct destructor | `Struct_free` |
| field accessors | `Struct_get_x` / `Struct_set_x` |
| clone | `Struct_clone` |
| `Result` / `Option` payload | `CResult_f` / `COption_f` |
| owned string buffer / release | `<owner>_RustCallOwnedString` / `<owner>_free_rust_string` |
| borrowed string view | `<owner>_RustCallBorrowedString` |

Only the first three wrap a *user-written* item and therefore have to step
aside from its name; everything else is purely generated and keeps the name it
has always had (`<owner>` is the free function, `<Struct>_<method>` or
`<Struct>` the buffer belongs to). The scheme is stable and part of artifact
identity — the manifest carries it, and nothing derives it by string surgery
on the Julia side. Inline expansion additionally emits a `compile_error!`
naming a user item that a generated symbol would collide with; the proc-macro
sees one item at a time and cannot make that check.

The wrapper calls the original by name in the same module, for the inline
flavour, the crate flavour and `specialize` output alike — which is exactly the
shape #275 Phase 2 needs for its external wrapper crate.

## Schema bump

`rustcall_core::manifest::SCHEMA_VERSION` and `RustCall.MANIFEST_SCHEMA_VERSION`
go from 2 to 3: `Function.symbol` / `Method.symbol` now differ from `name` for
*every* wrapped item, not only for generic instantiations, so a schema-2
consumer would `dlsym` the Rust name and find nothing. **The extractor must be
rebuilt** (`Pkg.build("RustCall")`). The schema-mismatch tests were updated.

## One wrapper generator

Per the #274 review: the per-flavour transforms in `codegen.rs` (which kept
losing the string ABI one flavour at a time) are collapsed into a single
`generate_wrapper(WrapperSpec)`. The spec is a signature model — args with ABI,
return kind, string-lowering flag, receiver, `#[cfg]` attributes — plus a call
target, and every entry point is now a thin adapter over it:
`transform_function`, `transform_function_julia_pyo3`, `plain_function_wrapper`
(used by `specialize`), `inline_method_wrapper` and
`generate_method_wrapper_crate` (both via one `method_spec`). Adding a flavour
cannot lose the lowering again. The now-dead `codegen::is_constructor` is gone.
`#[julia_pyo3]` keeps its either/or `cfg(feature = "python")` shape, but its
non-Python branch is "original item + additive wrapper" too, and its manifest
`abi` stays honest (signature exported as written).

`attrs.rs` also records the compatibility rule agreed for #275: an item
carrying both `#[julia]` and `#[pyfunction]` is owned by `#[julia]`, so the
PyO3 scan must skip it (`julia_owns_entry_point` / `pyo3_scan_selects`).

## Julia-side audit

Every `ccall` / `dlsym` / function-pointer lookup now goes through the manifest
`symbol`. Sites that assumed symbol == name and were fixed:

- `src/julia_functions.jl` — the inline plain / string / `Result` / `Option`
  wrappers looked the pointer up by `sig.name`;
- `src/crate_bindings.jl` — the four in-memory emitters and their
  `write_bindings_to_file` counterparts (`_emit_function_code`,
  `_emit_result_function_code`, `_emit_option_function_code`,
  `_emit_method_code`) used `func.name` and `"<Struct>_<method>"`;
- `src/structs.jl` — the concrete-struct method wrapper built
  `"<Struct>_" * m.name`;
- `src/generics.jl` — `Libdl.dlsym(lib, specialized_name)` and the pointer
  cache key (`SpecializedFunction` gains `symbol`);
- `src/rustmacro.jl` — `_rust_call_dynamic` looked up both the pointer and the
  registered return type under the source-level name.

`src/hot_reload.jl` turned out to deal only in library names — nothing to fix.

`@rust f(...)` names the *Rust function*, not the symbol, so `src/codegen.jl`
gains a manifest-fed name → symbol registry (`register_function_symbol` /
`exported_symbol`, filled by `_register_manifest`) that `get_function_pointer`
consults. The generated Julia function names are unchanged: users still call
`add(1, 2)`, which `ccall`s `rustcall_add`.

## Tests

- `deps/juliacall_macros/examples/pyo3_compose.rs`: `#[julia]` stacked with
  `#[pyfunction]` in **both** attribute orders for `Result`, `Option`, `String`
  and a plain signature, plus an in-crate caller. It lives in `examples/`
  rather than `tests/` so `cargo test` and `cargo clippy --all-targets` compile
  it without the suite having to load libpython (`pyo3` is a dev-dependency
  with `default-features = false, features = ["macros"]`).
- `deps/juliacall_macros/tests/additive.rs`: the runnable half — the annotated
  items keep their Rust signature (in-crate caller + `#[test]`), and the C
  entry points are the `rustcall_` symbols, methods included.
- Golden corpus regenerated (`UPDATE_GOLDEN=1 cargo test`): `schema_version = 3`,
  `symbol = "rustcall_..."` throughout, and the expanded sources now carry the
  original items next to the wrappers (the `<fn>_inner` shims are gone).
- `test/test_julia_attribute.jl`: a regression test that `dlsym`s the compiled
  block and asserts `rustcall_<fn>` is exported while the Rust name is **not**,
  plus an end-to-end `rust"""` round trip through both the generated wrapper
  and `@rust`.
- `examples/sample_crate_pyo3` stacks `#[julia]` with `#[pyfunction]` on
  `shout`, adds an in-crate caller and a `#[test]`, and its Julia demo still
  passes.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and
`cargo test` in `deps/rustcall_core`, `deps/rustcall_extract` (plus
`cargo build --release`), `deps/juliacall_macros` (`--all-features`) and
`examples/sample_crate_pyo3`; `Pkg.build("RustCall")` then the full
`Pkg.test()` against the freshly built extractor (6073 + 270 passing, 0
failures); `scripts/lint_interpolation.sh src`; `scripts/lint_rust_syntax_regex.sh src`;
`julia --project=docs docs/make.jl` exits 0.

## Downstream

`../Symbolica.jl` consumes `write_bindings_to_file`. Its generated
`src/generated/SymbolicaNative.jl` will change from
`_get_func_ptr("symbolica_expand")` to `_get_func_ptr("rustcall_symbolica_expand")`
(the `_free_rust_string` helpers keep their names), while the module's Julia
API — `symbolica_expand(input)` and friends — is unchanged. So re-running
`Pkg.build("Symbolica")` is all that is needed; `src/rust_backend.jl` and the
facade crate need no edits.

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
