### PR TITLE
Move the compilation cache out of Julia's compiled/ directory into a scratch space (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking
+- **The compilation cache moved out of `~/.julia/compiled/`**
+  ([#252](https://github.com/AtelierArith/RustCall.jl/issues/252)). RustCall
+  used to write compiled `.dylib`/`.so`/`.dll` files, their `.sha256`
+  checksums, the `metadata/` tree and the Cargo build products into
+  `$(DEPOT_PATH[1])/compiled/vX.Y/RustCall` — **Julia's own package precompile
+  directory**, which Pkg neither tracks nor garbage-collects for foreign files
+  and which is read-only in common deployments (shared/HPC depots, baked
+  container images), where `mkpath` threw and RustCall was simply unusable.
+
+  `RustCall.get_cache_dir()` is now a [Scratch.jl](https://github.com/JuliaPackaging/Scratch.jl)
+  space, `<depot>/scratchspaces/<RustCall UUID>/cache-v2` — writable by
+  construction, accounted for by `Pkg.gc()`, and removable with
+  `Pkg.Scratch.clear_scratchspaces!`. The space name folds in
+  `CACHE_FORMAT_VERSION`, so RustCalls that disagree about the on-disk layout
+  keep separate trees. Three consequences:
+
+  - **Nothing is written under `~/.julia/compiled/` any more.** That directory
+    is read *only* by the opt-in legacy sweep and is never created by RustCall.
+    `RustCall.clear_cache(sweep_legacy = true)` removes the tree the old layout
+    left behind (its `v<n>` and `cargo`/`metadata` directories and loose files
+    matching the exact pre-#278 naming) and nothing else — Julia's `.ji` and
+    native images in the same directory are left alone.
+  - **A read-only `DEPOT_PATH[1]` is no longer fatal.** `Scratch` defaults to
+    the first depot; RustCall scans `DEPOT_PATH` for the first *writable* one.
+    With no writable depot at all the failure is a named `RustError` naming the
+    depots tried, not an `IOError` from inside a file copy.
+  - **`RUSTCALL_CACHE_DIR` overrides the location entirely**, for air-gapped
+    and CI setups that need the cache in a specific place.
+
+  Existing caches are not migrated: the first compile after upgrading rebuilds.
+
 - **One load/registration path** ([#277](https://github.com/AtelierArith/RustCall.jl/issues/277),
   Phase B). Twelve `dlopen` sites with four different flag sets and eight
   open-coded `RUST_LIBRARIES[...] = ...` writes became one:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ bash scripts/lint_generation_snapshot.sh src  # FFI entry points resolve via a s
 2. `src/compiler.jl` invokes `rustc` to produce shared libraries or LLVM IR
 3. `src/codegen.jl` generates `ccall` expressions; `src/llvmcodegen.jl` / `src/llvmintegration.jl` handle the LLVM IR path (deprecated, see #265)
 4. `src/rustmacro.jl` expands `@rust` and `@irust` into the appropriate call mechanism
-5. `src/cache.jl` provides caching of compiled artifacts, namespaced by `CACHE_FORMAT_VERSION` (`~/.julia/compiled/vX.Y/RustCall/v2`). That root is shared with **Julia's own precompile output** for RustCall (`<slug>.ji`, `<slug>.dylib`), so the cache sweep only ever removes RustCall's own version subdirectories, and legacy loose files only on explicit request and only by exact name match.
+5. `src/cache.jl` provides caching of compiled artifacts in a **Scratch.jl space** (#252): `get_cache_dir()` is `<depot>/scratchspaces/<RustCall UUID>/cache-v$(CACHE_FORMAT_VERSION)`, with `metadata/` and `cargo/` under it. RustCall writes **nothing** under `~/.julia/compiled/` — that is Julia's own precompile directory, read-only for RustCall and never created by it; `_legacy_cache_root()` is read only by the opt-in legacy sweep (`clear_cache(sweep_legacy = true)`), which removes RustCall's own `v<n>`/`cargo`/`metadata` directories and loose files matching the exact pre-#278 naming, and nothing else. The depot is the first *writable* entry of `DEPOT_PATH`, so a read-only `DEPOT_PATH[1]` still works; `RUSTCALL_CACHE_DIR` overrides the location outright.
 
 ### Artifact identity is computed in exactly one place (issue #278)
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 RustToolChain = "e9dc52e2-edb8-4742-9783-5e542d30dbb5"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
@@ -18,6 +19,7 @@ BenchmarkTools = "1.6.3"
 LLVM = "9"
 ParallelTestRunner = "2.5"
 RustToolChain = "0.1.8"
+Scratch = "1.3.0"
 julia = "1.12"
 
 [extras]

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -26,11 +26,16 @@ RustCall.jl automatically caches compiled Rust libraries. This eliminates the ne
   environment, the toolchain fingerprint, and the identity of the `rustc` /
   `cargo` that actually runs. Fields are netstring-framed, so no two different
   requests can concatenate to the same bytes.
-- **Cache location**: `~/.julia/compiled/vX.Y/RustCall/v\$(CACHE_FORMAT_VERSION)/`.
-  `CACHE_FORMAT_VERSION` names the on-disk layout; bumping it namespaces a new
-  tree rather than serving or deleting the old one, and
+- **Cache location**: a [Scratch.jl](https://github.com/JuliaPackaging/Scratch.jl)
+  space, `<depot>/scratchspaces/<RustCall UUID>/cache-v\$(CACHE_FORMAT_VERSION)/`
+  — writable by construction and accounted for by `Pkg.gc()`. RustCall writes
+  nothing under `~/.julia/compiled/`, which is Julia's own precompile directory
+  (issue #252). `<depot>` is the first **writable** entry of `DEPOT_PATH`, so a
+  read-only first depot is not fatal, and `RUSTCALL_CACHE_DIR` overrides the
+  location outright. `CACHE_FORMAT_VERSION` names the on-disk layout; bumping it
+  namespaces a new space rather than serving or deleting the old one, and
   `RustCall.sweep_stale_cache_formats()` (called by `clear_cache` and
-  `cleanup_old_cache`) removes older siblings best effort.
+  `cleanup_old_cache`) removes older `cache-v<n>` siblings best effort.
 - **Cost**: every input byte is read and hashed on every key computation —
   file contents are never memoized, because a `(mtime, size)` stamp can alias
   distinct contents and the cost of being wrong is running machine code built
@@ -87,9 +92,10 @@ RustCall.cleanup_old_cache(30)
 # Clear cache completely
 RustCall.clear_cache()
 
-# Also remove loose files left by the pre-v2 cache layout. Off by default:
-# the cache root is Julia's own precompile directory for RustCall, so RustCall
-# only ever deletes files it can prove it wrote.
+# Also remove the tree the pre-#252 layout left in `~/.julia/compiled/`. Off by
+# default: that directory is Julia's own precompile directory for RustCall, so
+# RustCall only ever deletes entries it can prove it wrote, and never the
+# directory itself.
 RustCall.clear_cache(sweep_legacy = true)
 ```
 

--- a/docs/src/precompilation.md
+++ b/docs/src/precompilation.md
@@ -172,7 +172,7 @@ MyPackage.multiply(1.0, 2.0)
 
 ### During Development
 
-- Compiled libraries are cached under `~/.julia/compiled/vX.Y/RustCall/v2/` (see the Performance guide)
+- Compiled libraries are cached in a Scratch.jl space, `<depot>/scratchspaces/<RustCall UUID>/cache-v2/` (see the Performance guide)
 - Cache is keyed by source code hash
 - Rebuilding only happens when source changes
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -13,6 +13,7 @@
 
 using SHA
 using Dates
+using Scratch: Scratch
 
 """
     CACHE_LOCK
@@ -84,46 +85,171 @@ Version history:
 const CACHE_FORMAT_VERSION = 2
 
 """
-    _cache_format_root() -> String
+    CACHE_SCRATCH_NAME
 
-The parent directory holding one subdirectory per cache format version.
+The name of the scratch space every cached artifact lives in, `cache-v<N>` for
+`CACHE_FORMAT_VERSION` `N` (#252).
 
-!!! danger "This directory is not RustCall's to empty"
-    It is `\$(DEPOT_PATH[1])/compiled/vX.Y/RustCall` — **Julia's own package
-    precompile directory for RustCall**, where Julia writes `<slug>.ji` and
-    `<slug>.dylib`/`.so`/`.dll` native images (and `.dSYM` bundles beside them).
-    The root is kept here because `get_cache_dir()` has always been under it and
-    moving it would strand every existing cache, but the consequence is that
-    RustCall shares a directory with another program's data.
+Scratch spaces are namespaced by the owning package's UUID, not by its version,
+so the format version has to be part of the *name* for two RustCalls that
+disagree about the on-disk layout to keep separate trees.
+"""
+const CACHE_SCRATCH_NAME = "cache-v$(CACHE_FORMAT_VERSION)"
+
+"""
+    _legacy_cache_root() -> String
+
+The pre-#252 cache root, `\$(DEPOT_PATH[1])/compiled/vX.Y/RustCall`.
+
+!!! danger "Read-only, and not RustCall's to empty"
+    This is **Julia's own package precompile directory for RustCall**, where
+    Julia writes `<slug>.ji` and `<slug>.dylib`/`.so`/`.dll` native images (and
+    `.dSYM` bundles beside them). RustCall used to keep its compiled Rust
+    libraries here too; since #252 it writes to a scratch space instead
+    (`get_cache_dir`) and **never creates this directory** — it is only ever
+    read, and only by the opt-in legacy sweep.
 
     Nothing here may be deleted unless RustCall demonstrably wrote it: only its
-    own version subdirectories, and loose files matching the exact naming the
-    pre-#278 layout used (`_LEGACY_CACHE_FILE`). Removing a fresh `.ji` would
-    throw away Julia's precompilation output and can race a concurrent Julia
-    process writing it.
+    own version subdirectories and `_LEGACY_CACHE_DIRS`, plus loose files
+    matching the exact naming the pre-#278 layout used (`_LEGACY_CACHE_FILE`).
+    Removing a fresh `.ji` would throw away Julia's precompilation output and
+    can race a concurrent Julia process writing it.
 """
-function _cache_format_root()
+function _legacy_cache_root()
     return joinpath(DEPOT_PATH[1], "compiled", "v$(VERSION.major).$(VERSION.minor)", "RustCall")
+end
+
+# `(depot path snapshot, RUSTCALL_CACHE_DIR) => resolved cache directory`.
+# `get_cache_dir` is on the lookup path of every cached compile, and resolving
+# it probes the filesystem for a writable depot, so the answer is memoized and
+# invalidated whenever either input changes (which is what tests do).
+const _CACHE_DIR_MEMO = Ref{Union{Nothing, Tuple{Vector{String}, String, String}}}(nothing)
+
+"""
+    _reset_cache_dir_memo!()
+
+Drop the memoized cache directory. Only needed by tests that move `DEPOT_PATH`
+or `RUSTCALL_CACHE_DIR` out from under a running session; normal use is
+invalidated automatically because both inputs are part of the memo key.
+"""
+function _reset_cache_dir_memo!()
+    lock(CACHE_LOCK) do
+        _CACHE_DIR_MEMO[] = nothing
+    end
+    return nothing
+end
+
+"""
+    _cache_dir_override() -> String
+
+`RUSTCALL_CACHE_DIR`, expanded and absolutised, or `""` when unset or empty.
+
+The documented escape hatch for air-gapped and CI setups that need the cache in
+a specific place (#252): when it is set, no depot is consulted at all.
+"""
+function _cache_dir_override()
+    raw = get(ENV, "RUSTCALL_CACHE_DIR", "")
+    return isempty(raw) ? "" : abspath(expanduser(raw))
+end
+
+"""
+    _depot_is_writable(depot) -> Bool
+
+Whether a scratch space can actually be created under `depot`.
+
+`mkpath` succeeding is not enough — it is a no-op on an existing directory
+whatever its mode — so this creates the `scratchspaces` directory and then
+writes and removes a uniquely named probe file inside it. A read-only
+`DEPOT_PATH[1]` (shared/HPC depots, baked container images) fails here and the
+next depot is tried.
+"""
+function _depot_is_writable(depot::AbstractString)
+    dir = joinpath(depot, "scratchspaces")
+    try
+        mkpath(dir)
+        probe = joinpath(dir, ".rustcall-write-probe-$(getpid())-$(rand(UInt64))")
+        touch(probe)
+        rm(probe; force = true)
+        return true
+    catch e
+        @debug "Depot is not writable for RustCall's cache" depot exception = e
+        return false
+    end
+end
+
+"""
+    _writable_depot() -> Union{String, Nothing}
+
+The first entry of `DEPOT_PATH` a scratch space can be created in, or `nothing`
+when there is none.
+
+`Scratch.get_scratch!` defaults to `first(DEPOT_PATH)`; RustCall scans instead,
+so a read-only first depot with a writable one behind it still works (#252).
+"""
+function _writable_depot()
+    for depot in DEPOT_PATH
+        isempty(depot) && continue
+        _depot_is_writable(depot) && return String(depot)
+    end
+    return nothing
 end
 
 """
     get_cache_dir() -> String
 
-Get the cache directory for RustCall.jl compiled libraries.
-Uses Julia's standard cache directory structure, namespaced by
-`CACHE_FORMAT_VERSION`.
+The directory RustCall keeps compiled libraries, checksums, metadata and Cargo
+build products in.
+
+Since #252 this is a **scratch space** — `Scratch.get_scratch!(RustCall,
+CACHE_SCRATCH_NAME)`, i.e. `<depot>/scratchspaces/<RustCall UUID>/cache-vN`.
+Scratch spaces are the standard, `Pkg.gc()`-tracked, writable-by-construction
+per-package store; RustCall writes **nothing** under `~/.julia/compiled/`, which
+is Julia's own precompile directory and is read-only in many deployments.
+
+Resolution order:
+
+1. `RUSTCALL_CACHE_DIR`, when set — a documented, absolute escape hatch.
+2. The scratch space in the first writable `DEPOT_PATH` entry. `Scratch`'s own
+   default is the first depot only; scanning means a read-only
+   `DEPOT_PATH[1]` in front of a writable depot is not fatal.
+
+Throws a `RustError` when no depot can be written to, naming the depots tried
+and the override.
 """
 function get_cache_dir()
-    cache_root = joinpath(_cache_format_root(), "v$(CACHE_FORMAT_VERSION)")
-    mkpath(cache_root)
-    return cache_root
+    return lock(CACHE_LOCK) do
+        depots = String[String(d) for d in DEPOT_PATH]
+        override = _cache_dir_override()
+        memo = _CACHE_DIR_MEMO[]
+        if memo !== nothing && memo[1] == depots && memo[2] == override
+            isdir(memo[3]) && return memo[3]
+        end
+
+        dir = if !isempty(override)
+            mkpath(override)
+            override
+        else
+            depot = _writable_depot()
+            if depot === nothing
+                throw(RustError(
+                    "RustCall cannot create its compilation cache: none of the " *
+                    "depots in DEPOT_PATH is writable ($(join(depots, ", "))). " *
+                    "Set RUSTCALL_CACHE_DIR to a writable directory, or add a " *
+                    "writable depot to DEPOT_PATH/JULIA_DEPOT_PATH."))
+            end
+            Scratch.get_scratch!(@__MODULE__, CACHE_SCRATCH_NAME; depot_path = depot)
+        end
+
+        _CACHE_DIR_MEMO[] = (depots, override, dir)
+        return dir
+    end
 end
 
 """
     _LEGACY_CACHE_DIRS
 
 Subdirectories the pre-#278 (unversioned) layout created directly under
-`_cache_format_root()`: `save_cached_library` wrote metadata to `metadata/` and
+`_legacy_cache_root()`: `save_cached_library` wrote metadata to `metadata/` and
 `build_cargo_project_cached` wrote to `cargo/`. Both names are RustCall's own —
 Julia creates no directory there — so they are safe to remove.
 """
@@ -133,7 +259,7 @@ const _LEGACY_CACHE_DIRS = ("cargo", "metadata")
     _LEGACY_CACHE_FILE
 
 The exact naming the pre-#278 layout used for loose files in
-`_cache_format_root()`, taken from the code that wrote them, not guessed:
+`_legacy_cache_root()`, taken from the code that wrote them, not guessed:
 
 - `save_cached_library`  → `<cache_key><lib_ext>`
 - `_save_checksum`       → `<cache_key><lib_ext>.sha256`
@@ -151,27 +277,65 @@ A file that does not match this is never removed, whatever it looks like.
 const _LEGACY_CACHE_FILE = r"^[0-9a-f]{32,64}(\.(dylib|so|dll)(\.sha256)?|\.ll)$"
 
 """
+    _CACHE_SCRATCH_SIBLING
+
+A scratch space belonging to another on-disk cache format: `cache-v<n>`, the
+naming `CACHE_SCRATCH_NAME` produces. Nothing else in
+`scratchspaces/<RustCall UUID>` is swept, so a future RustCall that keeps a
+differently named space of its own is never touched.
+"""
+const _CACHE_SCRATCH_SIBLING = r"^cache-v(\d+)$"
+
+"""
     _stale_cache_format_dirs() -> Vector{String}
 
-Cache *directories* under `_cache_format_root()` that RustCall wrote and can no
-longer read: version subdirectories older than `CACHE_FORMAT_VERSION`, plus the
-`_LEGACY_CACHE_DIRS` of the unversioned pre-#278 layout.
+Scratch spaces of *older* cache formats — `cache-v<n>` with `n <
+CACHE_FORMAT_VERSION`, beside the current `get_cache_dir()`.
 
-Newer-versioned siblings are deliberately left alone (a future RustCall sharing
-the depot keeps its own cache), and so is every other entry — see the warning on
-`_cache_format_root`.
+These are unambiguously RustCall's own (the directory is namespaced by its
+package UUID) and unreadable by this version, so a plain
+`sweep_stale_cache_formats()` removes them. Newer-versioned siblings are
+deliberately left alone: a future RustCall sharing the depot keeps its cache.
+
+Empty when `RUSTCALL_CACHE_DIR` is set — an explicitly chosen directory has no
+sibling namespace to sweep.
 """
 function _stale_cache_format_dirs()
-    root = _cache_format_root()
+    out = String[]
+    isempty(_cache_dir_override()) || return out
+    root = dirname(get_cache_dir())
+    isdir(root) || return out
+    for entry in readdir(root)
+        path = joinpath(root, entry)
+        isdir(path) || continue
+        m = match(_CACHE_SCRATCH_SIBLING, entry)
+        m === nothing && continue
+        parse(Int, m.captures[1]) < CACHE_FORMAT_VERSION && push!(out, path)
+    end
+    return out
+end
+
+"""
+    _legacy_cache_dirs() -> Vector{String}
+
+Cache directories under `_legacy_cache_root()` — the pre-#252 root inside
+Julia's precompile directory. Every `v<n>` subdirectory counts, not just the
+older ones: since #252 RustCall writes none of them, so all of them are
+abandoned, whatever their number. `_LEGACY_CACHE_DIRS` (the unversioned pre-#278
+layout) counts too.
+
+Everything else in that directory is Julia's, or someone else's, and is never
+returned — see the warning on `_legacy_cache_root`. The root itself is never
+created and never removed.
+"""
+function _legacy_cache_dirs()
+    root = _legacy_cache_root()
     out = String[]
     isdir(root) || return out
     for entry in readdir(root)
         path = joinpath(root, entry)
         isdir(path) || continue
-        m = match(r"^v(\d+)$", entry)
-        if m !== nothing
-            parse(Int, m.captures[1]) < CACHE_FORMAT_VERSION && push!(out, path)
-        elseif entry in _LEGACY_CACHE_DIRS
+        if match(r"^v(\d+)$", entry) !== nothing || entry in _LEGACY_CACHE_DIRS
             push!(out, path)
         end
     end
@@ -181,13 +345,13 @@ end
 """
     _legacy_cache_files() -> Vector{String}
 
-Loose files directly under `_cache_format_root()` that the pre-#278 layout
+Loose files directly under `_legacy_cache_root()` that the pre-#278 layout
 wrote, identified by `_LEGACY_CACHE_FILE` and nothing else. Everything the
 pattern does not match — Julia's `.ji` and native images above all — is not
 RustCall's and is never returned.
 """
 function _legacy_cache_files()
-    root = _cache_format_root()
+    root = _legacy_cache_root()
     out = String[]
     isdir(root) || return out
     for entry in readdir(root)
@@ -199,29 +363,36 @@ function _legacy_cache_files()
 end
 
 """
-    sweep_stale_cache_formats(; legacy_files::Bool = false) -> Int
+    sweep_stale_cache_formats(; legacy::Bool = false) -> Int
 
-Best-effort removal of cache trees left behind by older cache formats. Returns
-the number of entries removed and never throws: a locked or unreadable entry is
+Best-effort removal of cache trees this RustCall can no longer read. Returns the
+number of entries removed and never throws: a locked or unreadable entry is
 skipped and simply stays on disk.
 
-Directories are always swept — they are unambiguously RustCall's. Loose files
-from the unversioned pre-#278 layout are swept **only** when `legacy_files` is
-true, because they share a directory with Julia's own precompile output for
-RustCall; see the warning on `_cache_format_root`. Even then, only files
-matching `_LEGACY_CACHE_FILE` are touched.
+Older scratch siblings (`_stale_cache_format_dirs`) are always swept — they are
+RustCall's own, in a directory namespaced by its package UUID.
+
+The pre-#252 tree under `_legacy_cache_root()` is swept **only** when `legacy`
+is true, because it lives inside Julia's own precompile directory for RustCall;
+see the warning there. Even then only RustCall's own version subdirectories,
+`_LEGACY_CACHE_DIRS`, and loose files matching `_LEGACY_CACHE_FILE` are touched,
+and the root directory itself is left in place.
 """
-function sweep_stale_cache_formats(; legacy_files::Bool = false)
+function sweep_stale_cache_formats(; legacy::Bool = false)
     removed = 0
-    for path in _stale_cache_format_dirs()
+    paths = _stale_cache_format_dirs()
+    if legacy
+        append!(paths, _legacy_cache_dirs())
+    end
+    for path in paths
         try
             rm(path, recursive = true, force = true)
             removed += 1
         catch e
-            @debug "Could not remove stale cache format directory" path exception = e
+            @debug "Could not remove stale cache directory" path exception = e
         end
     end
-    if legacy_files
+    if legacy
         for path in _legacy_cache_files()
             try
                 rm(path, force = true)
@@ -575,13 +746,13 @@ end
 """
     clear_cache(; sweep_legacy::Bool = false)
 
-Clear all cached libraries and metadata: the current format's tree, plus the
-directories older formats left behind.
+Clear all cached libraries and metadata: the current scratch space, plus the
+scratch spaces older cache formats left behind.
 
-Loose files from the unversioned pre-#278 layout are removed only with
-`sweep_legacy = true`. They live in a directory RustCall shares with Julia's own
-precompile output (see `_cache_format_root`), so removing them is opt-in even
-though the naming pattern used is exact.
+The pre-#252 tree under `_legacy_cache_root()` is removed only with
+`sweep_legacy = true`. It lives inside Julia's own precompile directory for
+RustCall (see the warning there), so removing it is opt-in even though every
+name matched is exact.
 
 On Windows, some files may be locked and cannot be deleted immediately.
 """
@@ -593,9 +764,9 @@ end
 
 function _clear_cache_unlocked(; sweep_legacy::Bool = false)
     # Clearing "the cache" means every format this RustCall is responsible for,
-    # not just the current one, or a `clear_cache()` would leave the pre-#278
-    # tree on disk forever.
-    sweep_stale_cache_formats(; legacy_files = sweep_legacy)
+    # not just the current one, or a `clear_cache()` would leave older scratch
+    # spaces on disk forever.
+    sweep_stale_cache_formats(; legacy = sweep_legacy)
     cache_dir = get_cache_dir()
     if isdir(cache_dir)
         try
@@ -702,12 +873,11 @@ println("Removed \$count old cache entries")
 ```
 """
 function cleanup_old_cache(max_age_days::Int = 30)
-    # Directories written under an older cache format are unreachable by
-    # construction, whatever their age: sweep them first (best effort). Loose
-    # legacy files are never swept from here — an age-based cleanup has no
-    # business deleting files in a directory RustCall shares with Julia's
-    # precompile output; `clear_cache(sweep_legacy = true)` is the explicit
-    # request for that.
+    # Scratch spaces of an older cache format are unreachable by construction,
+    # whatever their age: sweep them first (best effort). The legacy tree is
+    # never swept from here — an age-based cleanup has no business deleting
+    # files in a directory RustCall shares with Julia's precompile output;
+    # `clear_cache(sweep_legacy = true)` is the explicit request for that.
     sweep_stale_cache_formats()
 
     cache_dir = get_cache_dir()

--- a/test/test_cache.jl
+++ b/test/test_cache.jl
@@ -3,6 +3,37 @@
 using RustCall
 using Test
 
+"""
+    with_isolated_depot(f)
+
+Run `f(depot)` with a fresh temporary directory in front of `DEPOT_PATH`.
+
+The cache-location testsets look at, create in and sweep two trees that are
+derived from `DEPOT_PATH[1]`: the scratch space `get_cache_dir()` resolves to,
+and the pre-#252 root `_legacy_cache_root()`. In a depot a RustCall has really
+been used in, both hold the user's own files — a leftover `v2/` tree, real
+`cargo/` and `metadata/` directories — which would both break the assertions
+and make the opt-in legacy sweep delete something that is not a fixture. A
+temporary first depot gives those tests a tree nobody else wrote.
+
+Both inputs to the memoized cache directory change here, so the memo is reset on
+the way in and on the way out.
+"""
+function with_isolated_depot(f)
+    depot = mktempdir()
+    saved = copy(DEPOT_PATH)
+    try
+        pushfirst!(DEPOT_PATH, depot)
+        RustCall._reset_cache_dir_memo!()
+        return f(depot)
+    finally
+        empty!(DEPOT_PATH)
+        append!(DEPOT_PATH, saved)
+        RustCall._reset_cache_dir_memo!()
+        rm(depot; recursive = true, force = true)
+    end
+end
+
 @testset "Compilation Caching" begin
     # Clear cache before testing
     RustCall.clear_cache()
@@ -19,77 +50,90 @@ using Test
     end
 
     @testset "Cache format namespace (#252, #278)" begin
-        # Every cached artifact lives in a scratch space named for the on-disk
-        # cache format, so a key-formula change (#278 Phase B) cannot serve a
-        # hit written by the previous format, and two RustCalls that disagree
-        # about the layout keep separate trees.
-        cache_dir = RustCall.get_cache_dir()
-        @test basename(cache_dir) == "cache-v$(RustCall.CACHE_FORMAT_VERSION)"
-        @test RustCall.CACHE_SCRATCH_NAME == "cache-v$(RustCall.CACHE_FORMAT_VERSION)"
+        with_isolated_depot() do _depot
+            # Every cached artifact lives in a scratch space named for the on-disk
+            # cache format, so a key-formula change (#278 Phase B) cannot serve a
+            # hit written by the previous format, and two RustCalls that disagree
+            # about the layout keep separate trees.
+            cache_dir = RustCall.get_cache_dir()
+            @test basename(cache_dir) == "cache-v$(RustCall.CACHE_FORMAT_VERSION)"
+            @test RustCall.CACHE_SCRATCH_NAME == "cache-v$(RustCall.CACHE_FORMAT_VERSION)"
 
-        # The Cargo and metadata trees nest under it.
-        @test startswith(RustCall.get_metadata_dir(), cache_dir)
-        @test startswith(RustCall.get_cargo_cache_dir(), cache_dir)
+            # The Cargo and metadata trees nest under it.
+            @test startswith(RustCall.get_metadata_dir(), cache_dir)
+            @test startswith(RustCall.get_cargo_cache_dir(), cache_dir)
 
-        # Older scratch siblings are swept best-effort; newer ones are left alone.
-        root = dirname(cache_dir)
-        old_dir = joinpath(root, "cache-v1")
-        new_dir = joinpath(root, "cache-v$(RustCall.CACHE_FORMAT_VERSION + 1)")
-        unrelated = joinpath(root, "not-a-cache")
-        mkpath(old_dir)
-        mkpath(new_dir)
-        mkpath(unrelated)
-        write(joinpath(old_dir, "x.txt"), "old")
-        try
-            stale = RustCall._stale_cache_format_dirs()
-            @test old_dir in stale
-            @test !(new_dir in stale)
-            @test !(unrelated in stale)
-            @test !(cache_dir in stale)
+            # Older scratch siblings are swept best-effort; newer ones are left alone.
+            root = dirname(cache_dir)
+            old_dir = joinpath(root, "cache-v1")
+            new_dir = joinpath(root, "cache-v$(RustCall.CACHE_FORMAT_VERSION + 1)")
+            unrelated = joinpath(root, "not-a-cache")
+            mkpath(old_dir)
+            mkpath(new_dir)
+            mkpath(unrelated)
+            write(joinpath(old_dir, "x.txt"), "old")
+            try
+                stale = RustCall._stale_cache_format_dirs()
+                @test old_dir in stale
+                @test !(new_dir in stale)
+                @test !(unrelated in stale)
+                @test !(cache_dir in stale)
 
-            RustCall.sweep_stale_cache_formats()
-            @test !isdir(old_dir)
-            @test isdir(new_dir)      # a future format's cache is not ours to delete
-            @test isdir(unrelated)    # nor is anything that is not `cache-v<n>`
-            @test isdir(cache_dir)
-        finally
-            rm(new_dir; recursive = true, force = true)
-            rm(old_dir; recursive = true, force = true)
-            rm(unrelated; recursive = true, force = true)
+                RustCall.sweep_stale_cache_formats()
+                @test !isdir(old_dir)
+                @test isdir(new_dir)      # a future format's cache is not ours to delete
+                @test isdir(unrelated)    # nor is anything that is not `cache-v<n>`
+                @test isdir(cache_dir)
+            finally
+                rm(new_dir; recursive = true, force = true)
+                rm(old_dir; recursive = true, force = true)
+                rm(unrelated; recursive = true, force = true)
+            end
         end
     end
 
     @testset "RustCall writes nothing under ~/.julia/compiled (#252)" begin
-        # Acceptance criterion 1 of #252: the cache is a Scratch.jl space, and
-        # `.../compiled/vX.Y/RustCall` — Julia's own precompile directory — is
-        # read-only for RustCall and is never created by it.
-        cache_dir = RustCall.get_cache_dir()
-        @test !occursin(joinpath("compiled", "v$(VERSION.major).$(VERSION.minor)"), cache_dir)
+        with_isolated_depot() do _depot
+            # Acceptance criterion 1 of #252: the cache is a Scratch.jl space, and
+            # `.../compiled/vX.Y/RustCall` — Julia's own precompile directory — is
+            # read-only for RustCall and is never created by it.
+            cache_dir = RustCall.get_cache_dir()
+            @test !occursin(joinpath("compiled", "v$(VERSION.major).$(VERSION.minor)"), cache_dir)
 
-        legacy_root = RustCall._legacy_cache_root()
-        legacy_existed = isdir(legacy_root)
+            # The depot is brand new, so if anything appears under
+            # `.../compiled/vX.Y/RustCall` in this testset, RustCall put it
+            # there. The pre-#252 code created that directory in `get_cache_dir`
+            # itself, on the first cache lookup.
+            legacy_root = RustCall._legacy_cache_root()
+            @test startswith(legacy_root, _depot)
+            @test !isdir(legacy_root)
 
-        # Every writer on the cache path goes through `get_cache_dir`; exercise
-        # them and assert the legacy root is untouched.
-        key = RustCall.stable_content_hash("#252 storage location probe")
-        payload = joinpath(mktempdir(), "probe" * RustCall.get_library_extension())
-        write(payload, "not really a library")
-        RustCall.save_cached_library(key, payload, RustCall.CacheMetadata(
-            key, key, "probe", "probe-triple", RustCall.Dates.now(), String["probe"]))
-        try
-            @test RustCall.get_cached_library(key) !== nothing
-            @test startswith(RustCall.get_cached_library(key), cache_dir)
-            @test startswith(RustCall.get_cargo_cache_dir(), cache_dir)
-            # Nothing appeared in Julia's precompile directory.
-            @test isdir(legacy_root) == legacy_existed
-            if legacy_existed
-                # ... and no RustCall cache artifact was written into it.
+            # Every writer on the cache path goes through `get_cache_dir`; exercise
+            # them and assert the legacy root stays absent.
+            key = RustCall.stable_content_hash("#252 storage location probe")
+            payload = joinpath(mktempdir(), "probe" * RustCall.get_library_extension())
+            write(payload, "not really a library")
+            RustCall.save_cached_library(key, payload, RustCall.CacheMetadata(
+                key, key, "probe", "probe-triple", RustCall.Dates.now(), String["probe"]))
+            try
+                @test RustCall.get_cached_library(key) !== nothing
+                @test startswith(RustCall.get_cached_library(key), cache_dir)
+                @test startswith(RustCall.get_cargo_cache_dir(), cache_dir)
+                # Nothing appeared in Julia's precompile directory — not one
+                # file, and not the directory itself.
+                @test !isdir(legacy_root)
                 @test isempty(RustCall._legacy_cache_files())
+                @test isempty(RustCall._legacy_cache_dirs())
+                # A sweep, an age-based cleanup and a plain `clear_cache()` do
+                # not create it either.
+                RustCall.sweep_stale_cache_formats()
+                RustCall.cleanup_old_cache(365)
+                @test !isdir(legacy_root)
+            finally
+                rm(RustCall.get_cached_library(key); force = true)
+                rm(joinpath(cache_dir, key * RustCall.get_library_extension() * ".sha256"); force = true)
+                rm(joinpath(RustCall.get_metadata_dir(), key * ".json"); force = true)
             end
-        finally
-            rm(RustCall.get_cached_library(key); force = true)
-            rm(joinpath(cache_dir, key * RustCall.get_library_extension() * ".sha256"); force = true)
-            rm(joinpath(RustCall.get_metadata_dir(), key * ".json"); force = true)
         end
     end
 
@@ -187,101 +231,103 @@ using Test
     end
 
     @testset "The legacy sweep never deletes what RustCall did not write (#252, #287)" begin
-        # `_legacy_cache_root()` is `.../compiled/vX.Y/RustCall` — *Julia's own*
-        # package precompile directory for RustCall, where it keeps `<slug>.ji`
-        # and `<slug>.dylib` native images. Deleting every regular file there
-        # would throw away fresh precompilation output and could race another
-        # Julia process writing it. Since #252 RustCall never writes here at
-        # all; the tree is read for the opt-in legacy sweep and nothing else.
-        root = RustCall._legacy_cache_root()
-        root_existed = isdir(root)
-        mkpath(root)
+        with_isolated_depot() do _depot
+            # `_legacy_cache_root()` is `.../compiled/vX.Y/RustCall` — *Julia's own*
+            # package precompile directory for RustCall, where it keeps `<slug>.ji`
+            # and `<slug>.dylib` native images. Deleting every regular file there
+            # would throw away fresh precompilation output and could race another
+            # Julia process writing it. Since #252 RustCall never writes here at
+            # all; the tree is read for the opt-in legacy sweep and nothing else.
+            root = RustCall._legacy_cache_root()
+            root_existed = isdir(root)
+            mkpath(root)
 
-        # Named exactly as Julia names them (a package slug: mixed case and an
-        # underscore, so `_LEGACY_CACHE_FILE` cannot match).
-        julia_ji = joinpath(root, "qLtCw_2ChqG.ji")
-        julia_img = joinpath(root, "qLtCw_2ChqG." * (Sys.iswindows() ? "dll" :
-                                                     Sys.isapple() ? "dylib" : "so"))
-        unrelated = joinpath(root, "notes.txt")
-        # ... and a genuine v1 artifact: a `stable_content_hash` key plus the
-        # library extension, which is all v1 ever wrote loose in this directory.
-        v1_key = RustCall.stable_content_hash("a v1 cache entry")
-        legacy_lib = joinpath(root, v1_key * RustCall.get_library_extension())
-        legacy_sum = legacy_lib * ".sha256"
-        legacy_ir = joinpath(root, v1_key * ".ll")
-        # Directory shapes both layouts left behind, including the *current*
-        # format version: since #252 nothing under this root is written any
-        # more, so every `v<n>` there is abandoned, not just the older ones.
-        legacy_v1 = joinpath(root, "v1")
-        legacy_vcur = joinpath(root, "v$(RustCall.CACHE_FORMAT_VERSION)")
-        legacy_meta = joinpath(root, "metadata")
-        julia_dir = joinpath(root, "qLtCw_2ChqG.dSYM")
+            # Named exactly as Julia names them (a package slug: mixed case and an
+            # underscore, so `_LEGACY_CACHE_FILE` cannot match).
+            julia_ji = joinpath(root, "qLtCw_2ChqG.ji")
+            julia_img = joinpath(root, "qLtCw_2ChqG." * (Sys.iswindows() ? "dll" :
+                                                         Sys.isapple() ? "dylib" : "so"))
+            unrelated = joinpath(root, "notes.txt")
+            # ... and a genuine v1 artifact: a `stable_content_hash` key plus the
+            # library extension, which is all v1 ever wrote loose in this directory.
+            v1_key = RustCall.stable_content_hash("a v1 cache entry")
+            legacy_lib = joinpath(root, v1_key * RustCall.get_library_extension())
+            legacy_sum = legacy_lib * ".sha256"
+            legacy_ir = joinpath(root, v1_key * ".ll")
+            # Directory shapes both layouts left behind, including the *current*
+            # format version: since #252 nothing under this root is written any
+            # more, so every `v<n>` there is abandoned, not just the older ones.
+            legacy_v1 = joinpath(root, "v1")
+            legacy_vcur = joinpath(root, "v$(RustCall.CACHE_FORMAT_VERSION)")
+            legacy_meta = joinpath(root, "metadata")
+            julia_dir = joinpath(root, "qLtCw_2ChqG.dSYM")
 
-        for f in (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir)
-            write(f, "x")
-        end
-        for d in (legacy_v1, legacy_vcur, legacy_meta, julia_dir)
-            mkpath(d)
-            write(joinpath(d, "content"), "x")
-        end
-        try
-            # The classifiers are the safety property: only ours match.
-            listed = RustCall._legacy_cache_files()
-            @test legacy_lib in listed
-            @test legacy_sum in listed
-            @test legacy_ir in listed
-            @test !(julia_ji in listed)
-            @test !(julia_img in listed)
-            @test !(unrelated in listed)
-
-            dirs = RustCall._legacy_cache_dirs()
-            @test legacy_v1 in dirs
-            @test legacy_vcur in dirs
-            @test legacy_meta in dirs
-            @test !(julia_dir in dirs)
-
-            # Off by default: a plain sweep touches nothing under this root at
-            # all, and neither does an age-based cleanup.
-            RustCall.sweep_stale_cache_formats()
-            @test all(isfile, (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir))
-            @test all(isdir, (legacy_v1, legacy_vcur, legacy_meta, julia_dir))
-            RustCall.cleanup_old_cache(0)
-            @test all(isfile, (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir))
-            @test all(isdir, (legacy_v1, legacy_vcur, legacy_meta, julia_dir))
-
-            # Explicitly requested: only the RustCall artifacts go.
-            RustCall.sweep_stale_cache_formats(; legacy = true)
-            @test !isfile(legacy_lib)
-            @test !isfile(legacy_sum)
-            @test !isfile(legacy_ir)
-            @test !isdir(legacy_v1)
-            @test !isdir(legacy_vcur)
-            @test !isdir(legacy_meta)
-            @test isfile(julia_ji)      # Julia's precompile output survives
-            @test isfile(julia_img)
-            @test isfile(unrelated)
-            @test isdir(julia_dir)
-            @test isdir(root)           # the root itself is never removed
-        finally
             for f in (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir)
-                rm(f; force = true)
+                write(f, "x")
             end
             for d in (legacy_v1, legacy_vcur, legacy_meta, julia_dir)
-                rm(d; recursive = true, force = true)
+                mkpath(d)
+                write(joinpath(d, "content"), "x")
             end
-            # Do not leave Julia's precompile directory behind if this test
-            # created it: #252 is precisely about not writing here.
-            if !root_existed && isdir(root) && isempty(readdir(root))
-                rm(root; force = true)
-            end
-        end
+            try
+                # The classifiers are the safety property: only ours match.
+                listed = RustCall._legacy_cache_files()
+                @test legacy_lib in listed
+                @test legacy_sum in listed
+                @test legacy_ir in listed
+                @test !(julia_ji in listed)
+                @test !(julia_img in listed)
+                @test !(unrelated in listed)
 
-        # The pattern itself, stated directly.
-        @test occursin(RustCall._LEGACY_CACHE_FILE, "$(RustCall.stable_content_hash("k")).ll")
-        for name in ("qLtCw_2ChqG.ji", "qLtCw_2ChqG.dylib", "qLtCw_2ChqG.so",
-                     "notes.txt", "Manifest.toml", "ABCDEF0123456789.dylib",
-                     "deadbeef.stale", "libfoo.dylib")
-            @test !occursin(RustCall._LEGACY_CACHE_FILE, name)
+                dirs = RustCall._legacy_cache_dirs()
+                @test legacy_v1 in dirs
+                @test legacy_vcur in dirs
+                @test legacy_meta in dirs
+                @test !(julia_dir in dirs)
+
+                # Off by default: a plain sweep touches nothing under this root at
+                # all, and neither does an age-based cleanup.
+                RustCall.sweep_stale_cache_formats()
+                @test all(isfile, (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir))
+                @test all(isdir, (legacy_v1, legacy_vcur, legacy_meta, julia_dir))
+                RustCall.cleanup_old_cache(0)
+                @test all(isfile, (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir))
+                @test all(isdir, (legacy_v1, legacy_vcur, legacy_meta, julia_dir))
+
+                # Explicitly requested: only the RustCall artifacts go.
+                RustCall.sweep_stale_cache_formats(; legacy = true)
+                @test !isfile(legacy_lib)
+                @test !isfile(legacy_sum)
+                @test !isfile(legacy_ir)
+                @test !isdir(legacy_v1)
+                @test !isdir(legacy_vcur)
+                @test !isdir(legacy_meta)
+                @test isfile(julia_ji)      # Julia's precompile output survives
+                @test isfile(julia_img)
+                @test isfile(unrelated)
+                @test isdir(julia_dir)
+                @test isdir(root)           # the root itself is never removed
+            finally
+                for f in (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir)
+                    rm(f; force = true)
+                end
+                for d in (legacy_v1, legacy_vcur, legacy_meta, julia_dir)
+                    rm(d; recursive = true, force = true)
+                end
+                # Do not leave Julia's precompile directory behind if this test
+                # created it: #252 is precisely about not writing here.
+                if !root_existed && isdir(root) && isempty(readdir(root))
+                    rm(root; force = true)
+                end
+            end
+
+            # The pattern itself, stated directly.
+            @test occursin(RustCall._LEGACY_CACHE_FILE, "$(RustCall.stable_content_hash("k")).ll")
+            for name in ("qLtCw_2ChqG.ji", "qLtCw_2ChqG.dylib", "qLtCw_2ChqG.so",
+                         "notes.txt", "Manifest.toml", "ABCDEF0123456789.dylib",
+                         "deadbeef.stale", "libfoo.dylib")
+                @test !occursin(RustCall._LEGACY_CACHE_FILE, name)
+            end
         end
     end
 

--- a/test/test_cache.jl
+++ b/test/test_cache.jl
@@ -10,55 +10,191 @@ using Test
     @testset "Cache Directory Management" begin
         cache_dir = RustCall.get_cache_dir()
         @test isdir(cache_dir)
-        @test occursin("RustCall", cache_dir)
+        # The scratch space is namespaced by RustCall's package UUID.
+        @test occursin("scratchspaces", cache_dir)
+        @test occursin("7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c", cache_dir)
 
         metadata_dir = RustCall.get_metadata_dir()
         @test isdir(metadata_dir)
     end
 
-    @testset "Cache format namespace (#278)" begin
-        # Every cached artifact lives under a directory named for the on-disk
+    @testset "Cache format namespace (#252, #278)" begin
+        # Every cached artifact lives in a scratch space named for the on-disk
         # cache format, so a key-formula change (#278 Phase B) cannot serve a
-        # hit written by the previous format.
+        # hit written by the previous format, and two RustCalls that disagree
+        # about the layout keep separate trees.
         cache_dir = RustCall.get_cache_dir()
-        @test basename(cache_dir) == "v$(RustCall.CACHE_FORMAT_VERSION)"
-        @test basename(RustCall._cache_format_root()) == "RustCall"
-        @test dirname(cache_dir) == RustCall._cache_format_root()
+        @test basename(cache_dir) == "cache-v$(RustCall.CACHE_FORMAT_VERSION)"
+        @test RustCall.CACHE_SCRATCH_NAME == "cache-v$(RustCall.CACHE_FORMAT_VERSION)"
 
-        # The Cargo and metadata trees nest under the versioned directory.
+        # The Cargo and metadata trees nest under it.
         @test startswith(RustCall.get_metadata_dir(), cache_dir)
         @test startswith(RustCall.get_cargo_cache_dir(), cache_dir)
 
-        # Older siblings are swept best-effort; newer ones are left alone.
-        root = RustCall._cache_format_root()
-        old_dir = joinpath(root, "v1")
-        new_dir = joinpath(root, "v$(RustCall.CACHE_FORMAT_VERSION + 1)")
+        # Older scratch siblings are swept best-effort; newer ones are left alone.
+        root = dirname(cache_dir)
+        old_dir = joinpath(root, "cache-v1")
+        new_dir = joinpath(root, "cache-v$(RustCall.CACHE_FORMAT_VERSION + 1)")
+        unrelated = joinpath(root, "not-a-cache")
         mkpath(old_dir)
         mkpath(new_dir)
+        mkpath(unrelated)
         write(joinpath(old_dir, "x.txt"), "old")
         try
             stale = RustCall._stale_cache_format_dirs()
             @test old_dir in stale
             @test !(new_dir in stale)
+            @test !(unrelated in stale)
             @test !(cache_dir in stale)
 
             RustCall.sweep_stale_cache_formats()
             @test !isdir(old_dir)
             @test isdir(new_dir)      # a future format's cache is not ours to delete
+            @test isdir(unrelated)    # nor is anything that is not `cache-v<n>`
             @test isdir(cache_dir)
         finally
             rm(new_dir; recursive = true, force = true)
             rm(old_dir; recursive = true, force = true)
+            rm(unrelated; recursive = true, force = true)
         end
     end
 
-    @testset "The sweep never deletes what RustCall did not write (#287 review)" begin
-        # `_cache_format_root()` is `.../compiled/vX.Y/RustCall` — *Julia's own*
+    @testset "RustCall writes nothing under ~/.julia/compiled (#252)" begin
+        # Acceptance criterion 1 of #252: the cache is a Scratch.jl space, and
+        # `.../compiled/vX.Y/RustCall` — Julia's own precompile directory — is
+        # read-only for RustCall and is never created by it.
+        cache_dir = RustCall.get_cache_dir()
+        @test !occursin(joinpath("compiled", "v$(VERSION.major).$(VERSION.minor)"), cache_dir)
+
+        legacy_root = RustCall._legacy_cache_root()
+        legacy_existed = isdir(legacy_root)
+
+        # Every writer on the cache path goes through `get_cache_dir`; exercise
+        # them and assert the legacy root is untouched.
+        key = RustCall.stable_content_hash("#252 storage location probe")
+        payload = joinpath(mktempdir(), "probe" * RustCall.get_library_extension())
+        write(payload, "not really a library")
+        RustCall.save_cached_library(key, payload, RustCall.CacheMetadata(
+            key, key, "probe", "probe-triple", RustCall.Dates.now(), String["probe"]))
+        try
+            @test RustCall.get_cached_library(key) !== nothing
+            @test startswith(RustCall.get_cached_library(key), cache_dir)
+            @test startswith(RustCall.get_cargo_cache_dir(), cache_dir)
+            # Nothing appeared in Julia's precompile directory.
+            @test isdir(legacy_root) == legacy_existed
+            if legacy_existed
+                # ... and no RustCall cache artifact was written into it.
+                @test isempty(RustCall._legacy_cache_files())
+            end
+        finally
+            rm(RustCall.get_cached_library(key); force = true)
+            rm(joinpath(cache_dir, key * RustCall.get_library_extension() * ".sha256"); force = true)
+            rm(joinpath(RustCall.get_metadata_dir(), key * ".json"); force = true)
+        end
+    end
+
+    @testset "Read-only DEPOT_PATH[1] with a writable depot behind it (#252)" begin
+        # Acceptance criterion 3 of #252. `Scratch.get_scratch!` defaults to
+        # `first(DEPOT_PATH)`; RustCall scans for the first *writable* depot, so
+        # a read-only depot in front (shared/HPC depots, baked container images)
+        # is not fatal.
+        ro = mktempdir()
+        rw = mktempdir()
+        chmod(ro, 0o500)
+        ro_still_writable = try
+            probe = joinpath(ro, "probe")
+            touch(probe)
+            rm(probe; force = true)
+            true
+        catch
+            false
+        end
+        if Sys.iswindows() || ro_still_writable
+            # Running as root, or on a filesystem where mode bits do not deny
+            # the owner: there is no read-only directory to test against.
+            @info "Skipping read-only depot test: a 0o500 directory is still writable here"
+            chmod(ro, 0o700)
+            rm(ro; recursive = true, force = true)
+            rm(rw; recursive = true, force = true)
+        else
+            saved_depots = copy(DEPOT_PATH)
+            try
+                empty!(DEPOT_PATH)
+                append!(DEPOT_PATH, [ro, rw])
+                RustCall._reset_cache_dir_memo!()
+
+                @test RustCall._depot_is_writable(ro) == false
+                @test RustCall._depot_is_writable(rw) == true
+                @test RustCall._writable_depot() == rw
+
+                dir = RustCall.get_cache_dir()
+                @test isdir(dir)
+                @test startswith(dir, rw)
+                @test basename(dir) == RustCall.CACHE_SCRATCH_NAME
+                @test isempty(readdir(ro))          # the read-only depot stays empty
+
+                # The cache is actually usable from there.
+                write(joinpath(dir, "probe.txt"), "ok")
+                @test read(joinpath(dir, "probe.txt"), String) == "ok"
+                @test startswith(RustCall.get_metadata_dir(), dir)
+                @test startswith(RustCall.get_cargo_cache_dir(), dir)
+
+                # With no writable depot at all, the failure is a named error,
+                # not an IOError from deep inside a copy.
+                empty!(DEPOT_PATH)
+                push!(DEPOT_PATH, ro)
+                RustCall._reset_cache_dir_memo!()
+                @test RustCall._writable_depot() === nothing
+                err = try
+                    RustCall.get_cache_dir()
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa RustCall.RustError
+                @test occursin("DEPOT_PATH", sprint(showerror, err))
+                @test occursin("RUSTCALL_CACHE_DIR", sprint(showerror, err))
+            finally
+                empty!(DEPOT_PATH)
+                append!(DEPOT_PATH, saved_depots)
+                RustCall._reset_cache_dir_memo!()
+                chmod(ro, 0o700)
+                rm(ro; recursive = true, force = true)
+                rm(rw; recursive = true, force = true)
+            end
+        end
+    end
+
+    @testset "RUSTCALL_CACHE_DIR override (#252)" begin
+        override = mktempdir()
+        saved = get(ENV, "RUSTCALL_CACHE_DIR", nothing)
+        try
+            ENV["RUSTCALL_CACHE_DIR"] = override
+            RustCall._reset_cache_dir_memo!()
+            @test RustCall.get_cache_dir() == abspath(override)
+            @test startswith(RustCall.get_metadata_dir(), abspath(override))
+            # An explicitly chosen directory has no sibling namespace to sweep.
+            @test isempty(RustCall._stale_cache_format_dirs())
+        finally
+            if saved === nothing
+                delete!(ENV, "RUSTCALL_CACHE_DIR")
+            else
+                ENV["RUSTCALL_CACHE_DIR"] = saved
+            end
+            RustCall._reset_cache_dir_memo!()
+            rm(override; recursive = true, force = true)
+        end
+    end
+
+    @testset "The legacy sweep never deletes what RustCall did not write (#252, #287)" begin
+        # `_legacy_cache_root()` is `.../compiled/vX.Y/RustCall` — *Julia's own*
         # package precompile directory for RustCall, where it keeps `<slug>.ji`
         # and `<slug>.dylib` native images. Deleting every regular file there
         # would throw away fresh precompilation output and could race another
-        # Julia process writing it.
-        root = RustCall._cache_format_root()
+        # Julia process writing it. Since #252 RustCall never writes here at
+        # all; the tree is read for the opt-in legacy sweep and nothing else.
+        root = RustCall._legacy_cache_root()
+        root_existed = isdir(root)
         mkpath(root)
 
         # Named exactly as Julia names them (a package slug: mixed case and an
@@ -73,12 +209,23 @@ using Test
         legacy_lib = joinpath(root, v1_key * RustCall.get_library_extension())
         legacy_sum = legacy_lib * ".sha256"
         legacy_ir = joinpath(root, v1_key * ".ll")
+        # Directory shapes both layouts left behind, including the *current*
+        # format version: since #252 nothing under this root is written any
+        # more, so every `v<n>` there is abandoned, not just the older ones.
+        legacy_v1 = joinpath(root, "v1")
+        legacy_vcur = joinpath(root, "v$(RustCall.CACHE_FORMAT_VERSION)")
+        legacy_meta = joinpath(root, "metadata")
+        julia_dir = joinpath(root, "qLtCw_2ChqG.dSYM")
 
         for f in (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir)
             write(f, "x")
         end
+        for d in (legacy_v1, legacy_vcur, legacy_meta, julia_dir)
+            mkpath(d)
+            write(joinpath(d, "content"), "x")
+        end
         try
-            # The classifier is the safety property: only ours match.
+            # The classifiers are the safety property: only ours match.
             listed = RustCall._legacy_cache_files()
             @test legacy_lib in listed
             @test legacy_sum in listed
@@ -87,24 +234,45 @@ using Test
             @test !(julia_img in listed)
             @test !(unrelated in listed)
 
-            # Off by default: a plain sweep touches no loose file at all, and
-            # neither does an age-based cleanup.
+            dirs = RustCall._legacy_cache_dirs()
+            @test legacy_v1 in dirs
+            @test legacy_vcur in dirs
+            @test legacy_meta in dirs
+            @test !(julia_dir in dirs)
+
+            # Off by default: a plain sweep touches nothing under this root at
+            # all, and neither does an age-based cleanup.
             RustCall.sweep_stale_cache_formats()
             @test all(isfile, (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir))
+            @test all(isdir, (legacy_v1, legacy_vcur, legacy_meta, julia_dir))
             RustCall.cleanup_old_cache(0)
             @test all(isfile, (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir))
+            @test all(isdir, (legacy_v1, legacy_vcur, legacy_meta, julia_dir))
 
             # Explicitly requested: only the RustCall artifacts go.
-            RustCall.sweep_stale_cache_formats(; legacy_files = true)
+            RustCall.sweep_stale_cache_formats(; legacy = true)
             @test !isfile(legacy_lib)
             @test !isfile(legacy_sum)
             @test !isfile(legacy_ir)
+            @test !isdir(legacy_v1)
+            @test !isdir(legacy_vcur)
+            @test !isdir(legacy_meta)
             @test isfile(julia_ji)      # Julia's precompile output survives
             @test isfile(julia_img)
             @test isfile(unrelated)
+            @test isdir(julia_dir)
+            @test isdir(root)           # the root itself is never removed
         finally
             for f in (julia_ji, julia_img, unrelated, legacy_lib, legacy_sum, legacy_ir)
                 rm(f; force = true)
+            end
+            for d in (legacy_v1, legacy_vcur, legacy_meta, julia_dir)
+                rm(d; recursive = true, force = true)
+            end
+            # Do not leave Julia's precompile directory behind if this test
+            # created it: #252 is precisely about not writing here.
+            if !root_existed && isdir(root) && isempty(readdir(root))
+                rm(root; force = true)
             end
         end
 


### PR DESCRIPTION
## What

RustCall wrote its compiled `.dylib`/`.so`/`.dll` files, their `.sha256` checksums, the `metadata/` tree and the Cargo build products into `$(DEPOT_PATH[1])/compiled/vX.Y/RustCall` — **Julia's own package precompile directory**. Pkg neither tracks nor GCs foreign files there, and that depot is read-only in common deployments (shared/HPC depots, baked container images), where `mkpath`/`cp` threw and RustCall was simply unusable.

`RustCall.get_cache_dir()` is now a [Scratch.jl](https://github.com/JuliaPackaging/Scratch.jl) space — `<depot>/scratchspaces/<RustCall UUID>/cache-v$(CACHE_FORMAT_VERSION)` — writable by construction, accounted for by `Pkg.gc()`, and namespaced by the on-disk format version so two RustCalls that disagree about the layout keep separate trees. `get_metadata_dir()` and `get_cargo_cache_dir()` nest under it, so every writer on the cache path moved with one edit.

Three details worth review:

- **`Scratch` defaults to `first(DEPOT_PATH)`**, which would have preserved the read-only-depot failure. RustCall scans `DEPOT_PATH` for the first depot a scratch space can actually be created in and passes it as `depot_path`. The probe is a real write-and-remove, because `mkpath` is a no-op on an existing directory whatever its mode. With no writable depot at all the failure is a named `RustError` naming the depots tried and the `RUSTCALL_CACHE_DIR` override, not an `IOError` from inside a file copy. The resolved directory is memoized on `(DEPOT_PATH, RUSTCALL_CACHE_DIR)` so the probe is not on the path of every cache lookup.
- **`RUSTCALL_CACHE_DIR`** short-circuits resolution entirely, for air-gapped and CI setups (the override the issue asks for).
- **The old root is `_legacy_cache_root()`**: read-only for RustCall, never created by it, consulted only by the opt-in legacy sweep. Since nothing writes there any more, `_legacy_cache_dirs()` treats *every* `v<n>` directory there as abandoned rather than only the older ones — but only under `sweep_stale_cache_formats(legacy = true)` / `clear_cache(sweep_legacy = true)`, and still only RustCall's own directory names and the exact pre-#278 loose-file pattern. Julia's `.ji` and native images beside them, and the root directory itself, are never touched. The default sweep now removes only older `cache-v<n>` scratch siblings.

Existing caches are not migrated: the first compile after upgrading rebuilds.

## Acceptance criteria → test

| #252 criterion | test |
| --- | --- |
| No files written under `~/.julia/compiled/` by RustCall | `test/test_cache.jl` → `"RustCall writes nothing under ~/.julia/compiled (#252)"` — drives `save_cached_library`, `get_metadata_dir` and `get_cargo_cache_dir`, then asserts the legacy root is unchanged and holds no RustCall artifact. Plus `"The legacy sweep never deletes what RustCall did not write (#252, #287)"` for the read-only/opt-in contract on that root. |
| Cache entry created with toolchain A is not reused after the toolchain fingerprint changes | `test/test_cache.jl` → `"The compiler in the key is the compiler that runs (#252)"` (already present; injects a fake `_TOOLCHAIN_FINGERPRINT` and asserts key change + `!is_cache_valid`). |
| Works with a read-only `DEPOT_PATH[1]` when a writable scratch depot exists | `test/test_cache.jl` → `"Read-only DEPOT_PATH[1] with a writable depot behind it (#252)"` — `DEPOT_PATH` is pointed at a `0o500` temp dir plus a writable second depot; asserts the scratch space lands in the writable one, is usable, and the read-only depot stays empty. Skips where a `0o500` directory is still writable (root, Windows). Also covers the no-writable-depot `RustError`, and a sibling testset covers `RUSTCALL_CACHE_DIR`. |

Also updated: `CLAUDE.md` (cache description), `CHANGELOG.md`, `docs/src/performance.md`, `docs/src/precompilation.md`. `Scratch` added to `[deps]`/`[compat]`.

## Verification

`Pkg.build`, full `Pkg.test()` (6995 pass, 2 pre-existing broken), all five `scripts/lint_*.sh src`, `julia --project=docs docs/make.jl` exit 0.

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
