### PR TITLE
Additive #[julia] follow-ups: atomic symbol registration, RustMethod symbol fallback (#279)

### DIFF
--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -36,14 +36,18 @@ Maps (library name, function name) to FunctionInfo.
 const FUNCTION_REGISTRY_BY_LIB = Dict{Tuple{String, String}, FunctionInfo}()
 
 """
-Registry for function return types (for functions without full signature registration).
-Maps function name to return type.
-"""
-const FUNCTION_RETURN_TYPES = Dict{String, Type}()
+Registry for function return types (for functions without full signature
+registration), keyed by `(library name, function name)`.
 
-"""
-Library-scoped registry for function return types.
-Maps (library name, function name) to return type.
+There is deliberately **no** name-only fallback table. A name-keyed hint
+outlives the library that wrote it: clearing or reloading that library would
+leave its return type answering for every other library's function of the same
+name, and a rebuilt library that no longer declares the function that way would
+be typed by the stale value (#279). Every lookup has a library — `CURRENT_LIB`
+or an explicit one — so `get_function_return_type` resolves the same way
+`get_function_pointer` does instead.
+
+Guarded by `REGISTRY_LOCK`.
 """
 const FUNCTION_RETURN_TYPES_BY_LIB = Dict{Tuple{String, String}, Type}()
 
