### PR TITLE
CI: CompatHelper passed a token where an SSH private key belongs

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -5,22 +5,34 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:
 
+# The repository's default workflow token is read-only, so the job has to ask
+# for what it needs: push the compat branch and open the pull request.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v2
         with:
-          version: '1.10'
-      
+          version: '1'
+
       - name: Install CompatHelper
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      
-      - uses: actions/checkout@v4
-      
+
       - name: Run CompatHelper
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.GITHUB_TOKEN }}
+          # An *SSH private key* in PEM format, never a token: CompatHelper
+          # base64-decodes this and hands it to ssh. Passing GITHUB_TOKEN here
+          # made every run die with "Private key is not in the correct format".
+          # The secret is optional — unset, it is the empty string and
+          # CompatHelper falls back to GITHUB_TOKEN. Set it (with the matching
+          # public key added as a write deploy key) if the compat PRs should
+          # trigger CI, which a GITHUB_TOKEN-authored PR does not.
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       lookback:
+        description: How many days back to look for untagged releases.
         default: '3'
 
 # The repository's default workflow token is read-only; TagBot creates the tag
@@ -26,7 +27,13 @@ permissions:
 
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@JuliaTagBot tag'))
+    # `contents: write` above makes this condition a security boundary: in a
+    # public repository anyone can post an issue comment, so matching on the
+    # comment *body* would let any commenter start a job holding a write token.
+    # Gate on the actor instead — the JuliaTagBot account, which is what
+    # comments when a registry pull request merges — as the JuliaRegistries
+    # template does.
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
@@ -38,3 +45,7 @@ jobs:
           # in this repository; `DOCUMENTER_KEY` is the name the JuliaRegistries
           # template uses, and the one Documenter would share.
           ssh: ${{ secrets.DOCUMENTER_KEY }}
+          # Forwarded, so the dispatch input above is not a knob that does
+          # nothing. Empty on an `issue_comment` run, where it falls back to
+          # the action's own default of 3.
+          lookback: ${{ inputs.lookback || 3 }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,25 @@ on:
   issue_comment:
     types: [created]
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: '3'
+
+# The repository's default workflow token is read-only; TagBot creates the tag
+# and the GitHub release, so it has to ask for write access to contents.
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  discussions: read
+  issues: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 
 jobs:
   TagBot:
@@ -13,4 +32,9 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.TAGBOT_SSH_KEY }}
+          # Optional. When set (with the matching public key as a write deploy
+          # key) the tag push triggers the tag-gated workflows; unset, TagBot
+          # falls back to the token above. `TAGBOT_SSH_KEY` was never a secret
+          # in this repository; `DOCUMENTER_KEY` is the name the JuliaRegistries
+          # template uses, and the one Documenter would share.
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Why

[Run 34020167723](https://github.com/AtelierArith/RustCall.jl/actions/runs/34020167723) — and every CompatHelper run before it — ended the same way:

```
[ Info: EnvVar `COMPATHELPER_PRIV` is defined, nonempty, and not `false`
[ Info: This doesn't look like a raw SSH private key. I will assume that it is a Base64-encoded SSH private key.
ERROR: Private key is not in the correct format. It must be a private key in PEM format.
```

`COMPATHELPER_PRIV` is not a second place to put the GitHub token. CompatHelper base64-decodes it and hands it to `ssh`. The workflow set it to `${{ secrets.GITHUB_TOKEN }}`, so the job did all of its registry work and then died decoding the token as a PEM key. No compat PR has ever been opened.

Two things had to change for a run to actually succeed:

1. **`COMPATHELPER_PRIV` now names an optional `COMPATHELPER_PRIV` secret.** It is not configured in this repository, so the variable is the empty string and CompatHelper takes its documented `GITHUB_TOKEN` path. Setting the secret later (with the matching public key added as a write deploy key) is what makes the compat PRs trigger CI, which a `GITHUB_TOKEN`-authored PR does not.
2. **Explicit `permissions:`.** `default_workflow_permissions` for this repository is `read`, so the token fallback would have failed at the branch push immediately after. CompatHelper asks for `contents: write` + `pull-requests: write`; TagBot, which has the same problem waiting for it the first time a release is tagged, asks for `contents: write`.

In passing: `actions/checkout` runs before the Julia steps rather than between them, `julia-actions/setup-julia` moves from the deprecated `v1` to `v2` and from a pinned `1.10` to `1`, and TagBot's `ssh:` points at `DOCUMENTER_KEY` — the name the JuliaRegistries template uses — instead of `TAGBOT_SSH_KEY`, which has never been a secret here.

## Verification

Nothing in `src/` or `test/` is touched, so `Pkg.test()` is unaffected. The proof is a `workflow_dispatch` run of CompatHelper from this branch after merge; the failure signature above is reproduced exactly by the current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
