### PR TITLE
Document the pull request workflow in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,30 @@
 @CLAUDE.md
+
+# Agent instructions
+
+The project conventions live in `CLAUDE.md` (the `@CLAUDE.md` line above includes it for Claude Code). Agents that do not expand that directive must read `CLAUDE.md` directly. The pull-request loop is repeated here because every agent working on this repository must follow it.
+
+## Pull request loop
+
+1. Branch off `origin/main`, never commit to `main`. Open a **draft** PR; commit in steps that each leave `Pkg.test()` green.
+2. When CI is green, comment `@codex review`. Codex re-reviews on every push; do not push mid-round.
+3. Track CI and Codex **per head SHA**.
+4. For every finding: fix it with a regression test, reply on the thread with the fixing SHA, resolve. Do not resolve threads you did not act on.
+5. When findings converge on one class that a tech-debt issue owns, post a "scope decision" comment naming that issue, stop re-requesting review, merge on green, and record the deferred items on the issue.
+6. `Closes #N` only when every acceptance criterion of #N has a named test (criterion → test in the PR body); otherwise `Advances #N` with the remainder listed.
+7. Squash-merge with subject `<PR title> (#PR)` once CI is green and no threads are unresolved.
+
+## Before running tests
+
+- `cd deps/rustcall_extract && cargo build --release` and export `RUSTCALL_EXTRACT=<path to rustcall-extract>`.
+- Golden corpus: `UPDATE_GOLDEN=1 cargo test` in `deps/rustcall_core`, then review the diff.
+- All `scripts/lint_*.sh src` must pass; `julia --project=docs docs/make.jl` must exit 0.
+
+## Rules CI enforces
+
+- No `(@ref)` links to internal bindings in `src/*.jl` docstrings.
+- No `include` lines in `test/runtests.jl`; `test_*.jl` files are discovered automatically.
+- No regexes over Rust source in `src/`; Rust syntax is parsed only in `deps/rustcall_core`.
+- One artifact-identity function (`src/artifact_id.jl`), one load path (`src/loadpolicy.jl`), one FFI type table (`src/ffi_contract.jl`); the lints reject new ad-hoc keys, `dlopen` sites, or type maps.
+- Windows: unload libraries before deleting temp trees; a mapped DLL cannot be removed.
+- Finalizers never lock, `dlsym`, or log.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The project conventions live in `CLAUDE.md` (the `@CLAUDE.md` line above include
 ## Before running tests
 
 - `cd deps/rustcall_extract && cargo build --release` and export `RUSTCALL_EXTRACT=<path to rustcall-extract>`.
-- Golden corpus: `UPDATE_GOLDEN=1 cargo test` in `deps/rustcall_core`, then review the diff.
+- Golden corpus: run the plain `cargo test` in `deps/rustcall_core` first; a golden failure means the extractor output changed. Only if that change is intended, regenerate with `UPDATE_GOLDEN=1 cargo test` (it overwrites without comparing) and review `git diff tests/corpus`.
 - All `scripts/lint_*.sh src` must pass; `julia --project=docs docs/make.jl` must exit 0.
 
 ## Rules CI enforces
@@ -25,6 +25,6 @@ The project conventions live in `CLAUDE.md` (the `@CLAUDE.md` line above include
 - No `(@ref)` links to internal bindings in `src/*.jl` docstrings.
 - No `include` lines in `test/runtests.jl`; `test_*.jl` files are discovered automatically.
 - No regexes over Rust source in `src/`; Rust syntax is parsed only in `deps/rustcall_core`.
-- One artifact-identity function (`src/artifact_id.jl`), one load path (`src/loadpolicy.jl`), one FFI type table (`src/ffi_contract.jl`); the lints reject new ad-hoc keys, `dlopen` sites, or type maps.
+- One artifact-identity function (`src/artifact_id.jl`, enforced by `scripts/lint_artifact_identity.sh`) and one FFI type table (`src/ffi_contract.jl`, legacy tables deleted in #286). One load path through `src/loadpolicy.jl` is enforced by `scripts/lint_load_path.sh` from #277 Phase B (PR #289) onward; before that, `src/loadpolicy.jl` is the policy model only and `test/test_loadpolicy.jl` pins the open-coded `dlopen` sites.
 - Windows: unload libraries before deleting temp trees; a mapped DLL cannot be removed.
-- Finalizers never lock, `dlsym`, or log.
+- Finalizers must never lock, `dlsym`, or log — enforced by `test/test_finalizers.jl` from PR #289 onward; the older finalizers in `src/types.jl` and `src/crate_bindings.jl` are migrated there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,9 @@ Practical rules that CI enforces or that have bitten before:
 - Docstrings in `src/*.jl` must not use `(@ref)` links to internal bindings — the Documentation job fails. Plain backticks.
 - `test/runtests.jl` auto-discovers `test_*.jl`; never add an `include`.
 - Rebuild the extractor (`cd deps/rustcall_extract && cargo build --release`) and export `RUSTCALL_EXTRACT` before running Julia tests; a stale binary is rejected by the manifest schema check.
-- Regenerate golden files with `UPDATE_GOLDEN=1 cargo test` in `deps/rustcall_core` and inspect the diff before committing.
+- Golden corpus: run the plain `cargo test` in `deps/rustcall_core` first — a golden failure is the signal that the extractor's output changed. Only when that change is intended, regenerate with `UPDATE_GOLDEN=1 cargo test` (it overwrites without comparing) and review `git diff tests/corpus` before committing.
 - Run every `scripts/lint_*.sh src` locally; they are all CI jobs.
 - On Windows a loaded DLL cannot be deleted or overwritten: tests unload libraries before removing temp trees and clean up best-effort; hot reload opens a fresh generation path per rebuild.
-- Finalizers never take `REGISTRY_LOCK`, `dlsym`, or log; they use pointers captured at construction.
+- Finalizers must never take `REGISTRY_LOCK`, `dlsym`, or log; they use pointers captured at construction. Enforced by `test/test_finalizers.jl` from #277 Phase B (PR #289) onward; older finalizers in `src/types.jl` / `src/crate_bindings.jl` are migrated there.
 - `docs/src/api.md` is close to Documenter's size threshold (#288); a new docstring can break the docs job — check `julia --project=docs docs/make.jl` locally.
 - Verify tests pass before every commit; never commit red.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,3 +124,27 @@ Two jobs in `.github/workflows/CI.yml`:
 - Create a topic branch for any implementation or documentation change
 - Push the topic branch and open a draft PR for review-oriented sharing
 - If work is accidentally committed on `main`, move it onto a topic branch and reset local `main` back to `origin/main`
+
+## Pull Request Workflow
+
+Every change goes through this loop; the definition of done is the issue's acceptance criteria, not "the cause is gone".
+
+1. **Open a draft PR** from a topic branch off `origin/main`. Commit in logical steps, each leaving `Pkg.test()` green. Commit messages and the PR body carry the attribution trailers the session was given.
+2. **Request review**: comment `@codex review` once CI is green. Codex re-reviews automatically on every later push, so keep the branch quiet until a round is answered.
+3. **Monitor per head SHA**: CI results (`gh pr checks`) and Codex reviews are tracked against the current head; a green result on an older SHA means nothing.
+4. **Answer every finding**: fix real ones (with a regression test), reply on the thread with the fixing SHA, resolve the thread. Never resolve a thread you did not act on.
+5. **Scope decision**: when findings converge on one class that a tech-debt issue solves structurally, fix the current round, post a "scope decision" comment naming that issue, stop re-requesting review, and merge on green. Record the deferred items on the issue.
+6. **`Closes #N` only when every acceptance criterion of #N has a named test** (list criterion → test in the PR body). Otherwise write `Advances #N` and list what remains. A tech-debt fix removes the *class* of bug; the bug issue's concrete deliverables still need their own work.
+7. **Merge**: squash, subject `<PR title> (#PR)`, after CI is green, no unresolved threads, and the scope decision (if any) is recorded. Then pull `main` and rebase any open PR that overlaps.
+
+Practical rules that CI enforces or that have bitten before:
+
+- Docstrings in `src/*.jl` must not use `(@ref)` links to internal bindings — the Documentation job fails. Plain backticks.
+- `test/runtests.jl` auto-discovers `test_*.jl`; never add an `include`.
+- Rebuild the extractor (`cd deps/rustcall_extract && cargo build --release`) and export `RUSTCALL_EXTRACT` before running Julia tests; a stale binary is rejected by the manifest schema check.
+- Regenerate golden files with `UPDATE_GOLDEN=1 cargo test` in `deps/rustcall_core` and inspect the diff before committing.
+- Run every `scripts/lint_*.sh src` locally; they are all CI jobs.
+- On Windows a loaded DLL cannot be deleted or overwritten: tests unload libraries before removing temp trees and clean up best-effort; hot reload opens a fresh generation path per rebuild.
+- Finalizers never take `REGISTRY_LOCK`, `dlsym`, or log; they use pointers captured at construction.
+- `docs/src/api.md` is close to Documenter's size threshold (#288); a new docstring can break the docs job — check `julia --project=docs docs/make.jl` locally.
+- Verify tests pass before every commit; never commit red.


### PR DESCRIPTION
The PR/review loop that every change in the #264 → #279 → Phase B series followed was not written down anywhere: `CLAUDE.md`'s Git Workflow section stops at "open a draft PR", and `AGENTS.md` was a bare `@CLAUDE.md`.

This adds a **Pull Request Workflow** section to `CLAUDE.md` (draft PR → `@codex review` → monitor per head SHA → fix/reply/resolve → scope decision → `Closes` only with per-criterion tests → squash merge) plus the practical rules that CI enforces or that broke builds during the series (`@ref` in docstrings, `runtests.jl` auto-discovery, extractor rebuild + `RUSTCALL_EXTRACT`, golden regeneration, lints, Windows DLL locking, finalizer rules, the docs size threshold, never commit red).

`AGENTS.md` keeps `@CLAUDE.md` for Claude Code and now carries a self-contained copy of the loop and the CI-enforced rules for agents that do not expand that directive.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