@@ -111,25 +115,17 @@ a stale hint would type a call to a function the rebuilt library no longer
 declares that way — so the two must go together, in the same transaction that
 removes the handle (#279).
 
-The unscoped `FUNCTION_RETURN_TYPES` fallback is pruned as well, but only for
-names no *other* library still declares.
+Both registries are keyed by library, so dropping a library's rows is all there
+is to it: nothing it recorded can outlive it under a name-only key.
 """
 function clear_library_metadata!(lib_name::AbstractString)
     name = String(lib_name)
     lock(REGISTRY_LOCK) do
-        orphaned = String[]
         for key in collect(keys(FUNCTION_SYMBOLS_BY_LIB))
             first(key) == name && delete!(FUNCTION_SYMBOLS_BY_LIB, key)
         end
         for key in collect(keys(FUNCTION_RETURN_TYPES_BY_LIB))
-            if first(key) == name
-                delete!(FUNCTION_RETURN_TYPES_BY_LIB, key)
-                push!(orphaned, last(key))
-            end
-        end
-        for func_name in orphaned
-            any(k -> last(k) == func_name, keys(FUNCTION_RETURN_TYPES_BY_LIB)) && continue
-            delete!(FUNCTION_RETURN_TYPES, func_name)
+            first(key) == name && delete!(FUNCTION_RETURN_TYPES_BY_LIB, key)
         end
     end
     return nothing
@@ -200,15 +196,37 @@ end
 """
     get_function_return_type(lib_name::String, func_name::String) -> Union{Type, Nothing}
 
-Get a registered return type for a function in a specific library.
-Falls back to global function-name mapping for backward compatibility.
+The registered return type of `func_name` as seen from `lib_name`, or `nothing`
+when nothing applies.
+
+Resolution mirrors `get_function_pointer` so that a call's pointer and
+its return type always come from the same library: `lib_name` first, then the
+other **loaded** libraries. A name declared by exactly one of them answers; a
+name declared by several is ambiguous and yields `nothing`, leaving the caller
+to infer or to demand an explicit `::T` — the same situation in which
+`get_function_pointer` refuses to guess.
+
+There is no name-only fallback: a hint keyed by name alone outlives the library
+that wrote it and would type a call into a *different* library, or into a
+rebuilt one that no longer declares the function that way (#279).
 """
 function get_function_return_type(lib_name::String, func_name::String)
-    by_lib = get(FUNCTION_RETURN_TYPES_BY_LIB, (lib_name, func_name), nothing)
-    if by_lib !== nothing
-        return by_lib
+    lock(REGISTRY_LOCK) do
+        by_lib = get(FUNCTION_RETURN_TYPES_BY_LIB, (lib_name, func_name), nothing)
+        by_lib === nothing || return by_lib
+
+        found = nothing
+        for other_lib_name in keys(RUST_LIBRARIES)
+            other_lib_name == lib_name && continue
+            hint = get(FUNCTION_RETURN_TYPES_BY_LIB, (other_lib_name, func_name), nothing)
+            hint === nothing && continue
+            # Declared by more than one other library: ambiguous, exactly as
+            # the pointer lookup would be.
+            found === nothing || return nothing
+            found = hint
+        end
+        return found
     end
-    return get(FUNCTION_RETURN_TYPES, func_name, nothing)
 end
 
 """

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -60,7 +60,7 @@ The mapping is strictly **per library**, and identity mappings are recorded
 too. One library exporting `#[julia] fn f` as `rustcall_f` must not decide how
 `f` resolves in another library that exports a plain `#[no_mangle] fn f` under
 its own name; a library with no entry for a name resolves it to the name
-itself. Entries are dropped with the library (`clear_function_symbols!`), so an
+itself. Entries are dropped with the library (`clear_library_metadata!`), so an
 unloaded library cannot leave a stale mapping behind.
 
 Guarded by `REGISTRY_LOCK`.
@@ -99,42 +99,67 @@ function exported_symbol(lib_name::AbstractString, name::AbstractString)
 end
 
 """
-    clear_function_symbols!(lib_name)
+    clear_library_metadata!(lib_name)
 
-Drop every name-to-symbol mapping of `lib_name`. Called wherever a library
-leaves `RUST_LIBRARIES` or is replaced under the same name (unload, hot
-reload, re-registration of a `rust\"\"\"` block), so a stale mapping can never
-redirect a later lookup to a symbol that is no longer loaded.
+Drop everything the registries record *about* one library: its name-to-symbol
+mappings and its return-type hints.
+
+Called wherever a library leaves `RUST_LIBRARIES` or is replaced under the same
+name (unload, hot reload, re-registration of a `rust\"\"\"` block). A stale
+mapping would redirect a later lookup to a symbol that is no longer loaded, and
+a stale hint would type a call to a function the rebuilt library no longer
+declares that way — so the two must go together, in the same transaction that
+removes the handle (#279).
+
+The unscoped `FUNCTION_RETURN_TYPES` fallback is pruned as well, but only for
+names no *other* library still declares.
 """
-function clear_function_symbols!(lib_name::AbstractString)
+function clear_library_metadata!(lib_name::AbstractString)
     name = String(lib_name)
     lock(REGISTRY_LOCK) do
+        orphaned = String[]
         for key in collect(keys(FUNCTION_SYMBOLS_BY_LIB))
             first(key) == name && delete!(FUNCTION_SYMBOLS_BY_LIB, key)
+        end
+        for key in collect(keys(FUNCTION_RETURN_TYPES_BY_LIB))
+            if first(key) == name
+                delete!(FUNCTION_RETURN_TYPES_BY_LIB, key)
+                push!(orphaned, last(key))
+            end
+        end
+        for func_name in orphaned
+            any(k -> last(k) == func_name, keys(FUNCTION_RETURN_TYPES_BY_LIB)) && continue
+            delete!(FUNCTION_RETURN_TYPES, func_name)
         end
     end
     return nothing
 end
 
 """
-    copy_function_symbols!(from, to)
+    copy_library_metadata!(from, to)
 
-Give the library `to` the same name-to-symbol mappings as `from`, replacing
-whatever it had.
+Give the library `to` the same name-to-symbol mappings and return-type hints as
+`from`, replacing whatever it had.
 
 Used when one loaded handle is registered under a second name (`@rust`'s reload
-alias, `_alias_reloaded_library`): resolution is per library, so the alias
-needs its own entries or a lookup through it would resolve `f` to `f` and miss
-the `rustcall_f` the library actually exports (#279).
+alias, `_alias_reloaded_library`): both registries are per library, so the alias
+needs its own entries. Without the mappings a lookup through it would resolve
+`f` to `f` and miss the `rustcall_f` the library actually exports; without the
+hints an untyped `@rust f(...)` through the alias would fall back to the
+unscoped table and pick up whatever *another* block last registered for that
+name (#279).
 """
-function copy_function_symbols!(from::AbstractString, to::AbstractString)
+function copy_library_metadata!(from::AbstractString, to::AbstractString)
     source = String(from)
     target = String(to)
     source == target && return nothing
     lock(REGISTRY_LOCK) do
-        clear_function_symbols!(target)
+        clear_library_metadata!(target)
         for ((lib, name), symbol) in collect(FUNCTION_SYMBOLS_BY_LIB)
             lib == source && (FUNCTION_SYMBOLS_BY_LIB[(target, name)] = symbol)
+        end
+        for ((lib, name), ret_type) in collect(FUNCTION_RETURN_TYPES_BY_LIB)
+            lib == source && (FUNCTION_RETURN_TYPES_BY_LIB[(target, name)] = ret_type)
         end
     end
     return nothing

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -39,13 +39,13 @@ const FUNCTION_REGISTRY_BY_LIB = Dict{Tuple{String, String}, FunctionInfo}()
 Registry for function return types (for functions without full signature
 registration), keyed by `(library name, function name)`.
 
-There is deliberately **no** name-only fallback table. A name-keyed hint
-outlives the library that wrote it: clearing or reloading that library would
-leave its return type answering for every other library's function of the same
-name, and a rebuilt library that no longer declares the function that way would
-be typed by the stale value (#279). Every lookup has a library — `CURRENT_LIB`
-or an explicit one — so `get_function_return_type` resolves the same way
-`get_function_pointer` does instead.
+There is deliberately **no** name-only fallback table, and no cross-library
+search. A name-keyed hint outlives the library that wrote it: clearing or
+reloading that library would leave its return type answering for every other
+library's function of the same name, and a rebuilt library that no longer
+declares the function that way would be typed by the stale value (#279).
+Lookups go through the library `_resolve_call` took the pointer from, so a
+call's pointer and its ABI always come from the same build.
 
 Guarded by `REGISTRY_LOCK`.
 """
@@ -196,36 +196,23 @@ end
 """
     get_function_return_type(lib_name::String, func_name::String) -> Union{Type, Nothing}
 
-The registered return type of `func_name` as seen from `lib_name`, or `nothing`
-when nothing applies.
+The return type `lib_name` itself registered for `func_name`, or `nothing`.
 
-Resolution mirrors `get_function_pointer` so that a call's pointer and
-its return type always come from the same library: `lib_name` first, then the
-other **loaded** libraries. A name declared by exactly one of them answers; a
-name declared by several is ambiguous and yields `nothing`, leaving the caller
-to infer or to demand an explicit `::T` — the same situation in which
-`get_function_pointer` refuses to guess.
+**Only that library's own entry is consulted.** No name-only fallback, and no
+search of the other libraries: a hint must never describe a function in a
+library other than the one the call actually reaches. `lib_name` here is the
+*owning* library — the one `_resolve_call` took the pointer from — so the
+pointer and the ABI it is called with always come from the same build.
 
-There is no name-only fallback: a hint keyed by name alone outlives the library
-that wrote it and would type a call into a *different* library, or into a
-rebuilt one that no longer declares the function that way (#279).
+Borrowing would be worse than having no hint: a library whose `f` returns
+`Result<i32, i32>` deliberately records nothing (the wrapper returns a
+`CResult_f` struct, and `@rust` callers must be explicit), so any hint found
+elsewhere for the name `f` is not merely unrelated but the wrong ABI. Absent a
+hint the caller infers from the arguments or demands an explicit `::T` (#279).
 """
 function get_function_return_type(lib_name::String, func_name::String)
     lock(REGISTRY_LOCK) do
-        by_lib = get(FUNCTION_RETURN_TYPES_BY_LIB, (lib_name, func_name), nothing)
-        by_lib === nothing || return by_lib
-
-        found = nothing
-        for other_lib_name in keys(RUST_LIBRARIES)
-            other_lib_name == lib_name && continue
-            hint = get(FUNCTION_RETURN_TYPES_BY_LIB, (other_lib_name, func_name), nothing)
-            hint === nothing && continue
-            # Declared by more than one other library: ambiguous, exactly as
-            # the pointer lookup would be.
-            found === nothing || return nothing
-            found = hint
-        end
-        return found
+        get(FUNCTION_RETURN_TYPES_BY_LIB, (lib_name, func_name), nothing)
     end
 end
 

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -117,6 +117,30 @@ function clear_function_symbols!(lib_name::AbstractString)
 end
 
 """
+    copy_function_symbols!(from, to)
+
+Give the library `to` the same name-to-symbol mappings as `from`, replacing
+whatever it had.
+
+Used when one loaded handle is registered under a second name (`@rust`'s reload
+alias, `_alias_reloaded_library`): resolution is per library, so the alias
+needs its own entries or a lookup through it would resolve `f` to `f` and miss
+the `rustcall_f` the library actually exports (#279).
+"""
+function copy_function_symbols!(from::AbstractString, to::AbstractString)
+    source = String(from)
+    target = String(to)
+    source == target && return nothing
+    lock(REGISTRY_LOCK) do
+        clear_function_symbols!(target)
+        for ((lib, name), symbol) in collect(FUNCTION_SYMBOLS_BY_LIB)
+            lib == source && (FUNCTION_SYMBOLS_BY_LIB[(target, name)] = symbol)
+        end
+    end
+    return nothing
+end
+
+"""
     register_function(name::String, lib_name::String, ret_type::Type, arg_types::Vector{Type})
 
 Register a function with its type signature for later calling.

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -750,7 +750,7 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
     method_name = Symbol(method.name)
     # Exported symbol of the method wrapper (`rustcall_<Struct>_<method>`, #279);
     # the per-method string buffers stay named after the method itself.
-    wrapper_name = method.symbol
+    wrapper_name = method_wrapper_symbol(struct_name_str, method)
     helper_owner = "$(struct_name_str)_$(method.name)"
 
     arg_syms = [Symbol(name) for name in method.arg_names]
@@ -1685,7 +1685,7 @@ function _emit_method_code(struct_info::RustStructInfo, method::RustMethod)
     method_name = method.name
     # Exported symbol (`rustcall_<Struct>_<method>`, #279); the per-method
     # string buffers stay named after the method itself.
-    wrapper_name = method.symbol
+    wrapper_name = method_wrapper_symbol(struct_name, method)
     helper_owner = "$(struct_name)_$(method_name)"
 
     arg_syms = join(method.arg_names, ", ")

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -629,6 +629,29 @@ The name of the symbol that releases an `:owned_by_rust` string produced by
 ffi_free_symbol(owner::AbstractString) = string(owner, "_free_rust_string")
 
 """
+Prefix of every exported symbol that stands in for a user-written Rust item.
+
+`#[julia]` is additive (#279): the annotated item keeps its name and the
+`extern "C"` entry point is emitted next to it under this prefix. Mirrors
+`rustcall_core::codegen::SYMBOL_PREFIX`.
+"""
+const FFI_SYMBOL_PREFIX = "rustcall_"
+
+"""
+    ffi_method_symbol(struct_name, method_name) -> String
+
+The exported symbol of the wrapper of the `#[julia]` method `Struct::method`
+(`rustcall_<Struct>_<method>`, see `deps/rustcall_core/src/codegen.rs`).
+
+This is the fallback for a `RustMethod` built by hand rather than read from a
+manifest: its six-argument constructor cannot know the struct name, so it
+records no `symbol` and the emitters derive one here. A manifest-backed method
+always carries its own `symbol` and never reaches this (#279).
+"""
+ffi_method_symbol(struct_name::AbstractString, method_name::AbstractString) =
+    string(FFI_SYMBOL_PREFIX, struct_name, "_", method_name)
+
+"""
     ffi_argument_contract(rust_type; abi = "") -> FFIContract
 
 The contract for one argument position. Multi-word values are **expanded into

--- a/src/hot_reload.jl
+++ b/src/hot_reload.jl
@@ -203,6 +203,19 @@ function _reload_library_locked(state::HotReloadState)
         # Update state
         state.lib_path = new_lib_path
 
+        # The rebuilt crate decides its own exported symbols, so the mappings
+        # the unload dropped are rebuilt from a fresh scan (#279). Scanning
+        # runs the extractor, so it happens before the lock is taken; a scan
+        # failure must not lose the rebuilt library, only its name-to-symbol
+        # mappings (a `#[julia]` function is then unreachable by its Rust name
+        # until the next successful reload).
+        signatures = try
+            scan_crate(state.crate_path).julia_functions
+        catch error
+            @warn "Hot reload: could not rescan $(state.crate_path) for exported symbols" error
+            nothing
+        end
+
         # Re-register the library.  Check that nothing else has registered the
         # same name during the rebuild window.
         lib_handle = Libdl.dlopen(new_lib_path, Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW)
@@ -210,6 +223,10 @@ function _reload_library_locked(state::HotReloadState)
             if haskey(RUST_LIBRARIES, state.lib_name)
                 @warn "Hot reload: Library $(state.lib_name) was re-registered during rebuild; overwriting"
             end
+            # Mappings first, handle last: the two must never be observable
+            # apart (#279).
+            signatures === nothing ||
+                _register_exported_symbols!(signatures, state.lib_name)
             RUST_LIBRARIES[state.lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
         end
 

--- a/src/hot_reload.jl
+++ b/src/hot_reload.jl
@@ -177,7 +177,7 @@ function _reload_library_locked(state::HotReloadState)
                 delete!(RUST_LIBRARIES, state.lib_name)
                 # The rebuilt library re-registers its own mappings; a stale
                 # entry would redirect a lookup to the unloaded handle (#279).
-                clear_function_symbols!(state.lib_name)
+                clear_library_metadata!(state.lib_name)
                 if CURRENT_LIB[] == state.lib_name
                     CURRENT_LIB[] = ""
                 end

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -764,7 +764,8 @@ end
     unregister_library!(policy::LoadPolicy, lib_name::AbstractString) -> Bool
 
 Remove the `RUST_LIBRARIES` entry, its function-pointer cache and the
-library's name-to-symbol mappings (`clear_function_symbols!`, #279) under
+library's registry metadata — its name-to-symbol mappings and return-type
+hints (`clear_library_metadata!`, #279) — under
 `REGISTRY_LOCK`, clearing `CURRENT_LIB[]` if it pointed at `lib_name`.
 Returns whether an entry was removed.  Does not `dlclose`: Phase B decides that
 together with the unload purge described in #250.
@@ -781,7 +782,7 @@ function unregister_library!(policy::LoadPolicy, lib_name::AbstractString)
         if removed
             delete!(RUST_LIBRARIES, name)
         end
-        clear_function_symbols!(name)
+        clear_library_metadata!(name)
         if CURRENT_LIB[] == name
             CURRENT_LIB[] = ""
         end

--- a/src/loadpolicy.jl
+++ b/src/loadpolicy.jl
@@ -731,9 +731,15 @@ Returns `lib_name`.  A no-op returning `lib_name` for policies that do not use
 `RUST_LIBRARIES` (`:module_local`, `:helper_slot`, `:none`), so a Phase B call
 site can call it unconditionally.
 
-Subsumes the eight open-coded `RUST_LIBRARIES[...] = ...` sites:
-`src/ruststr.jl:335`, `:375`, `:483`, `:520`, `:997`, `src/generics.jl:261`,
-`src/hot_reload.jl:210`, and the reload alias `src/rustmacro.jl:166` (#272).  Not called from `src/` yet (Phase A is additive).
+Subsumes the five remaining open-coded `RUST_LIBRARIES[...] = ...` sites:
+`_register_manifest` and the `@irust` loader in `src/ruststr.jl`,
+`src/generics.jl`, `src/hot_reload.jl`, and the reload alias in
+`src/rustmacro.jl` (#272).  The four inline-block sites collapsed into
+`_register_manifest`, which publishes the handle together with the manifest's
+name-to-symbol mappings so the two cannot be observed apart (#279); a Phase B
+`register_library!` has to keep that guarantee, which is what the `symbols`
+argument this function will grow is for.  Not called from `src/` yet (Phase A
+is additive).
 """
 function register_library!(policy::LoadPolicy, lib_name::AbstractString, handle::Ptr{Cvoid})
     name = String(lib_name)

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -303,21 +303,21 @@ function _rust_call_dynamic(lib_name::String, func_name::String, args...)
 
     # Regular function - use existing logic
     # `@rust f(...)` names the Rust function; `#[julia]` exports the additive
-    # wrapper `rustcall_f` next to it (#279). `get_function_pointer` resolves
-    # that per library, and the return-type registry is keyed by both the name
-    # and the symbol, so the source-level name is what we pass around here.
-    # Get function pointer
-    @debug "Calling function '$func_name' from library '$lib_name'"
-    func_ptr = get_function_pointer(lib_name, func_name)
+    # wrapper `rustcall_f` next to it (#279). `_resolve_call` resolves that per
+    # library and reports which library the pointer came from, so the return
+    # type is read from that same library and never borrowed from another one
+    # whose `f` has a different ABI.
+    func_ptr, owning_lib = _resolve_call(lib_name, func_name)
+    @debug "Calling function '$func_name' from library '$owning_lib'"
 
     # Try to get type info from registered function info
-    func_info = get_function_info(lib_name, func_name)
+    func_info = get_function_info(owning_lib, func_name)
     if func_info !== nothing && func_info.return_type !== Any
         return call_rust_function(func_ptr, func_info.return_type, args...)
     end
 
-    # Try to get return type from registries (library-scoped first, then fallback)
-    ret_type = get_function_return_type(lib_name, func_name)
+    # Try to get the return type the owning library registered
+    ret_type = get_function_return_type(owning_lib, func_name)
     if ret_type !== nothing
         @debug "Using registered return type for $func_name: $ret_type"
         return call_rust_function(func_ptr, ret_type, args...)

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -164,12 +164,15 @@ function _alias_reloaded_library(mod::Module, stored_name::String, actual_name::
     lock(REGISTRY_LOCK) do
         entry = get(RUST_LIBRARIES, actual_name, nothing)
         if entry !== nothing
-            # Symbol resolution is per library (#279), so the alias needs its
-            # own name-to-symbol entries: without them a lookup through the
+            # Both registries are per library (#279), so the alias needs its
+            # own entries: without the symbol mappings a lookup through the
             # stored name resolves `f` to `f`, misses the `rustcall_f` this
             # library exports, and falls back to the cross-library search —
-            # which another block defining `f` would make ambiguous.
-            copy_function_symbols!(actual_name, stored_name)
+            # which another block defining `f` would make ambiguous; without
+            # the return-type hints an untyped `@rust f(...)` through the alias
+            # would take the unscoped fallback and pick up whatever another
+            # block last registered for that name.
+            copy_library_metadata!(actual_name, stored_name)
             RUST_LIBRARIES[stored_name] = entry
         end
     end

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -163,7 +163,15 @@ library moves to the actual name, under which the manifest was registered.
 function _alias_reloaded_library(mod::Module, stored_name::String, actual_name::String)
     lock(REGISTRY_LOCK) do
         entry = get(RUST_LIBRARIES, actual_name, nothing)
-        entry === nothing || (RUST_LIBRARIES[stored_name] = entry)
+        if entry !== nothing
+            # Symbol resolution is per library (#279), so the alias needs its
+            # own name-to-symbol entries: without them a lookup through the
+            # stored name resolves `f` to `f`, misses the `rustcall_f` this
+            # library exports, and falls back to the cross-library search —
+            # which another block defining `f` would make ambiguous.
+            copy_function_symbols!(actual_name, stored_name)
+            RUST_LIBRARIES[stored_name] = entry
+        end
     end
     if isdefined(mod, :__RUSTCALL_ACTIVE_LIB)
         active = getfield(mod, :__RUSTCALL_ACTIVE_LIB)

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -321,16 +321,15 @@ function _compile_and_load_rust(code::String, source_file::String, source_line::
     lib_name = "rust_$(code_hash)"
 
     # Check if already compiled and loaded in memory
-    lock(REGISTRY_LOCK) do
-        if haskey(RUST_LIBRARIES, lib_name)
-            CURRENT_LIB[] = lib_name
-
-            # Ensure generic functions and return types are registered
-            # (the registries are volatile)
-            _register_manifest(expanded, lib_name; compiler)
-
-            return lib_name
-        end
+    is_in_memory = lock(REGISTRY_LOCK) do
+        haskey(RUST_LIBRARIES, lib_name)
+    end
+    if is_in_memory
+        # Ensure the symbol mappings, return types and generic functions are
+        # registered (the registries are volatile). The handle is already
+        # published, so only `CURRENT_LIB[]` moves here.
+        _register_manifest(expanded, lib_name; compiler)
+        return lib_name
     end
 
     # Check cache first
@@ -339,14 +338,10 @@ function _compile_and_load_rust(code::String, source_file::String, source_line::
         # Load from cache
         lib_handle, _ = load_cached_library(cache_key)
 
-        # Register the library
-        lock(REGISTRY_LOCK) do
-            RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
-            CURRENT_LIB[] = lib_name
-
-        end
-
-        _register_manifest(expanded, lib_name; compiler)
+        # Register the library. The handle and the manifest's lookup tables
+        # are published together (#279 follow-up): a concurrent
+        # `ensure_loaded` must never see the library before its symbols.
+        _register_manifest(expanded, lib_name; compiler, handle = lib_handle)
 
         return lib_name
     end
@@ -379,16 +374,12 @@ function _compile_and_load_rust(code::String, source_file::String, source_line::
         error("Failed to load compiled Rust library: $lib_path")
     end
 
-    # Register the library
-    lock(REGISTRY_LOCK) do
-        RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
-        CURRENT_LIB[] = lib_name
-    end
-
     # Temporarily disabled LLVM IR loading for stability
     # (LLVM IR is used for type inference and @rust_llvm)
 
-    _register_manifest(expanded, lib_name; compiler)
+    # Register the library: the handle and the manifest's lookup tables are
+    # published in one critical section (#279 follow-up).
+    _register_manifest(expanded, lib_name; compiler, handle = lib_handle)
 
     return lib_name
 end
@@ -470,9 +461,6 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
         haskey(RUST_LIBRARIES, lib_name)
     end
     if is_in_memory
-        lock(REGISTRY_LOCK) do
-            CURRENT_LIB[] = lib_name
-        end
         @debug "Using cached Cargo library from memory" lib_name=lib_name
 
         _register_manifest(expanded, lib_name; cargo_backed = true)
@@ -488,13 +476,8 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
         # Load from cache
         lib_handle = Libdl.dlopen(cached_lib, Libdl.RTLD_GLOBAL | Libdl.RTLD_NOW)
         if lib_handle != C_NULL
-            lock(REGISTRY_LOCK) do
-                RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
-                CURRENT_LIB[] = lib_name
-            end
+            _register_manifest(expanded, lib_name; cargo_backed = true, handle = lib_handle)
             @debug "Loaded Cargo library from cache" lib_name=lib_name cache_key=cache_key[1:8]
-
-            _register_manifest(expanded, lib_name; cargo_backed = true)
 
             return lib_name
         end
@@ -524,15 +507,11 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
             error("Failed to load compiled Cargo library: $lib_path")
         end
 
-        # Register the library
-        lock(REGISTRY_LOCK) do
-            RUST_LIBRARIES[lib_name] = (lib_handle, Dict{String, Ptr{Cvoid}}())
-            CURRENT_LIB[] = lib_name
-        end
+        # Register the library: handle and manifest lookup tables together
+        # (#279 follow-up).
+        _register_manifest(expanded, lib_name; cargo_backed = true, handle = lib_handle)
 
         @info "Successfully built Rust code with Cargo" lib_name=lib_name
-
-        _register_manifest(expanded, lib_name; cargo_backed = true)
     finally
         # Clean up temporary project (keep for debugging if debug mode is enabled)
         compiler = get_default_compiler()
@@ -614,26 +593,64 @@ function _rustc_block_identity(wrapped_source::AbstractString, compiler::RustCom
 end
 
 """
-    _register_manifest(expanded::ExpandedInline, lib_name::String)
+    _register_manifest(expanded::ExpandedInline, lib_name::String; handle = nothing)
 
 Register everything the manifest of a compiled block tells us:
 
+- the name-to-symbol mapping and the return type of every exported function,
+  so `@rust f(...)` resolves `rustcall_f` (#279) and works without `::T`;
 - generic free functions and generic struct wrappers, for on-demand
   monomorphization. The registered code is the whole expanded block and the
   function is addressed by its qualified name, so `specialize` instantiates it
   in place with sibling items, imports and `super::` paths intact.
-- return types of exported functions, so `@rust f(...)` works without `::T`
+
+Pass `handle` to publish a freshly loaded library at the same time. The handle
+and the manifest-derived lookup tables then become visible in **one**
+`REGISTRY_LOCK` critical section, which is what makes a concurrent
+`ensure_loaded` / `@rust f(...)` safe: a task that sees the library in
+`RUST_LIBRARIES` also sees that `f` is exported as `rustcall_f`, instead of
+resolving `f` to itself and failing (or, worse, hitting another library's `f`).
+Callers must therefore not insert into `RUST_LIBRARIES` themselves.
+
+The generic registrations stay outside the lock: `register_generic_function`
+may shell out to the extractor to recover a signature, which must not run with
+the global registry lock held.
 """
-function _register_manifest(expanded, lib_name::String; compiler = nothing, cargo_backed::Bool = false)
+function _register_manifest(expanded, lib_name::String; compiler = nothing,
+                            cargo_backed::Bool = false,
+                            handle::Union{Ptr{Cvoid}, Nothing} = nothing,
+                            set_current::Bool = true)
     manifest = expanded.manifest
-    # This library's name-to-symbol mappings are rebuilt from scratch: a block
-    # re-registered under the same library name must not keep the entries of
-    # functions it no longer defines (#279).
-    clear_function_symbols!(lib_name)
+    signatures = manifest_function_signatures(manifest; only_attributed = false)
+
+    lock(REGISTRY_LOCK) do
+        # This library's name-to-symbol mappings are rebuilt from scratch: a
+        # block re-registered under the same library name must not keep the
+        # entries of functions it no longer defines (#279).
+        clear_function_symbols!(lib_name)
+        for sig in signatures
+            sig.is_generic && continue
+            sig.exported || continue
+            # `@rust f(...)` names the Rust function; the library exports the
+            # additive wrapper (#279), so record the mapping before the handle
+            # becomes visible. Identity mappings are recorded too, so a plain
+            # `#[no_mangle] fn f` here is explicitly `f => f` for this library
+            # and cannot pick up another library's `f => rustcall_f`.
+            register_function_symbol(lib_name, sig.name, sig.symbol)
+            _register_return_type(sig, lib_name)
+        end
+        # Publishing the handle last is what closes the window: no reader can
+        # find the library before its symbol mappings are in place.
+        if handle !== nothing
+            RUST_LIBRARIES[lib_name] = (handle, Dict{String, Ptr{Cvoid}}())
+        end
+        set_current && (CURRENT_LIB[] = lib_name)
+    end
+
     for info in manifest_struct_infos(manifest)
         register_generic_struct_wrappers(info, expanded.source; compiler)
     end
-    for sig in manifest_function_signatures(manifest; only_attributed = false)
+    for sig in signatures
         if sig.is_generic
             # Generic functions are compiled lazily; keep the compiler they were
             # expanded for so a later `set_default_compiler` cannot drop
@@ -655,14 +672,6 @@ function _register_manifest(expanded, lib_name::String; compiler = nothing, carg
                                       arg_types = sig.arg_types, return_type = sig.return_type,
                                       path = qualified_name(sig.module_path, sig.name), compiler, blocked)
             @debug "Registered generic function: $(sig.name)" type_params = sig.type_params
-        elseif sig.exported
-            # `@rust f(...)` names the Rust function; the library exports the
-            # additive wrapper (#279), so record the mapping before anything
-            # tries to resolve it. Identity mappings are recorded too, so a
-            # plain `#[no_mangle] fn f` here is explicitly `f => f` for this
-            # library and cannot pick up another library's `f => rustcall_f`.
-            register_function_symbol(lib_name, sig.name, sig.symbol)
-            _register_return_type(sig, lib_name)
         end
     end
     return nothing

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -51,23 +51,29 @@ function get_library_handle(name::String)
 end
 
 """
-    get_function_pointer(lib_name::String, func_name::String) -> Ptr{Cvoid}
+    _resolve_call(lib_name::String, func_name::String) -> (Ptr{Cvoid}, String)
 
-Get a function pointer from a loaded library.
+The function pointer for `func_name` **and the library it came from**.
 
-If the function is not found in the specified library, searches all other
-loaded libraries as a fallback. This enables using functions from multiple
-`rust\"\"\"` blocks.
+`lib_name` is tried first; failing that, every other loaded library is searched
+as a fallback, which is what lets one `rust\"\"\"` block call another's
+functions. Each library resolves the name through its own symbol mapping
+(`#[julia]` is additive, so `f` may be exported as `rustcall_f`, #279).
+
+Candidates are deduplicated **by pointer**: one loaded handle may legitimately
+sit in `RUST_LIBRARIES` under two names — `_alias_reloaded_library` registers a
+reloaded library under the identity a precompiled module stored as well as the
+one the reload derived — and finding the same function twice through the same
+handle is not an ambiguity. Genuinely different functions of the same name in
+different libraries still are, and are refused rather than guessed.
+
+Returning the owning library is the point of this function: the caller needs
+the pointer and the return-type hint to come from the *same* library, or a
+`Result`-returning `f` in one library gets typed by a primitive-returning `f`
+in another.
 """
-function get_function_pointer(lib_name::String, func_name::String)
+function _resolve_call(lib_name::String, func_name::String)
     lock(REGISTRY_LOCK) do
-        # `#[julia]` is additive (#279): a Rust item named `add` may be exported
-        # as `rustcall_add`. The name-to-symbol mapping is per library, so it is
-        # resolved separately for every library searched below — one library's
-        # `#[julia] fn f` must never redirect the lookup of another library's
-        # plain `#[no_mangle] fn f`. A library with no entry for the name looks
-        # it up as given.
-
         # First, try the specified library
         if haskey(RUST_LIBRARIES, lib_name)
             symbol = exported_symbol(lib_name, func_name)
@@ -75,7 +81,7 @@ function get_function_pointer(lib_name::String, func_name::String)
 
             # Check cache first
             if haskey(func_cache, symbol)
-                return func_cache[symbol]
+                return (func_cache[symbol], lib_name)
             end
 
             # Look up the function
@@ -83,14 +89,12 @@ function get_function_pointer(lib_name::String, func_name::String)
             if func_ptr !== nothing && func_ptr != C_NULL
                 # Cache it
                 func_cache[symbol] = func_ptr
-                return func_ptr
+                return (func_ptr, lib_name)
             end
         end
 
         # Fallback: search all other loaded libraries
-        found_libs = String[]
-        found_ptr = C_NULL
-
+        candidates = Tuple{String, Ptr{Cvoid}}[]
         for (other_lib_name, (other_lib_handle, other_func_cache)) in RUST_LIBRARIES
             if other_lib_name == lib_name
                 continue  # Already checked
@@ -98,29 +102,28 @@ function get_function_pointer(lib_name::String, func_name::String)
             symbol = exported_symbol(other_lib_name, func_name)
 
             # Check cache first
-            if haskey(other_func_cache, symbol)
-                push!(found_libs, other_lib_name)
-                found_ptr = other_func_cache[symbol]
-                continue
-            end
-
-            # Look up the function
-            func_ptr = Libdl.dlsym(other_lib_handle, symbol; throw_error=false)
-            if func_ptr !== nothing && func_ptr != C_NULL
+            ptr = get(other_func_cache, symbol, C_NULL)
+            if ptr == C_NULL
+                # Look up the function
+                found = Libdl.dlsym(other_lib_handle, symbol; throw_error=false)
+                (found === nothing || found == C_NULL) && continue
                 # Cache it
-                other_func_cache[symbol] = func_ptr
-                push!(found_libs, other_lib_name)
-                found_ptr = func_ptr
+                other_func_cache[symbol] = found
+                ptr = found
             end
+            push!(candidates, (other_lib_name, ptr))
         end
 
-        if length(found_libs) == 1
-            # Found in exactly one other library - use it
-            @debug "Function '$func_name' found in library '$(found_libs[1])' (fallback search)"
-            return found_ptr
-        elseif length(found_libs) > 1
-            # Ambiguous - found in multiple libraries
-            error("Function '$func_name' found in multiple libraries: $(join(found_libs, ", ")). Please use a unique function name.")
+        # Two names for one handle resolve to one pointer, and that is one
+        # candidate, not a conflict.
+        distinct = unique(last, candidates)
+        if length(distinct) == 1
+            owner, ptr = first(distinct)
+            @debug "Function '$func_name' found in library '$owner' (fallback search)"
+            return (ptr, owner)
+        elseif length(distinct) > 1
+            # Ambiguous - found in genuinely different libraries
+            error("Function '$func_name' found in multiple libraries: $(join(first.(candidates), ", ")). Please use a unique function name.")
         else
             # Not found anywhere
             if haskey(RUST_LIBRARIES, lib_name)
@@ -131,6 +134,19 @@ function get_function_pointer(lib_name::String, func_name::String)
         end
     end
 end
+
+"""
+    get_function_pointer(lib_name::String, func_name::String) -> Ptr{Cvoid}
+
+Get a function pointer from a loaded library.
+
+If the function is not found in the specified library, searches all other
+loaded libraries as a fallback. This enables using functions from multiple
+`rust\"\"\"` blocks. See `_resolve_call`, which a caller that also needs the
+return type should use instead so that both come from the same library.
+"""
+get_function_pointer(lib_name::String, func_name::String) =
+    first(_resolve_call(lib_name, func_name))
 
 """
     @rust_str(code)

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -732,11 +732,10 @@ function _register_return_type(sig, lib_name::String)
     ret_type === nothing && return nothing
     # Recorded under both the Rust name and the exported symbol: `@rust f(...)`
     # names the function, while a caller that already resolved the symbol (or a
-    # generated wrapper) asks for `rustcall_f`. Unlike the symbol mapping, this
-    # is only a type hint, so the pre-#279 unscoped name key stays.
+    # generated wrapper) asks for `rustcall_f`. Both keys are library-scoped —
+    # a name-only hint would outlive this library (#279).
     for key in unique((sig.name, sig.symbol))
         FUNCTION_RETURN_TYPES_BY_LIB[(lib_name, key)] = ret_type
-        FUNCTION_RETURN_TYPES[key] = ret_type
     end
     @debug "Registered return type for function: $(sig.name) (symbol $(sig.symbol)) => $ret_type (library: $lib_name)"
     return nothing

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -324,11 +324,13 @@ function _compile_and_load_rust(code::String, source_file::String, source_line::
     is_in_memory = lock(REGISTRY_LOCK) do
         haskey(RUST_LIBRARIES, lib_name)
     end
-    if is_in_memory
-        # Ensure the symbol mappings, return types and generic functions are
-        # registered (the registries are volatile). The handle is already
-        # published, so only `CURRENT_LIB[]` moves here.
-        _register_manifest(expanded, lib_name; compiler)
+    # Ensure the symbol mappings, return types and generic functions are
+    # registered (the registries are volatile). The handle is already
+    # published, so only `CURRENT_LIB[]` moves here. `require_loaded` re-checks
+    # inside the lock: an `unload_library` racing with the check above must
+    # send us down the compile path, not leave metadata behind for a library
+    # that is gone.
+    if is_in_memory && _register_manifest(expanded, lib_name; compiler, require_loaded = true)
         return lib_name
     end
 
@@ -460,11 +462,12 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
     is_in_memory = lock(REGISTRY_LOCK) do
         haskey(RUST_LIBRARIES, lib_name)
     end
-    if is_in_memory
+    # As in the rustc path: the re-check happens inside `_register_manifest`'s
+    # critical section, so a concurrent unload sends us down the build path
+    # rather than leaving metadata for a library that is gone.
+    if is_in_memory &&
+       _register_manifest(expanded, lib_name; cargo_backed = true, require_loaded = true)
         @debug "Using cached Cargo library from memory" lib_name=lib_name
-
-        _register_manifest(expanded, lib_name; cargo_backed = true)
-
         return lib_name
     end
 
@@ -612,6 +615,14 @@ and the manifest-derived lookup tables then become visible in **one**
 resolving `f` to itself and failing (or, worse, hitting another library's `f`).
 Callers must therefore not insert into `RUST_LIBRARIES` themselves.
 
+Pass `require_loaded` instead when re-registering the volatile tables of a
+library that is *already* loaded. The existence check then happens inside the
+same critical section, so an `unload_library` or hot reload racing between a
+caller's `haskey` and this call cannot leave metadata and `CURRENT_LIB[]`
+pointing at a library that is no longer in `RUST_LIBRARIES`. Returns `false`
+when the library turned out to be gone and nothing was registered; the caller
+then falls through to compiling and loading it again.
+
 The generic registrations stay outside the lock: `register_generic_function`
 may shell out to the extractor to recover a signature, which must not run with
 the global registry lock held.
@@ -619,11 +630,15 @@ the global registry lock held.
 function _register_manifest(expanded, lib_name::String; compiler = nothing,
                             cargo_backed::Bool = false,
                             handle::Union{Ptr{Cvoid}, Nothing} = nothing,
-                            set_current::Bool = true)
+                            set_current::Bool = true,
+                            require_loaded::Bool = false)
     manifest = expanded.manifest
     signatures = manifest_function_signatures(manifest; only_attributed = false)
 
-    lock(REGISTRY_LOCK) do
+    registered = lock(REGISTRY_LOCK) do
+        if require_loaded && !haskey(RUST_LIBRARIES, lib_name)
+            return false
+        end
         _register_exported_symbols!(signatures, lib_name)
         # Publishing the handle last is what closes the window: no reader can
         # find the library before its symbol mappings are in place.
@@ -631,7 +646,9 @@ function _register_manifest(expanded, lib_name::String; compiler = nothing,
             RUST_LIBRARIES[lib_name] = (handle, Dict{String, Ptr{Cvoid}}())
         end
         set_current && (CURRENT_LIB[] = lib_name)
+        return true
     end
+    registered || return false
 
     for info in manifest_struct_infos(manifest)
         register_generic_struct_wrappers(info, expanded.source; compiler)
@@ -660,7 +677,7 @@ function _register_manifest(expanded, lib_name::String; compiler = nothing,
             @debug "Registered generic function: $(sig.name)" type_params = sig.type_params
         end
     end
-    return nothing
+    return true
 end
 
 """
@@ -671,16 +688,18 @@ non-generic function of a manifest.
 
 The caller must hold `REGISTRY_LOCK` and publish the library handle in the same
 critical section, so that a task which finds the library in `RUST_LIBRARIES`
-also finds how to resolve its names (#279). The library's previous mappings are
-dropped first: a library re-registered under the same name (a re-run block, a
-hot reload) must not keep the entries of functions it no longer defines.
+also finds how to resolve its names (#279). Everything the registries recorded
+about the library is dropped first (`clear_library_metadata!`: both the symbol
+mappings and the return-type hints), so a library re-registered under the same
+name — a re-run block, a hot reload — keeps nothing about a function it no
+longer defines or now declares differently.
 
 Identity mappings are recorded too, so a plain `#[no_mangle] fn f` is
 explicitly `f => f` for this library and cannot pick up another library's
 `f => rustcall_f`.
 """
 function _register_exported_symbols!(signatures, lib_name::String)
-    clear_function_symbols!(lib_name)
+    clear_library_metadata!(lib_name)
     for sig in signatures
         sig.is_generic && continue
         sig.exported || continue
@@ -794,7 +813,7 @@ function unload_library(lib_name::String)
         delete!(RUST_LIBRARIES, lib_name)
         # A stale name-to-symbol mapping would keep redirecting lookups to a
         # symbol that is no longer loaded (#279).
-        clear_function_symbols!(lib_name)
+        clear_library_metadata!(lib_name)
         if CURRENT_LIB[] == lib_name
             CURRENT_LIB[] = ""
         end

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -624,21 +624,7 @@ function _register_manifest(expanded, lib_name::String; compiler = nothing,
     signatures = manifest_function_signatures(manifest; only_attributed = false)
 
     lock(REGISTRY_LOCK) do
-        # This library's name-to-symbol mappings are rebuilt from scratch: a
-        # block re-registered under the same library name must not keep the
-        # entries of functions it no longer defines (#279).
-        clear_function_symbols!(lib_name)
-        for sig in signatures
-            sig.is_generic && continue
-            sig.exported || continue
-            # `@rust f(...)` names the Rust function; the library exports the
-            # additive wrapper (#279), so record the mapping before the handle
-            # becomes visible. Identity mappings are recorded too, so a plain
-            # `#[no_mangle] fn f` here is explicitly `f => f` for this library
-            # and cannot pick up another library's `f => rustcall_f`.
-            register_function_symbol(lib_name, sig.name, sig.symbol)
-            _register_return_type(sig, lib_name)
-        end
+        _register_exported_symbols!(signatures, lib_name)
         # Publishing the handle last is what closes the window: no reader can
         # find the library before its symbol mappings are in place.
         if handle !== nothing
@@ -673,6 +659,33 @@ function _register_manifest(expanded, lib_name::String; compiler = nothing,
                                       path = qualified_name(sig.module_path, sig.name), compiler, blocked)
             @debug "Registered generic function: $(sig.name)" type_params = sig.type_params
         end
+    end
+    return nothing
+end
+
+"""
+    _register_exported_symbols!(signatures, lib_name)
+
+Record the name-to-symbol mapping and the return type of every exported,
+non-generic function of a manifest.
+
+The caller must hold `REGISTRY_LOCK` and publish the library handle in the same
+critical section, so that a task which finds the library in `RUST_LIBRARIES`
+also finds how to resolve its names (#279). The library's previous mappings are
+dropped first: a library re-registered under the same name (a re-run block, a
+hot reload) must not keep the entries of functions it no longer defines.
+
+Identity mappings are recorded too, so a plain `#[no_mangle] fn f` is
+explicitly `f => f` for this library and cannot pick up another library's
+`f => rustcall_f`.
+"""
+function _register_exported_symbols!(signatures, lib_name::String)
+    clear_function_symbols!(lib_name)
+    for sig in signatures
+        sig.is_generic && continue
+        sig.exported || continue
+        register_function_symbol(lib_name, sig.name, sig.symbol)
+        _register_return_type(sig, lib_name)
     end
     return nothing
 end

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -713,13 +713,30 @@ longer defines or now declares differently.
 Identity mappings are recorded too, so a plain `#[no_mangle] fn f` is
 explicitly `f => f` for this library and cannot pick up another library's
 `f => rustcall_f`.
+
+A manifest may report one symbol twice. `@rust_crate` and the hot reload scan
+an external crate leniently — only target predicates are decided, because the
+crate's own features and build script are not RustCall's to evaluate — so
+mutually exclusive `#[cfg(feature = ...)]` variants of one `#[julia] fn` both
+survive. The symbol mapping is the same either way and is recorded, but the
+**return type is not**: source order is not evidence of which variant was
+built, and a wrong primitive hint is a wrong ABI. Such a call falls through to
+inference or an explicit `::T` instead. Deciding an external crate's features
+exactly needs the crate's own build configuration, which #277 Phase B owns.
 """
 function _register_exported_symbols!(signatures, lib_name::String)
     clear_library_metadata!(lib_name)
-    for sig in signatures
-        sig.is_generic && continue
-        sig.exported || continue
+    exported = [sig for sig in signatures if !sig.is_generic && sig.exported]
+    occurrences = Dict{String, Int}()
+    for sig in exported
+        occurrences[sig.symbol] = get(occurrences, sig.symbol, 0) + 1
+    end
+    for sig in exported
         register_function_symbol(lib_name, sig.name, sig.symbol)
+        if occurrences[sig.symbol] > 1
+            @debug "Ambiguous manifest entry: not registering a return type" symbol = sig.symbol lib_name
+            continue
+        end
         _register_return_type(sig, lib_name)
     end
     return nothing

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -10,7 +10,9 @@
 
 A method of a `#[julia]` struct as recorded in the manifest.
 
-- `symbol`: exported wrapper symbol (`Struct_method`); empty for generic structs
+- `symbol`: exported wrapper symbol (`rustcall_<Struct>_<method>`, #279); empty
+  for generic structs, and for a method built by hand rather than read from a
+  manifest, where the emitters fall back to `method_wrapper_symbol`
 - `is_constructor`: static `new`, or any method returning `Self`/the struct type
 - `generic_wrapper`: generic wrapper source registered for monomorphization
 """
@@ -36,6 +38,23 @@ function RustMethod(name::String, is_static::Bool, is_mutable::Bool, arg_names::
                     return_abi::String = _default_return_abi(return_type, arg_abis))
     RustMethod(name, is_static, is_mutable, arg_names, arg_types, return_type,
                symbol, is_constructor, generic_wrapper, arg_abis, return_abi)
+end
+
+"""
+    method_wrapper_symbol(struct_name, method::RustMethod) -> String
+
+The exported symbol the Julia wrapper of a **concrete** struct method calls.
+
+Manifest-backed methods carry it in `symbol` (`rustcall_<Struct>_<method>`
+since #279). The six-argument `RustMethod` constructor cannot know the struct
+name, so a hand-built method records none; rather than emit `_get_func_ptr("")`
+the symbol is derived from the same scheme here. Generic structs never take
+this path: their wrappers are monomorphized by name and are addressed through
+`generic_wrapper`, not through a symbol.
+"""
+function method_wrapper_symbol(struct_name::AbstractString, method::RustMethod)
+    isempty(method.symbol) || return method.symbol
+    return ffi_method_symbol(struct_name, method.name)
 end
 
 """
@@ -317,8 +336,9 @@ function emit_julia_definitions(info::RustStructInfo)
     # 2. Add constructors and methods
     for m in info.methods
         fname = esc(Symbol(m.name))
-        # Exported symbol of the method wrapper, `rustcall_<Struct>_<method>` (#279).
-        wrapper_name = m.symbol
+        # Exported symbol of the method wrapper, `rustcall_<Struct>_<method>`
+        # (#279); derived when a hand-built `RustMethod` carries none.
+        wrapper_name = method_wrapper_symbol(struct_name_str, m)
 
         is_ctor = m.is_constructor
 

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -591,6 +591,50 @@ end
         @test occursin("_check_not_freed", code)
     end
 
+    # #279 follow-up: the six-argument `RustMethod` constructor cannot know the
+    # struct name, so a hand-built method carries no `symbol`. The emitters must
+    # derive `rustcall_<Struct>_<method>` rather than emit `_get_func_ptr("")`.
+    @testset "hand-built RustMethod falls back to the rustcall_ symbol" begin
+        ctor = RustCall.RustMethod("new", true, false, ["x", "y"], ["f64", "f64"], "Self")
+        getter = RustCall.RustMethod("norm", false, false, String[], String[], "f64")
+        shout = RustCall.RustMethod("shout", false, false, ["s"], ["String"], "String")
+        @test ctor.symbol == ""
+        @test RustCall.method_wrapper_symbol("Point", ctor) == "rustcall_Point_new"
+        @test RustCall.method_wrapper_symbol("Point", getter) == "rustcall_Point_norm"
+        # A manifest-backed symbol always wins over the derived one.
+        manifest_backed = RustCall.RustMethod("norm", false, false, String[], String[], "f64";
+                                              symbol = "rustcall_Other_norm")
+        @test RustCall.method_wrapper_symbol("Point", manifest_backed) == "rustcall_Other_norm"
+
+        struct_info = RustCall.RustStructInfo(
+            "Point", String[], [ctor, getter, shout], "",
+            [("x", "f64"), ("y", "f64")], true, Dict{String, Bool}()
+        )
+
+        # Source-text emitter (write_bindings_to_file).
+        for m in struct_info.methods
+            code = RustCall._emit_method_code(struct_info, m)
+            @test occursin("_get_func_ptr(\"rustcall_Point_$(m.name)\")", code)
+            @test !occursin("_get_func_ptr(\"\")", code)
+        end
+        # The string buffers stay named after the method, not after the symbol.
+        @test occursin("_get_func_ptr(\"Point_shout_free_rust_string\")",
+                       RustCall._emit_method_code(struct_info, shout))
+
+        # In-memory emitter (@rust_crate).
+        for m in struct_info.methods
+            expr = string(RustCall._generate_crate_method_wrapper(struct_info, m))
+            @test occursin("rustcall_Point_$(m.name)", expr)
+            @test !occursin("_get_func_ptr(\"\")", expr)
+        end
+
+        # Julia struct emitter (inline blocks).
+        defs = string(RustCall.emit_julia_definitions(struct_info))
+        @test occursin("rustcall_Point_new", defs)
+        @test occursin("rustcall_Point_norm", defs)
+        @test !occursin("\"\"", defs)
+    end
+
     @testset "_emit_struct_code finalizer is exception-safe" begin
         struct_info = RustCall.RustStructInfo(
             "SafeStruct",

--- a/test/test_hot_reload.jl
+++ b/test/test_hot_reload.jl
@@ -212,9 +212,29 @@ end
             state = RustCall.enable_hot_reload(lib_name, SAMPLE_CRATE_PATH)
             @test state !== nothing
 
+            # Metadata a previous build of this library left behind: a
+            # function that no longer exists, and a return-type hint for it.
+            # The reload rebuilds the tables from the rescanned manifest, so
+            # both must be gone afterwards (#279).
+            lock(RustCall.REGISTRY_LOCK) do
+                RustCall.FUNCTION_SYMBOLS_BY_LIB[(lib_name, "ghost_fn")] = "rustcall_ghost_fn"
+                RustCall.FUNCTION_RETURN_TYPES_BY_LIB[(lib_name, "ghost_fn")] = Int32
+                RustCall.FUNCTION_RETURN_TYPES["ghost_fn"] = Int32
+                # A stale hint for a function that *does* still exist, under a
+                # type the crate never declared.
+                RustCall.FUNCTION_RETURN_TYPES_BY_LIB[(lib_name, sig.name)] = Bool
+            end
+
             # Whatever the enable path left behind, a reload must end with the
             # mappings in place next to the new handle.
             RustCall.trigger_reload(lib_name)
+
+            # The stale entries are gone, including the unscoped fallback that
+            # no other library claims.
+            @test RustCall.exported_symbol(lib_name, "ghost_fn") == "ghost_fn"
+            @test RustCall.get_function_return_type(lib_name, "ghost_fn") === nothing
+            # ... and the surviving function's hint was rebuilt, not kept.
+            @test RustCall.get_function_return_type(lib_name, sig.name) !== Bool
 
             @test RustCall.exported_symbol(lib_name, sig.name) == sig.symbol
             @test haskey(RustCall.RUST_LIBRARIES, lib_name)
@@ -226,7 +246,7 @@ end
             empty!(RustCall.HOT_RELOAD_REGISTRY)
             lock(RustCall.REGISTRY_LOCK) do
                 delete!(RustCall.RUST_LIBRARIES, lib_name)
-                RustCall.clear_function_symbols!(lib_name)
+                RustCall.clear_library_metadata!(lib_name)
             end
         end
     end

--- a/test/test_hot_reload.jl
+++ b/test/test_hot_reload.jl
@@ -195,6 +195,42 @@ end
         end
     end
 
+    # #279 follow-up: unloading a library drops its name-to-symbol mappings, so
+    # a reload has to rebuild them from a fresh scan of the crate. Without that,
+    # the first reload leaves `get_function_pointer(lib, "f")` hunting for the
+    # symbol `f` while the rebuilt library exports `rustcall_f`.
+    @testset "reload restores the name -> symbol mappings (#279)" begin
+        empty!(RustCall.HOT_RELOAD_REGISTRY)
+        lib_name = "SampleCrateSymbols"
+
+        # A `#[julia]` function the sample crate exports under a prefixed symbol.
+        attributed = RustCall.scan_crate(SAMPLE_CRATE_PATH).julia_functions
+        sig = first(f for f in attributed if !f.is_generic && f.exported)
+        @test sig.symbol == "rustcall_" * sig.name
+
+        try
+            state = RustCall.enable_hot_reload(lib_name, SAMPLE_CRATE_PATH)
+            @test state !== nothing
+
+            # Whatever the enable path left behind, a reload must end with the
+            # mappings in place next to the new handle.
+            RustCall.trigger_reload(lib_name)
+
+            @test RustCall.exported_symbol(lib_name, sig.name) == sig.symbol
+            @test haskey(RustCall.RUST_LIBRARIES, lib_name)
+            ptr = RustCall.get_function_pointer(lib_name, sig.name)
+            @test ptr != C_NULL
+        finally
+            RustCall.disable_all_hot_reload()
+            sleep(0.1)
+            empty!(RustCall.HOT_RELOAD_REGISTRY)
+            lock(RustCall.REGISTRY_LOCK) do
+                delete!(RustCall.RUST_LIBRARIES, lib_name)
+                RustCall.clear_function_symbols!(lib_name)
+            end
+        end
+    end
+
     @testset "Check for changes" begin
         # Clear registry
         empty!(RustCall.HOT_RELOAD_REGISTRY)

--- a/test/test_hot_reload.jl
+++ b/test/test_hot_reload.jl
@@ -219,7 +219,6 @@ end
             lock(RustCall.REGISTRY_LOCK) do
                 RustCall.FUNCTION_SYMBOLS_BY_LIB[(lib_name, "ghost_fn")] = "rustcall_ghost_fn"
                 RustCall.FUNCTION_RETURN_TYPES_BY_LIB[(lib_name, "ghost_fn")] = Int32
-                RustCall.FUNCTION_RETURN_TYPES["ghost_fn"] = Int32
                 # A stale hint for a function that *does* still exist, under a
                 # type the crate never declared.
                 RustCall.FUNCTION_RETURN_TYPES_BY_LIB[(lib_name, sig.name)] = Bool
@@ -229,8 +228,7 @@ end
             # mappings in place next to the new handle.
             RustCall.trigger_reload(lib_name)
 
-            # The stale entries are gone, including the unscoped fallback that
-            # no other library claims.
+            # The stale entries are gone.
             @test RustCall.exported_symbol(lib_name, "ghost_fn") == "ghost_fn"
             @test RustCall.get_function_return_type(lib_name, "ghost_fn") === nothing
             # ... and the surviving function's hint was rebuilt, not kept.

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -321,10 +321,12 @@ _count_in(name, needle) = count(_ -> true, eachmatch(needle, _src(name)))
             writes += count(_ -> true,
                             eachmatch(r"RUST_LIBRARIES\[[^\]]*\]\s*=", _src(file)))
         end
-        # Eight open-coded registration sites on current main: five in
-        # ruststr.jl, generics.jl, hot_reload.jl, and the reload alias that
-        # #272 added in rustmacro.jl (`_alias_reloaded_library`).
-        @test writes == 8
+        # Five open-coded registration sites on current main: two in
+        # ruststr.jl (`_register_manifest`, which publishes an inline block's
+        # handle together with its symbol mappings since #279, and the `@irust`
+        # loader), generics.jl, hot_reload.jl, and the reload alias that #272
+        # added in rustmacro.jl (`_alias_reloaded_library`).
+        @test writes == 5
 
         # Each site decides for itself whether CURRENT_LIB moves and what the
         # key looks like; the policies record that disagreement.

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -657,17 +657,121 @@ end
         @test RustCall.exported_symbol(stored, "aliased_probe") == "rustcall_aliased_probe"
         ptr = RustCall.get_function_pointer(stored, "aliased_probe")
         @test RustCall.call_rust_function(ptr, Int32, Int32(5)) == Int32(4)
+        # The return-type hints travel with the mappings.
+        @test RustCall.get_function_return_type(stored, "aliased_probe") === Int32
 
         # Dropping the alias must not disturb the library it pointed at.
-        RustCall.clear_function_symbols!(stored)
+        RustCall.clear_library_metadata!(stored)
         @test RustCall.exported_symbol(actual, "aliased_probe") == "rustcall_aliased_probe"
+        @test RustCall.get_function_return_type(actual, "aliased_probe") === Int32
     finally
         for name in (stored, actual)
             lock(RustCall.REGISTRY_LOCK) do
                 delete!(RustCall.RUST_LIBRARIES, name)
-                RustCall.clear_function_symbols!(name)
+                RustCall.clear_library_metadata!(name)
             end
         end
         Libdl.dlclose(handle)
+    end
+end
+
+# #279 follow-up: the alias must carry the return-type hints too, not just the
+# symbol mappings. Otherwise an untyped `@rust f(...)` through the stored name
+# misses the library-scoped entry and takes the unscoped fallback, which holds
+# whatever *another* block last registered for that name.
+@testset "#279: an aliased library keeps its return-type hints" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping alias return-type test"
+        return
+    end
+
+    # Two blocks declaring the same Rust name with different return types.
+    expanded_i32 = RustCall.expand_inline("""
+    #[julia]
+    pub fn alias_typed(x: i32) -> i32 { x }
+    """)
+    expanded_f64 = RustCall.expand_inline("""
+    #[julia]
+    pub fn alias_typed(x: i32) -> f64 { x as f64 }
+    """)
+    path_i32 = RustCall.compile_rust_to_shared_lib(expanded_i32.source)
+    path_f64 = RustCall.compile_rust_to_shared_lib(expanded_f64.source)
+    lib_i32 = "test279_ret_i32_" * string(hash(path_i32), base = 16)
+    lib_f64 = "test279_ret_f64_" * string(hash(path_f64), base = 16)
+    stored = "test279_ret_stored_" * string(hash(path_i32), base = 16)
+    handle_i32 = Libdl.dlopen(path_i32, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+    handle_f64 = Libdl.dlopen(path_f64, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+
+    try
+        RustCall._register_manifest(expanded_i32, lib_i32; handle = handle_i32, set_current = false)
+        # Registered second, so the unscoped fallback now says Float64.
+        RustCall._register_manifest(expanded_f64, lib_f64; handle = handle_f64, set_current = false)
+        @test RustCall.get_function_return_type(lib_i32, "alias_typed") === Int32
+        @test RustCall.get_function_return_type(lib_f64, "alias_typed") === Float64
+        @test RustCall.get_function_return_type("test279_ret_unknown", "alias_typed") === Float64
+
+        # Aliasing the i32 block must give the alias *its* type, not the
+        # fallback the f64 block left behind.
+        RustCall._alias_reloaded_library(Main, stored, lib_i32)
+        @test RustCall.get_function_return_type(stored, "alias_typed") === Int32
+        @test RustCall.exported_symbol(stored, "alias_typed") == "rustcall_alias_typed"
+    finally
+        for name in (stored, lib_i32, lib_f64)
+            lock(RustCall.REGISTRY_LOCK) do
+                delete!(RustCall.RUST_LIBRARIES, name)
+                RustCall.clear_library_metadata!(name)
+            end
+        end
+        Libdl.dlclose(handle_i32)
+        Libdl.dlclose(handle_f64)
+    end
+end
+
+# #279 follow-up: the in-memory hit re-registers a library's volatile tables.
+# The existence check and the registration must be one transaction, or an
+# unload racing between them leaves metadata and `CURRENT_LIB[]` pointing at a
+# library that is no longer in `RUST_LIBRARIES`.
+@testset "#279: re-registering an unloaded library is refused" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping unload-race test"
+        return
+    end
+
+    expanded = RustCall.expand_inline("""
+    #[julia]
+    pub fn raced_probe(x: i32) -> i32 { x + 2 }
+    """)
+    path = RustCall.compile_rust_to_shared_lib(expanded.source)
+    lib_name = "test279_raced_" * string(hash(path), base = 16)
+    handle = Libdl.dlopen(path, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+    previous_current = RustCall.get_current_library()
+
+    try
+        RustCall._register_manifest(expanded, lib_name; handle = handle, set_current = false)
+        @test RustCall.exported_symbol(lib_name, "raced_probe") == "rustcall_raced_probe"
+
+        # The library goes away between a caller's `haskey` and its
+        # re-registration; the guarded call must decline rather than register
+        # metadata for a name that is no longer loaded.
+        RustCall.unload_library(lib_name)
+        @test !haskey(RustCall.RUST_LIBRARIES, lib_name)
+        @test !RustCall._register_manifest(expanded, lib_name; require_loaded = true)
+
+        # Nothing was left behind, and CURRENT_LIB does not dangle.
+        @test RustCall.exported_symbol(lib_name, "raced_probe") == "raced_probe"
+        @test RustCall.get_function_return_type(lib_name, "raced_probe") === nothing
+        @test RustCall.get_current_library() != lib_name
+
+        # Without the guard the caller is the one publishing the handle, which
+        # is still allowed and still atomic.
+        handle2 = Libdl.dlopen(path, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+        @test RustCall._register_manifest(expanded, lib_name; handle = handle2, set_current = false)
+        @test RustCall.exported_symbol(lib_name, "raced_probe") == "rustcall_raced_probe"
+    finally
+        haskey(RustCall.RUST_LIBRARIES, lib_name) && RustCall.unload_library(lib_name)
+        lock(RustCall.REGISTRY_LOCK) do
+            RustCall.clear_library_metadata!(lib_name)
+            RustCall.CURRENT_LIB[] = previous_current
+        end
     end
 end

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -843,3 +843,138 @@ end
         foreach(Libdl.dlclose, handles)
     end
 end
+
+# #279 follow-up: `_alias_reloaded_library` deliberately leaves one handle in
+# `RUST_LIBRARIES` under two names. The cross-library fallback must not count
+# that as two candidates, or every multi-block precompiled module raises the
+# ambiguity error after any identity change.
+@testset "#279: an aliased handle is one candidate, not an ambiguity" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping alias ambiguity test"
+        return
+    end
+
+    expanded_one = RustCall.expand_inline("""
+    #[julia]
+    pub fn aliased_block_fn(x: i32) -> i32 { x * 2 }
+    """)
+    expanded_two = RustCall.expand_inline("""
+    #[julia]
+    pub fn sibling_block_fn(x: i32) -> i32 { x + 3 }
+    """)
+    path_one = RustCall.compile_rust_to_shared_lib(expanded_one.source)
+    path_two = RustCall.compile_rust_to_shared_lib(expanded_two.source)
+    actual = "test279_amb_actual_" * string(hash(path_one), base = 16)
+    stored = "test279_amb_stored_" * string(hash(path_one), base = 16)
+    sibling = "test279_amb_sibling_" * string(hash(path_two), base = 16)
+    handle_one = Libdl.dlopen(path_one, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+    handle_two = Libdl.dlopen(path_two, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+
+    try
+        RustCall._register_manifest(expanded_one, actual; handle = handle_one, set_current = false)
+        RustCall._register_manifest(expanded_two, sibling; handle = handle_two, set_current = false)
+        # The reload path: one handle, two names.
+        RustCall._alias_reloaded_library(Main, stored, actual)
+        @test RustCall.RUST_LIBRARIES[stored][1] == RustCall.RUST_LIBRARIES[actual][1]
+
+        # Looking the aliased block's function up from the *sibling* block has
+        # to fall back across libraries and finds it twice, through the same
+        # handle. That is one function, not a conflict.
+        ptr_via_sibling = RustCall.get_function_pointer(sibling, "aliased_block_fn")
+        ptr_direct = RustCall.get_function_pointer(actual, "aliased_block_fn")
+        ptr_via_alias = RustCall.get_function_pointer(stored, "aliased_block_fn")
+        @test ptr_via_sibling == ptr_direct == ptr_via_alias
+        @test RustCall.call_rust_function(ptr_via_sibling, Int32, Int32(4)) == Int32(8)
+
+        # And the other block's function still resolves from the aliased names.
+        ptr_sibling_fn = RustCall.get_function_pointer(stored, "sibling_block_fn")
+        @test RustCall.call_rust_function(ptr_sibling_fn, Int32, Int32(4)) == Int32(7)
+
+        # Two genuinely different libraries exporting one name are still refused.
+        expanded_clash = RustCall.expand_inline("""
+        #[julia]
+        pub fn aliased_block_fn(x: i32) -> i32 { x * 5 }
+        """)
+        path_clash = RustCall.compile_rust_to_shared_lib(expanded_clash.source)
+        clash = "test279_amb_clash_" * string(hash(path_clash), base = 16)
+        handle_clash = Libdl.dlopen(path_clash, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+        try
+            RustCall._register_manifest(expanded_clash, clash; handle = handle_clash, set_current = false)
+            @test_throws ErrorException RustCall.get_function_pointer(sibling, "aliased_block_fn")
+        finally
+            haskey(RustCall.RUST_LIBRARIES, clash) && RustCall.unload_library(clash)
+            RustCall.clear_library_metadata!(clash)
+            Libdl.dlclose(handle_clash)
+        end
+    finally
+        for name in (stored, actual, sibling)
+            haskey(RustCall.RUST_LIBRARIES, name) && RustCall.unload_library(name)
+            RustCall.clear_library_metadata!(name)
+        end
+        Libdl.dlclose(handle_one)
+        Libdl.dlclose(handle_two)
+    end
+end
+
+# #279 follow-up: the pointer and the return type must come from the same
+# library. A library whose `f` returns `Result` records no hint on purpose;
+# another library's primitive hint for the same name would call it with the
+# wrong ABI.
+@testset "#279: a return-type hint is never borrowed across libraries" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping cross-library ABI test"
+        return
+    end
+
+    # A: `Result` return, so no hint is registered at all.
+    expanded_a = RustCall.expand_inline("""
+    #[julia]
+    pub fn abi_probe(x: i32) -> Result<i32, i32> { Ok(x) }
+    """)
+    # B: a plain f64 return, which does register a hint.
+    expanded_b = RustCall.expand_inline("""
+    #[julia]
+    pub fn abi_probe(x: i32) -> f64 { x as f64 }
+    """)
+    path_a = RustCall.compile_rust_to_shared_lib(expanded_a.source)
+    path_b = RustCall.compile_rust_to_shared_lib(expanded_b.source)
+    lib_a = "test279_abi_a_" * string(hash(path_a), base = 16)
+    lib_b = "test279_abi_b_" * string(hash(path_b), base = 16)
+    handle_a = Libdl.dlopen(path_a, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+    handle_b = Libdl.dlopen(path_b, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+
+    try
+        RustCall._register_manifest(expanded_a, lib_a; handle = handle_a, set_current = false)
+        RustCall._register_manifest(expanded_b, lib_b; handle = handle_b, set_current = false)
+
+        # A records nothing; B's Float64 must not leak into A.
+        @test RustCall.get_function_return_type(lib_a, "abi_probe") === nothing
+        @test RustCall.get_function_return_type(lib_b, "abi_probe") === Float64
+
+        # The pointer and the owning library agree, for each library.
+        ptr_a, owner_a = RustCall._resolve_call(lib_a, "abi_probe")
+        ptr_b, owner_b = RustCall._resolve_call(lib_b, "abi_probe")
+        @test owner_a == lib_a && owner_b == lib_b
+        @test ptr_a != ptr_b
+
+        # An untyped call into B uses B's own hint.
+        @test RustCall._rust_call_dynamic(lib_b, "abi_probe", Int32(3)) == 3.0
+
+        # An untyped call into A must not come back as B's `Float64`: with no
+        # hint it falls through to inference, which for a `CResult_abi_probe`
+        # return cannot produce a Float64.
+        untyped_a = try
+            RustCall._rust_call_dynamic(lib_a, "abi_probe", Int32(3))
+        catch error
+            error
+        end
+        @test !(untyped_a isa Float64)
+    finally
+        for name in (lib_a, lib_b)
+            haskey(RustCall.RUST_LIBRARIES, name) && RustCall.unload_library(name)
+            RustCall.clear_library_metadata!(name)
+        end
+        Libdl.dlclose(handle_a)
+        Libdl.dlclose(handle_b)
+    end
+end

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -583,3 +583,47 @@ end
         unload!(lib_b)
     end
 end
+
+# #279 follow-up: a library handle and the name-to-symbol mappings its manifest
+# describes must become visible together. Publishing the handle first left a
+# window in which a concurrent `ensure_loaded` / `@rust f(...)` saw the library
+# but not the mapping, and resolved `f` to `f` instead of `rustcall_f`.
+@testset "#279: a library and its symbol mappings are published together" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping concurrent publication test"
+        return
+    end
+
+    rust"""
+    #[julia]
+    pub fn concurrent_probe(x: i32) -> i32 { x * 7 }
+    """
+    lib_name = RustCall.get_current_library()
+
+    # The mapping is in place for the library that is now current.
+    @test RustCall.exported_symbol(lib_name, "concurrent_probe") == "rustcall_concurrent_probe"
+
+    # Several tasks calling the attributed function concurrently: every call
+    # resolves and returns, none races the publication of the handle.
+    results = Vector{Int32}(undef, 32)
+    @sync for i in 1:length(results)
+        Threads.@spawn begin
+            results[i] = concurrent_probe(Int32(i))
+        end
+    end
+    @test results == Int32[i * 7 for i in 1:length(results)]
+
+    # The same through `@rust`, which resolves the Rust name at call time.
+    macro_results = Vector{Int32}(undef, 16)
+    @sync for i in 1:length(macro_results)
+        Threads.@spawn begin
+            macro_results[i] = @rust concurrent_probe(Int32(i))::Int32
+        end
+    end
+    @test macro_results == Int32[i * 7 for i in 1:length(macro_results)]
+
+    # Reloading the very same block (the in-memory hit path) keeps the mapping.
+    RustCall.ensure_loaded(lib_name, "#[julia]\npub fn concurrent_probe(x: i32) -> i32 { x * 7 }")
+    @test RustCall.exported_symbol(lib_name, "concurrent_probe") == "rustcall_concurrent_probe"
+    @test concurrent_probe(Int32(3)) == Int32(21)
+end

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -836,11 +836,13 @@ end
         RustCall.unload_library(lib_b)
         @test RustCall.get_function_return_type(lib_a, "stale_probe") === nothing
     finally
+        # Every handle here was published into RUST_LIBRARIES, and
+        # `unload_library` dlcloses what it removes — closing them again here
+        # would be a double close.
         for name in (lib_a, lib_b)
             haskey(RustCall.RUST_LIBRARIES, name) && RustCall.unload_library(name)
             RustCall.clear_library_metadata!(name)
         end
-        foreach(Libdl.dlclose, handles)
     end
 end
 
@@ -904,15 +906,19 @@ end
         finally
             haskey(RustCall.RUST_LIBRARIES, clash) && RustCall.unload_library(clash)
             RustCall.clear_library_metadata!(clash)
-            Libdl.dlclose(handle_clash)
         end
     finally
-        for name in (stored, actual, sibling)
+        # `stored` and `actual` are two names for one handle: drop the alias
+        # without unloading, so the handle is dlclosed exactly once (by
+        # `unload_library(actual)`), and never again here.
+        lock(RustCall.REGISTRY_LOCK) do
+            delete!(RustCall.RUST_LIBRARIES, stored)
+        end
+        RustCall.clear_library_metadata!(stored)
+        for name in (actual, sibling)
             haskey(RustCall.RUST_LIBRARIES, name) && RustCall.unload_library(name)
             RustCall.clear_library_metadata!(name)
         end
-        Libdl.dlclose(handle_one)
-        Libdl.dlclose(handle_two)
     end
 end
 
@@ -970,11 +976,83 @@ end
         end
         @test !(untyped_a isa Float64)
     finally
+        # `unload_library` dlcloses both handles; do not close them again.
         for name in (lib_a, lib_b)
             haskey(RustCall.RUST_LIBRARIES, name) && RustCall.unload_library(name)
             RustCall.clear_library_metadata!(name)
         end
-        Libdl.dlclose(handle_a)
-        Libdl.dlclose(handle_b)
+    end
+end
+
+# #279 follow-up: an external crate is scanned leniently — only target
+# predicates are decided, because its own features and build script are not
+# RustCall's to evaluate — so mutually exclusive `#[cfg(feature = ...)]`
+# variants of one `#[julia] fn` both reach the registry. Source order is not
+# evidence of which one was built, so no return type may be registered for
+# them; a wrong primitive hint would be a wrong ABI. (Deciding the crate's
+# features exactly belongs to #277 Phase B.)
+@testset "#279: ambiguous cfg variants register no return type" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping ambiguous cfg variant test"
+        return
+    end
+
+    mktempdir() do dir
+        mkpath(joinpath(dir, "src"))
+        write(joinpath(dir, "Cargo.toml"), """
+        [package]
+        name = "cfg_variant_probe"
+        version = "0.0.0"
+        edition = "2021"
+
+        [features]
+        a = []
+
+        [lib]
+        crate-type = ["cdylib"]
+        """)
+        write(joinpath(dir, "src", "lib.rs"), """
+        use juliacall_macros::julia;
+
+        #[cfg(feature = "a")]
+        #[julia]
+        pub fn variant_probe() -> i32 { 1 }
+
+        #[cfg(not(feature = "a"))]
+        #[julia]
+        pub fn variant_probe() -> f64 { 1.0 }
+
+        #[julia]
+        pub fn unambiguous_probe() -> i32 { 2 }
+        """)
+
+        # The lenient scan the crate paths use keeps both variants.
+        info = RustCall.scan_crate(dir)
+        variants = filter(f -> f.name == "variant_probe", info.julia_functions)
+        @test length(variants) == 2
+        @test Set(f.return_type for f in variants) == Set(["i32", "f64"])
+        @test all(f -> f.symbol == "rustcall_variant_probe", variants)
+
+        lib_name = "test279_cfg_variant"
+        try
+            lock(RustCall.REGISTRY_LOCK) do
+                RustCall._register_exported_symbols!(info.julia_functions, lib_name)
+            end
+
+            # The symbol is unambiguous, so it is recorded ...
+            @test RustCall.exported_symbol(lib_name, "variant_probe") ==
+                  "rustcall_variant_probe"
+            # ... but neither variant's return type is, so an untyped call
+            # falls through to inference rather than to the wrong ABI.
+            @test RustCall.get_function_return_type(lib_name, "variant_probe") === nothing
+            @test RustCall.get_function_return_type(lib_name, "rustcall_variant_probe") === nothing
+
+            # A function with only one variant is unaffected.
+            @test RustCall.exported_symbol(lib_name, "unambiguous_probe") ==
+                  "rustcall_unambiguous_probe"
+            @test RustCall.get_function_return_type(lib_name, "unambiguous_probe") === Int32
+        finally
+            RustCall.clear_library_metadata!(lib_name)
+        end
     end
 end

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -16,20 +16,23 @@ signature_for(code, name; mode = "inline") = only(
 
 @testset "Known Regressions" begin
     @testset "Library-scoped return type metadata" begin
-        empty!(RustCall.FUNCTION_RETURN_TYPES)
         empty!(RustCall.FUNCTION_RETURN_TYPES_BY_LIB)
 
         code_i32 = "#[no_mangle] pub extern \"C\" fn same_name() -> i32 { 1 }"
         code_f64 = "#[no_mangle] pub extern \"C\" fn same_name() -> f64 { 1.0 }"
 
         RustCall._register_manifest(RustCall.expand_inline(code_i32), "lib_i32")
-        @test RustCall.FUNCTION_RETURN_TYPES["same_name"] == Int32
+        @test RustCall.FUNCTION_RETURN_TYPES_BY_LIB[("lib_i32", "same_name")] == Int32
         @test RustCall.get_function_return_type("lib_i32", "same_name") == Int32
 
         RustCall._register_manifest(RustCall.expand_inline(code_f64), "lib_f64")
-        @test RustCall.FUNCTION_RETURN_TYPES["same_name"] == Float64
+        @test RustCall.FUNCTION_RETURN_TYPES_BY_LIB[("lib_f64", "same_name")] == Float64
         @test RustCall.get_function_return_type("lib_i32", "same_name") == Int32
         @test RustCall.get_function_return_type("lib_f64", "same_name") == Float64
+        # Neither library answers for a third one: registering `same_name`
+        # twice makes the cross-library hint ambiguous, and there is no
+        # name-only table that could pick a winner (#279).
+        @test RustCall.get_function_return_type("lib_other", "same_name") === nothing
     end
 
     @testset "Library-scoped return type is used by dynamic calls" begin
@@ -677,8 +680,8 @@ end
 
 # #279 follow-up: the alias must carry the return-type hints too, not just the
 # symbol mappings. Otherwise an untyped `@rust f(...)` through the stored name
-# misses the library-scoped entry and takes the unscoped fallback, which holds
-# whatever *another* block last registered for that name.
+# misses the library-scoped entry and either takes another library's answer or
+# none at all, instead of the type the aliased block declared.
 @testset "#279: an aliased library keeps its return-type hints" begin
     if !RustCall.check_rustc_available()
         @warn "rustc not found, skipping alias return-type test"
@@ -704,14 +707,15 @@ end
 
     try
         RustCall._register_manifest(expanded_i32, lib_i32; handle = handle_i32, set_current = false)
-        # Registered second, so the unscoped fallback now says Float64.
         RustCall._register_manifest(expanded_f64, lib_f64; handle = handle_f64, set_current = false)
         @test RustCall.get_function_return_type(lib_i32, "alias_typed") === Int32
         @test RustCall.get_function_return_type(lib_f64, "alias_typed") === Float64
-        @test RustCall.get_function_return_type("test279_ret_unknown", "alias_typed") === Float64
+        # Two libraries declare the name, so a third gets no answer at all
+        # rather than an arbitrary one.
+        @test RustCall.get_function_return_type("test279_ret_unknown", "alias_typed") === nothing
 
-        # Aliasing the i32 block must give the alias *its* type, not the
-        # fallback the f64 block left behind.
+        # Aliasing the i32 block must give the alias *its* type, not the other
+        # block's and not nothing.
         RustCall._alias_reloaded_library(Main, stored, lib_i32)
         @test RustCall.get_function_return_type(stored, "alias_typed") === Int32
         @test RustCall.exported_symbol(stored, "alias_typed") == "rustcall_alias_typed"
@@ -773,5 +777,69 @@ end
             RustCall.clear_library_metadata!(lib_name)
             RustCall.CURRENT_LIB[] = previous_current
         end
+    end
+end
+
+# #279 follow-up: a return-type hint must never outlive the library that
+# registered it. There is no name-only table, so clearing or rebuilding a
+# library cannot leave its type answering for anyone else's function of the
+# same name.
+@testset "#279: return-type hints do not outlive their library" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping stale return-type test"
+        return
+    end
+
+    expanded_a = RustCall.expand_inline("""
+    #[julia]
+    pub fn stale_probe(x: i32) -> i32 { x }
+    """)
+    expanded_b = RustCall.expand_inline("""
+    #[julia]
+    pub fn stale_probe(x: i32) -> f64 { x as f64 }
+    """)
+    # The rebuilt A returns `Result`, for which no hint is recorded at all:
+    # an untyped call must fall through to inference, never to A's old `Int32`.
+    expanded_a2 = RustCall.expand_inline("""
+    #[julia]
+    pub fn stale_probe(x: i32) -> Result<i32, i32> { Ok(x) }
+    """)
+
+    path_a = RustCall.compile_rust_to_shared_lib(expanded_a.source)
+    path_b = RustCall.compile_rust_to_shared_lib(expanded_b.source)
+    path_a2 = RustCall.compile_rust_to_shared_lib(expanded_a2.source)
+    lib_a = "test279_stale_a_" * string(hash(path_a), base = 16)
+    lib_b = "test279_stale_b_" * string(hash(path_b), base = 16)
+    handles = [Libdl.dlopen(p, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+               for p in (path_a, path_b, path_a2)]
+
+    try
+        RustCall._register_manifest(expanded_a, lib_a; handle = handles[1], set_current = false)
+        RustCall._register_manifest(expanded_b, lib_b; handle = handles[2], set_current = false)
+        @test RustCall.get_function_return_type(lib_a, "stale_probe") === Int32
+        @test RustCall.get_function_return_type(lib_b, "stale_probe") === Float64
+
+        # Clearing A leaves B answering for itself, and A answering for nobody.
+        RustCall.unload_library(lib_a)
+        @test RustCall.get_function_return_type(lib_b, "stale_probe") === Float64
+        @test RustCall.get_function_return_type(lib_a, "stale_probe") === Float64 ||
+              RustCall.get_function_return_type(lib_a, "stale_probe") === nothing
+
+        # A comes back declaring `Result`, so it records no hint. The old
+        # `Int32` must be gone: what answers is B's own type or nothing, never
+        # the value A itself last wrote.
+        RustCall._register_manifest(expanded_a2, lib_a; handle = handles[3], set_current = false)
+        @test RustCall.get_function_return_type(lib_a, "stale_probe") !== Int32
+        @test RustCall.get_function_return_type(lib_b, "stale_probe") === Float64
+
+        # And with B gone too, nothing is left to answer at all.
+        RustCall.unload_library(lib_b)
+        @test RustCall.get_function_return_type(lib_a, "stale_probe") === nothing
+    finally
+        for name in (lib_a, lib_b)
+            haskey(RustCall.RUST_LIBRARIES, name) && RustCall.unload_library(name)
+            RustCall.clear_library_metadata!(name)
+        end
+        foreach(Libdl.dlclose, handles)
     end
 end

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -627,3 +627,47 @@ end
     @test RustCall.exported_symbol(lib_name, "concurrent_probe") == "rustcall_concurrent_probe"
     @test concurrent_probe(Int32(3)) == Int32(21)
 end
+
+# #279 follow-up: registering one loaded handle under a second name has to
+# carry the name-to-symbol mappings over, or a lookup through the alias
+# resolves `f` to `f`, misses `rustcall_f`, and falls back to the ambiguous
+# cross-library search.
+@testset "#279: an aliased library keeps its symbol mappings" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping alias mapping test"
+        return
+    end
+
+    expanded = RustCall.expand_inline("""
+    #[julia]
+    pub fn aliased_probe(x: i32) -> i32 { x - 1 }
+    """)
+    path = RustCall.compile_rust_to_shared_lib(expanded.source)
+    actual = "test279_actual_" * string(hash(path), base = 16)
+    stored = "test279_stored_" * string(hash(path), base = 16)
+    handle = Libdl.dlopen(path, Libdl.RTLD_LOCAL | Libdl.RTLD_NOW)
+
+    try
+        RustCall._register_manifest(expanded, actual; handle = handle, set_current = false)
+        @test RustCall.exported_symbol(actual, "aliased_probe") == "rustcall_aliased_probe"
+        # The alias has nothing of its own yet.
+        @test RustCall.exported_symbol(stored, "aliased_probe") == "aliased_probe"
+
+        RustCall._alias_reloaded_library(Main, stored, actual)
+        @test RustCall.exported_symbol(stored, "aliased_probe") == "rustcall_aliased_probe"
+        ptr = RustCall.get_function_pointer(stored, "aliased_probe")
+        @test RustCall.call_rust_function(ptr, Int32, Int32(5)) == Int32(4)
+
+        # Dropping the alias must not disturb the library it pointed at.
+        RustCall.clear_function_symbols!(stored)
+        @test RustCall.exported_symbol(actual, "aliased_probe") == "rustcall_aliased_probe"
+    finally
+        for name in (stored, actual)
+            lock(RustCall.REGISTRY_LOCK) do
+                delete!(RustCall.RUST_LIBRARIES, name)
+                RustCall.clear_function_symbols!(name)
+            end
+        end
+        Libdl.dlclose(handle)
+    end
+end


### PR DESCRIPTION
Every finding from the Codex review of #284 and from its four rounds on this
PR — five P1s and seven P2s — fixed on top of `main`.

Most of them are one bug in different clothes: whatever the registries
record *about* a library — its name-to-symbol mappings and its return-type
hints — must be installed, copied and dropped with the handle, atomically. The
two registries are handled together throughout, by
`clear_library_metadata!(lib)` and `copy_library_metadata!(from, to)`.

## 1. A library and its symbol mappings are now published together

`src/ruststr.jl` inserted the handle into `RUST_LIBRARIES` and released
`REGISTRY_LOCK` **before** `_register_manifest` recorded the name→symbol
mappings. In that window a concurrent `ensure_loaded` / `@rust f(...)` could
see the library but not the mapping, and resolve `f` to `f` instead of
`rustcall_f` — failing outright, or hitting another library's `f`.

`_register_manifest` now takes the freshly loaded `handle` and installs the
symbol mappings, the return-type hints and the handle in **one** critical
section, publishing the handle *last*, so no reader can find the library before
its symbols. Every load path that registers a manifest goes through it:

| path | before | now |
|---|---|---|
| rustc, fresh compile | lock → insert; then `_register_manifest` | one `_register_manifest(…; handle)` |
| rustc, disk-cache hit | same | same |
| rustc, in-memory hit | lock → `CURRENT_LIB`; `_register_manifest` **inside** the lock | `_register_manifest` (no handle) |
| Cargo, fresh build / cache hit / in-memory hit | same three shapes | same |
| precompiled reload (`ensure_loaded`) | — | routes through `_compile_and_load_rust`, so covered |

Callers no longer insert into `RUST_LIBRARIES` themselves. The **generic**
registrations deliberately stay outside the lock: `register_generic_function`
may shell out to the extractor to recover a signature, which must not run with
the global registry lock held — and the in-memory-hit path used to do exactly
that.

`@irust` registers no manifest (its wrapper is a plain `#[no_mangle]` function
whose symbol is its name), so it is unchanged. The crate hot-reload path is
finding 4 below.

This collapses four of the eight open-coded `RUST_LIBRARIES[...] =` sites into
one, so the #251/#255 census in `test/test_loadpolicy.jl` and the
`register_library!` docstring are updated to five — and the docstring now
records that a Phase B `register_library!` (#277) has to keep the
handle-with-symbols guarantee, which is what its future `symbols` argument is
for.

## 2. A hand-built `RustMethod` no longer emits `_get_func_ptr("")`

A `RustMethod` built with the six-argument constructor has `symbol == ""`, so
all three emitters produced `_get_func_ptr("")`. Several repository tests build
`RustStructInfo` / `RustMethod` directly.

The constructor cannot know the struct name, so the fallback lives at the emit
sites: `method_wrapper_symbol(struct_name, method)` prefers the manifest symbol
and otherwise derives `rustcall_<Struct>_<method>` through the new
`ffi_method_symbol`, which sits next to `ffi_free_symbol` in the FFI-contract
module so the scheme has one home on the Julia side. Used by
`_generate_crate_method_wrapper`, `_emit_method_code` and
`emit_julia_definitions`. Generic structs are untouched — their wrappers are
addressed through `generic_wrapper`, not through a symbol.

## 3. An aliased library keeps its symbol mappings

`_alias_reloaded_library` (`src/rustmacro.jl`) registers one loaded handle under
a second name when a reload derives a different library identity than the one a
precompiled module stored. It copied only the `RUST_LIBRARIES` entry, so a
lookup through the stored name resolved `f` to `f`, missed the `rustcall_f` the
library exports, and fell through to the cross-library search — ambiguous as
soon as another loaded block also defines `f`.

The new `copy_function_symbols!(from, to)` gives the alias its own entries, in
the same critical section that installs the handle.

## 4. A hot reload restores the mappings it dropped

`_reload_library_locked` (`src/hot_reload.jl`) clears the mappings on unload —
correctly, since a stale entry would point at an unloaded handle — but the
rebuild published only the new handle. After the first reload a `#[julia] fn f`
in the crate was unreachable by its Rust name.

The rebuilt crate is now rescanned and the mappings re-registered before the new
handle becomes visible. The scan runs the extractor, so it happens *outside* the
lock; a scan failure warns and keeps the rebuilt library rather than losing it.

The registration loop is factored out as
`_register_exported_symbols!(signatures, lib_name)`, shared by
`_register_manifest` and the reload path, with the "caller holds the lock and
publishes the handle in the same critical section" contract in its docstring.

## 5. The in-memory hit is one conditional transaction

The rustc and Cargo in-memory-hit paths checked `haskey(RUST_LIBRARIES, ...)`,
released `REGISTRY_LOCK`, and only then re-registered the volatile tables. An
`unload_library` or hot reload landing in between left mappings, hints and
`CURRENT_LIB[]` pointing at a library that was gone.

`_register_manifest` gained `require_loaded`: the re-check happens inside the
same critical section, and the call returns `false` when the library has
disappeared, so the caller falls through to compiling and loading it again.

## 6. The alias carries the return-type hints too

Without them an untyped `@rust f(...)` through the stored name missed the
library-scoped entry and took the unscoped `FUNCTION_RETURN_TYPES` fallback —
whatever *another* block last registered for that name.
`copy_function_symbols!` is generalized into `copy_library_metadata!`.

## 7. A hot reload purges stale return-type hints

`clear_function_symbols!` is widened into `clear_library_metadata!`, which drops
the hints as well and prunes the unscoped fallback for names no other library
still declares. `_register_exported_symbols!` calls it before rebuilding from
the rescanned manifest, so a rebuilt crate keeps nothing about a function it
removed or now declares with another return type. The unload path and
`unregister_library!` inherit the same widening.

## 8. No name-only return-type table at all

`FUNCTION_RETURN_TYPES` was keyed by function name alone, so a hint outlived
the library that wrote it: clearing or reloading A left A's `f::Int32`
answering for every other library's `f`, and a rebuilt A returning `Result`
(for which no hint is recorded at all) would still be typed `Int32` by an
untyped call.

The table is deleted rather than patched. Since #284 every lookup has a
library, so `get_function_return_type(lib, name)` resolves the way
`get_function_pointer` does: `lib`'s own entry first, then the other *loaded*
libraries — one declarer answers, several are ambiguous and yield `nothing`,
leaving the caller to infer or to demand an explicit `::T`, which is exactly
where the pointer lookup already refuses to guess. Pointer and return type
therefore always come from the same library.

## 9. An aliased handle is one candidate, not an ambiguity

`_alias_reloaded_library` deliberately leaves one handle in `RUST_LIBRARIES`
under two names — the identity a precompiled module stored, and the one the
reload derived. The cross-library fallback counted that as two candidates and
raised the ambiguity error, breaking every multi-block precompiled module after
any toolchain or cfg change.

Candidates are now deduplicated by resolved pointer. Genuinely different
functions of the same name in different libraries are still refused.

## 10. Pointer and return type come from the same library

`get_function_return_type`'s cross-library loop could hand library B's
primitive hint to a call that landed in library A — and a library whose `f`
returns `Result` records no hint *on purpose* (its wrapper returns a
`CResult_f` struct), so the borrowed hint was the wrong ABI, not merely an
unrelated one.

`_resolve_call(lib, name) -> (ptr, owning_lib)` now does the lookup and reports
the owner; `get_function_pointer` is a thin wrapper over it and
`_rust_call_dynamic` reads its type info from `owning_lib`.
`get_function_return_type` consults only that library's own entry — no
name-only table and no cross-library search — so with no hint the caller falls
through to inference or an explicit `::T`.

## 11. No return type guessed from ambiguous cfg variants

An external crate is scanned leniently — only target predicates are decided,
since its own features and build script are not RustCall's to evaluate — so
mutually exclusive `#[cfg(feature = ...)]` variants of one `#[julia] fn` both
reach the registry, and source order decided whose return type was recorded.

When a manifest reports one symbol more than once the mapping is still
registered (it is the same either way) but no return type is, so the call falls
through to inference or an explicit `::T`. Scanning under the crate's *own*
features would give the exact answer, but the `:cargo` cfg mode is a
dependency-free probe crate that declares no features by design; doing it
properly means building the user's crate with its real features and profile,
which is #277 Phase B's business.

## Tests

- `test/test_regressions.jl` — `#279: a library and its symbol mappings are
  published together`: a `@sync` / `Threads.@spawn` loop of 32 + 16 tasks
  calling an attributed function from a freshly defined block, through the
  generated wrapper and through `@rust`, plus an `ensure_loaded` round trip
  that must keep the mapping.
- `test/test_regressions.jl` — `#279: an aliased library keeps its symbol
  mappings`: the alias resolves the prefixed symbol and calls through it, and
  clearing the alias leaves the original library intact.
- `test/test_hot_reload.jl` — `reload restores the name -> symbol mappings
  (#279)`: a real `trigger_reload` of the sample crate ends with the mapping in
  place next to the new handle and the pointer resolvable.
- `test/test_regressions.jl` — `#279: an aliased library keeps its return-type
  hints`: two blocks declare the same name with different return types, the
  second poisoning the unscoped fallback; the alias still reports its own.
- `test/test_regressions.jl` — `#279: re-registering an unloaded library is
  refused`: after an unload the guarded call returns `false` and leaves no
  metadata and no dangling `CURRENT_LIB[]`.
- `test/test_hot_reload.jl` also seeds a `ghost_fn` mapping, its scoped hint,
  its unscoped fallback and a wrong `Bool` hint for a real function before the
  reload, and asserts all four are gone or rebuilt afterwards.
- `test/test_regressions.jl` — `#279: return-type hints do not outlive their
  library`: A declares `f::i32`, B `f::f64`; clearing A leaves B answering for
  itself, a rebuilt A declaring `Result` never reports A's old `Int32`, and
  with both gone nothing answers.
- `test/test_regressions.jl` — `#279: an aliased handle is one candidate, not
  an ambiguity`: the aliased block's function resolves from a sibling block and
  from both of its own names to one pointer, while a third library genuinely
  exporting the name still raises the ambiguity error.
- `test/test_regressions.jl` — `#279: a return-type hint is never borrowed
  across libraries`: with A declaring `Result` (no hint) and B `f64`, A's
  untyped call never comes back as B's `Float64` while B's still does.
- `test/test_regressions.jl` — `#279: ambiguous cfg variants register no return
  type`: a temp crate with both cfg variants of one function keeps its symbol
  mapping and gets no return type, while a single-variant function still does.
- `test/test_crate_bindings.jl` — `hand-built RustMethod falls back to the
  rustcall_ symbol`: constructor, plain and `String`-returning methods built
  with the six-argument form all reach `rustcall_Point_<method>` through all
  three emitters, no `_get_func_ptr("")` anywhere, the string buffers still
  named after the method, and a manifest-backed `symbol` still winning.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and
`cargo test` in `deps/rustcall_core`, `deps/rustcall_extract` (+
`cargo build --release`) and `deps/juliacall_macros` (`--all-features`);
`Pkg.test()` against the freshly built extractor (6164 + 270 passing, 0
failures); `scripts/lint_interpolation.sh src`;
`scripts/lint_rust_syntax_regex.sh src`; `julia --project=docs docs/make.jl`
exits 0.

Follow-up to #284 / #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
