### PR TITLE
Fail closed on by-value aggregates and on contradicted return annotations (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Existing caches are not migrated: the first compile after upgrading rebuilds.
 
+- **Passing a Julia struct to Rust by value is opt-in**
+  ([#245](https://github.com/AtelierArith/RustCall.jl/issues/245)).
+  `is_supported_arg_type(::Type{T}) = isbitstype(T)` accepted *any* isbits Julia
+  struct or tuple as a by-value argument or return, and `ccall_arg_type` passed
+  it through unchanged — assuming its layout matched the Rust side's. Rust's
+  default `repr(Rust)` layout is explicitly unspecified (fields may be
+  reordered, niches exploited), so an unannotated struct that works today is a
+  silent miscompile waiting for a toolchain upgrade.
+
+  An aggregate now needs a layout assertion, and `RustCall.register_ffi_struct`
+  is where it is made:
+
+  ```julia
+  struct Point            # matches #[repr(C)] pub struct Point { x: f64, y: f64 }
+      x::Float64
+      y::Float64
+  end
+  RustCall.register_ffi_struct(Point)
+  ```
+
+  Without it the call raises a `RustError` naming the type, its fields and the
+  opt-in. Registration is for **concrete types only**: `Point{Float64}` says
+  nothing about `Point{Int32}` — a parameter changes sizes, alignment and
+  register classes — and registering the `UnionAll` `Point`, or an abstract
+  type, is an error rather than a family-wide claim. Scalars, pointers,
+  `Cstring`, `Char` and
+  `Bool` are unaffected — their ABI is their width. So are the wrappers
+  RustCall generates from a `#[julia] struct`, which cross as opaque handles,
+  and RustCall's own `#[repr(C)]` mirrors: `CRustString`, `CRustSlice` and
+  friends have `ffi_by_value_layout` methods in the package, and the
+  `CResult_<fn>` / `COption_<fn>` aggregates the wrapper generators emit
+  subtype `RustCall.FFIByValue`. The assertion is a **method**, defined in the
+  module that owns the type, so `register_ffi_struct` at a package's top level
+  is carried by that package's precompile cache and holds in every later
+  session — a mutated global would not be. `unregister_ffi_struct` withdraws an
+  assertion; `repr_c = false` is rejected, because then there is nothing to
+  assert. The supported-type matrix and the opt-in are documented on the FFI
+  type contract page. `BINDINGS_FORMAT_VERSION` goes to `4`: a written-out
+  bindings file now imports `RustCall.FFIByValue`, a name an older RustCall does
+  not have, so regenerate after upgrading.
+
+- **A `::T` return annotation may no longer contradict the manifest**
+  ([#245](https://github.com/AtelierArith/RustCall.jl/issues/245)). `@rust
+  f(x)::Float64` on a function the manifest records as `-> i32` used to win, and
+  the `ccall` then read a 32-bit return slot as a `Float64` — silent garbage.
+  An annotation supplies a return type RustCall does not know; when one *is*
+  recorded, a differing annotation raises a `RustError` naming both types.
+  Agreement is *the same `ccall` return slot*, not the same Julia type — the
+  manifest records the slot while an annotation names the surface type, so
+  `::Char` and `::UInt32` both agree with a `-> char` and `::Int32` does not.
+  Annotations on symbols with no recorded type are unchanged. Convert on the
+  Julia side if you wanted the other type.
+
 - **One load/registration path** ([#277](https://github.com/AtelierArith/RustCall.jl/issues/277),
   Phase B). Twelve `dlopen` sites with four different flag sets and eight
   open-coded `RUST_LIBRARIES[...] = ...` writes became one:

--- a/docs/generate_type_matrix.jl
+++ b/docs/generate_type_matrix.jl
@@ -165,6 +165,100 @@ re-encode from whatever the bytes really are) produces one that is. To send
 bytes that are **not** text at all, take them on the Rust side as a
 `*const u8` plus a length — a `&[u8]` slice argument is not lowered by the
 `#[julia]` pipeline, so there is no `Vec{UInt8}` argument to pass.
+
+## Passing a Julia struct to Rust by value is opt-in
+
+A Julia struct is not a C type. `@rust f(p)` with an `isbits` struct `p` used to
+copy its fields straight into the argument registers on the assumption that the
+Rust struct on the other side has the same layout — but Rust's default
+`repr(Rust)` layout is **explicitly unspecified**: the compiler may reorder
+fields and exploit niches, and is free to change its mind between versions. An
+unannotated struct that "works" today is a silent miscompile waiting for a
+toolchain upgrade, which is why RustCall refuses it (issue
+[#245](https://github.com/AtelierArith/RustCall.jl/issues/245)):
+
+```julia
+struct Point
+    x::Float64
+    y::Float64
+end
+
+@rust process_point(Point(3.0, 4.0))::Float64
+# ERROR: RustError: cannot pass `Point` to Rust by value as argument 1:
+# RustCall has no layout assertion for it (#245). ...
+```
+
+Declare the Rust struct `#[repr(C)]` — which *does* fix the field order — and
+record the claim once:
+
+```julia
+RustCall.register_ffi_struct(Point)
+
+@rust process_point(Point(3.0, 4.0))::Float64   # 25.0
+```
+
+`register_ffi_struct` asserts that the corresponding Rust type is `#[repr(C)]`
+and that its fields line up with the Julia struct's in order and in type.
+RustCall cannot check that for you; the call is where you take responsibility
+for it. The assertion is recorded as a **method** of
+`RustCall.ffi_by_value_layout`, defined in the module that owns the type, so
+calling `register_ffi_struct` at a package's top level survives that package's
+precompilation and holds in every later session.
+
+Registration is for **concrete types only**. `register_ffi_struct(Point)` on a
+parametric struct, or on an abstract type, is an error: instantiations of
+`Point{T}` do not share a layout — a type parameter changes field sizes,
+alignment and even ABI register classes — and subtypes of an abstract family
+share even less, so a family-wide assertion would license values you never
+matched against a Rust struct. Register each concrete type you actually pass;
+`register_ffi_struct(Point{Float64})` says exactly that, and says nothing about
+`Point{Int32}`. `RustCall.unregister_ffi_struct(T)` withdraws an assertion, and
+`repr_c = false` is rejected — without `#[repr(C)]` there is nothing to assert.
+
+You do **not** need it for:
+
+- scalars, pointers, `Cstring`, `Char` and `Bool` — their ABI is their width;
+- the struct wrappers RustCall generates from a `#[julia] struct` (see
+  [Struct mapping](struct_mapping.md)), which cross the boundary as an opaque
+  handle rather than as a field-by-field copy;
+- RustCall's own `#[repr(C)]` mirrors: `CRustString`, `CRustSlice` and friends
+  have `ffi_by_value_layout` methods written in the package itself — including
+  covering ones such as `::Type{<:RustPtr}`, which is a claim RustCall may make
+  about its own types (a `RustPtr{T}` really is one pointer whatever `T` is)
+  and which `register_ffi_struct` will not make on your behalf. The
+  `CResult_<fn>` / `COption_<fn>` aggregates the wrapper generators emit are
+  subtypes of `RustCall.FFIByValue`, an assertion that needs no call at all.
+
+If the Rust struct is not `#[repr(C)]`, do not register it. Pass the value
+behind a pointer, or define it with `#[julia]` and let RustCall generate the
+handle-based wrapper.
+
+## A return annotation may not contradict the manifest
+
+`::T` at a call site exists to supply a return type RustCall does not know. When
+the manifest *does* record one, a differing annotation is an error rather than
+an override — reading a 32-bit return slot as a `Float64` is undefined
+behaviour, not a cast:
+
+```julia
+rust\"\"\"
+#[julia]
+pub fn double(a: i32) -> i32 { a * 2 }
+\"\"\"
+
+@rust double(Int32(21))            # Int32(42) — the manifest decides
+@rust double(Int32(21))::Int32     # Int32(42) — agreeing is fine
+@rust double(Int32(21))::Float64
+# ERROR: RustError: return type annotation `::Float64` on `@rust double(...)`
+# disagrees with the manifest, which records `Int32` ...
+```
+
+Convert on the Julia side if you wanted a `Float64`.
+
+Agreement is *the same `ccall` return slot*, not the same Julia type, because
+the manifest records the slot while an annotation names the surface type. Rust
+`char` is a `UInt32` code point in the slot and a `Char` on the surface, so
+`::Char` and `::UInt32` both agree with a `-> char` and `::Int32` does not.
 """
 
 function _matrix_rows()

--- a/docs/src/crate_bindings.md
+++ b/docs/src/crate_bindings.md
@@ -532,10 +532,11 @@ library; see [Panics, Visibility and Lifetime](panics.md) for the full contract.
 ## Regenerating bindings after an upgrade
 
 Files written by `write_bindings_to_file` carry a format marker
-(`# Bindings format: 3`). Regenerate after upgrading RustCall.
+(`# Bindings format: 4`). Regenerate after upgrading RustCall.
 
 Version `3` is the first that does **not** keep working when it is older than
 the RustCall loading it: the emitted wrappers name `RustCall.ffi_string_argument`,
-which earlier versions do not have. A file at version `2` or below still loads —
-it uses only API that still exists — but does not get the unload,
-panic-containment, lifetime or UTF-8 guarantees described above.
+and `4` adds `RustCall.FFIByValue`, neither of which earlier versions have. A
+file at version `2` or below still loads — it uses only API that still exists —
+but does not get the unload, panic-containment, lifetime, UTF-8 or by-value
+guarantees described above.

--- a/docs/src/type_contract.md
+++ b/docs/src/type_contract.md
@@ -183,3 +183,97 @@ re-encode from whatever the bytes really are) produces one that is. To send
 bytes that are **not** text at all, take them on the Rust side as a
 `*const u8` plus a length — a `&[u8]` slice argument is not lowered by the
 `#[julia]` pipeline, so there is no `Vec{UInt8}` argument to pass.
+
+## Passing a Julia struct to Rust by value is opt-in
+
+A Julia struct is not a C type. `@rust f(p)` with an `isbits` struct `p` used to
+copy its fields straight into the argument registers on the assumption that the
+Rust struct on the other side has the same layout — but Rust's default
+`repr(Rust)` layout is **explicitly unspecified**: the compiler may reorder
+fields and exploit niches, and is free to change its mind between versions. An
+unannotated struct that "works" today is a silent miscompile waiting for a
+toolchain upgrade, which is why RustCall refuses it (issue
+[#245](https://github.com/AtelierArith/RustCall.jl/issues/245)):
+
+```julia
+struct Point
+    x::Float64
+    y::Float64
+end
+
+@rust process_point(Point(3.0, 4.0))::Float64
+# ERROR: RustError: cannot pass `Point` to Rust by value as argument 1:
+# RustCall has no layout assertion for it (#245). ...
+```
+
+Declare the Rust struct `#[repr(C)]` — which *does* fix the field order — and
+record the claim once:
+
+```julia
+RustCall.register_ffi_struct(Point)
+
+@rust process_point(Point(3.0, 4.0))::Float64   # 25.0
+```
+
+`register_ffi_struct` asserts that the corresponding Rust type is `#[repr(C)]`
+and that its fields line up with the Julia struct's in order and in type.
+RustCall cannot check that for you; the call is where you take responsibility
+for it. The assertion is recorded as a **method** of
+`RustCall.ffi_by_value_layout`, defined in the module that owns the type, so
+calling `register_ffi_struct` at a package's top level survives that package's
+precompilation and holds in every later session.
+
+Registration is for **concrete types only**. `register_ffi_struct(Point)` on a
+parametric struct, or on an abstract type, is an error: instantiations of
+`Point{T}` do not share a layout — a type parameter changes field sizes,
+alignment and even ABI register classes — and subtypes of an abstract family
+share even less, so a family-wide assertion would license values you never
+matched against a Rust struct. Register each concrete type you actually pass;
+`register_ffi_struct(Point{Float64})` says exactly that, and says nothing about
+`Point{Int32}`. `RustCall.unregister_ffi_struct(T)` withdraws an assertion, and
+`repr_c = false` is rejected — without `#[repr(C)]` there is nothing to assert.
+
+You do **not** need it for:
+
+- scalars, pointers, `Cstring`, `Char` and `Bool` — their ABI is their width;
+- the struct wrappers RustCall generates from a `#[julia] struct` (see
+  [Struct mapping](struct_mapping.md)), which cross the boundary as an opaque
+  handle rather than as a field-by-field copy;
+- RustCall's own `#[repr(C)]` mirrors: `CRustString`, `CRustSlice` and friends
+  have `ffi_by_value_layout` methods written in the package itself — including
+  covering ones such as `::Type{<:RustPtr}`, which is a claim RustCall may make
+  about its own types (a `RustPtr{T}` really is one pointer whatever `T` is)
+  and which `register_ffi_struct` will not make on your behalf. The
+  `CResult_<fn>` / `COption_<fn>` aggregates the wrapper generators emit are
+  subtypes of `RustCall.FFIByValue`, an assertion that needs no call at all.
+
+If the Rust struct is not `#[repr(C)]`, do not register it. Pass the value
+behind a pointer, or define it with `#[julia]` and let RustCall generate the
+handle-based wrapper.
+
+## A return annotation may not contradict the manifest
+
+`::T` at a call site exists to supply a return type RustCall does not know. When
+the manifest *does* record one, a differing annotation is an error rather than
+an override — reading a 32-bit return slot as a `Float64` is undefined
+behaviour, not a cast:
+
+```julia
+rust"""
+#[julia]
+pub fn double(a: i32) -> i32 { a * 2 }
+"""
+
+@rust double(Int32(21))            # Int32(42) — the manifest decides
+@rust double(Int32(21))::Int32     # Int32(42) — agreeing is fine
+@rust double(Int32(21))::Float64
+# ERROR: RustError: return type annotation `::Float64` on `@rust double(...)`
+# disagrees with the manifest, which records `Int32` ...
+```
+
+Convert on the Julia side if you wanted a `Float64`.
+
+Agreement is *the same `ccall` return slot*, not the same Julia type, because
+the manifest records the slot while an annotation names the surface type. Rust
+`char` is a `UInt32` code point in the slot and a `Char` on the surface, so
+`::Char` and `::UInt32` both agree with a `-> char` and `::Int32` does not.

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -531,8 +531,11 @@ function infer_function_types(lib_name::String, func_name::String)
         end
     end
 
-    # If we can't infer, return generic types
-    error("Cannot infer types for function '$func_name'. Please provide explicit type annotations.")
+    # If we can't infer, say so with a type the caller can catch *narrowly*.
+    # This used to be a bare `error(...)`, and the one caller wrapped it in a
+    # `try`/`catch` that swallowed every exception — including the fail-closed
+    # errors the FFI contract raises (#245).
+    throw(SignatureInferenceError(func_name, lib_name))
 end
 
 """
@@ -689,6 +692,11 @@ result = call_rust_function(target.func_ptr, Int32, 10, 20)  # Returns Int32
 """
 function call_rust_function(func_ptr::Ptr{Cvoid}, ret_type::Type, args...)
     argt = normalize_arg_types(ret_type, typeof(args))
+    # Fail closed on an aggregate nobody asserted a layout for (#245 item 3).
+    # Checked here rather than inside `_call_rust_function`, which is
+    # `@generated`: a generated method is not re-generated when
+    # `register_ffi_struct` is called later in the session.
+    ffi_check_by_value(ret_type, argt.parameters)
     return _call_rust_function(func_ptr, ret_type, argt, args...)
 end
 
@@ -717,6 +725,7 @@ function call_rust_function(func_ptr::Ptr{Cvoid}, ret_type::Type, arg_types::Vec
         error("Argument count mismatch: expected $(length(arg_types)), got $(length(args))")
     end
     argt = Core.apply_type(Tuple, arg_types...)
+    ffi_check_by_value(ret_type, argt.parameters)
     return _call_rust_function(func_ptr, ret_type, argt, args...)
 end
 
@@ -738,6 +747,7 @@ function call_rust_function(func_ptr::Ptr{Cvoid}, ret_type::Type, argt::Type{<:T
     if length(argt.parameters) != length(args)
         error("Argument count mismatch: expected $(length(argt.parameters)), got $(length(args))")
     end
+    ffi_check_by_value(ret_type, argt.parameters)
     return _call_rust_function(func_ptr, ret_type, argt, args...)
 end
 

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -414,7 +414,8 @@ function emit_crate_module(info::CrateInfo, lib_path::String;
     module_body = quote
         import RustCall
         import RustCall: call_rust_function, get_function_pointer_from_lib, RustResult, RustOption, _check_not_freed,
-                         _call_rust_owned_string_ptr, _call_rust_borrowed_string_ptr, convert_return
+                         _call_rust_owned_string_ptr, _call_rust_borrowed_string_ptr, convert_return,
+                         FFIByValue
         import Libdl
 
         const _LIB_PATH = $lib_path
@@ -692,7 +693,11 @@ function _generate_result_function_wrapper(func::RustFunctionSignature, arg_syms
 
     quote
         # Define the C-compatible struct for this function's result
-        struct $c_result_struct_name
+        # RustCall's own mirror of the extractor's `#[repr(C)]` aggregate, so
+        # it carries the by-value layout assertion in its supertype (#245) —
+        # a static property that survives this module being precompiled into a
+        # downstream package, which a registry mutation would not.
+        struct $c_result_struct_name <: FFIByValue
             is_ok::UInt8
             ok_value::$ok_slot_type
             err_value::$err_slot_type
@@ -746,7 +751,8 @@ function _generate_option_function_wrapper(func::RustFunctionSignature, arg_syms
 
     quote
         # Define the C-compatible struct for this function's option
-        struct $c_option_struct_name
+        # See the Result wrapper: RustCall's own mirror (#245).
+        struct $c_option_struct_name <: FFIByValue
             is_some::UInt8
             value::$inner_slot_type
         end
@@ -1272,12 +1278,16 @@ older RustCall produced.
   which the file imports, so invalid UTF-8 raises instead of being substituted.
   That name does not exist in an older RustCall, so a file emitted here does
   not load against one — the direction the marker is really for.
+- `4` (#245): the emitted `CResult_<fn>` / `COption_<fn>` mirrors subtype
+  `RustCall.FFIByValue`, which the file imports. That name does not exist in an
+  older RustCall, so a file emitted here does not load against one — the
+  direction the marker is really for.
 
 A file emitted by an older version still *works* — it only uses public API that
 still exists — but it does not get the unload, panic or lifetime guarantees.
 Regenerate after upgrading; the marker is what makes that visible.
 """
-const BINDINGS_FORMAT_VERSION = 3
+const BINDINGS_FORMAT_VERSION = 4
 
 """
     crate_library_name(info::CrateInfo; release = true) -> String
@@ -1768,7 +1778,8 @@ function emit_crate_module_code(info::CrateInfo, lib_path::String;
     # Imports
     push!(lines, "import RustCall")
     push!(lines, "import RustCall: call_rust_function, get_function_pointer_from_lib, RustResult, RustOption, _check_not_freed,")
-    push!(lines, "                 _call_rust_owned_string_ptr, _call_rust_borrowed_string_ptr, convert_return")
+    push!(lines, "                 _call_rust_owned_string_ptr, _call_rust_borrowed_string_ptr, convert_return,")
+    push!(lines, "                 FFIByValue")
     push!(lines, "import Libdl")
     push!(lines, "")
 
@@ -1976,7 +1987,7 @@ function _emit_result_function_code(func::RustFunctionSignature, arg_syms::Strin
     channel_var = _generated_local("panic_channel", func.arg_names)
 
     return """
-struct $c_result_struct_name
+struct $c_result_struct_name <: FFIByValue
     is_ok::UInt8
     ok_value::$ok_slot_str
     err_value::$err_slot_str
@@ -2010,7 +2021,7 @@ function _emit_option_function_code(func::RustFunctionSignature, arg_syms::Strin
     channel_var = _generated_local("panic_channel", func.arg_names)
 
     return """
-struct $c_option_struct_name
+struct $c_option_struct_name <: FFIByValue
     is_some::UInt8
     value::$inner_slot_str
 end

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -21,6 +21,36 @@ struct RustError <: Exception
 end
 
 """
+    SignatureInferenceError
+
+RustCall could not work out a function's signature from the LLVM IR it has for
+it — because it has none, or because the function is not in it.
+
+It exists so the *caller* can catch that, and only that. `_rust_call_dynamic`
+tries LLVM inference as one of several ways to learn a return type, and a bare
+`try`/`catch` there swallowed everything: a `RustError` from the FFI type
+contract (an unregistered by-value aggregate, #245), a `MethodError`, anything
+— and reported "no return type" instead. Swallowing a fail-closed error is the
+fail-open pattern the contract exists to remove, so the catch names this type
+and every other exception propagates.
+
+# Fields
+- `func_name::String`, `lib_name::String` — what was being resolved.
+"""
+struct SignatureInferenceError <: Exception
+    func_name::String
+    lib_name::String
+end
+
+function Base.showerror(io::IO, e::SignatureInferenceError)
+    print(io, "SignatureInferenceError: cannot infer the signature of '",
+          e.func_name, "'")
+    isempty(e.lib_name) || print(io, " in library '", e.lib_name, "'")
+    print(io, " from LLVM IR. Annotate the call site with `::T`, or mark the ",
+          "Rust function `#[julia]` so the manifest reports its signature.")
+end
+
+"""
     RustPanicError <: Exception
 
 A Rust `panic!` that was caught at the FFI boundary (#244).

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -1219,3 +1219,358 @@ function _ffi_string_argument(value, descriptor::AbstractString, context::Abstra
         "all, take them as a `*const u8` plus a length on the Rust side; a " *
         "`&[u8]` slice argument is not lowered by the `#[julia]` pipeline."))
 end
+
+# By-value aggregates are opt-in (issue #245 item 3)
+# ============================================================================
+
+"""
+    FFIByValue
+
+Marker supertype for the `#[repr(C)]` mirror aggregates **RustCall itself
+generates**: the `CResult_<fn>` / `COption_<fn>` structs the wrapper generators
+emit next to a `Result`- or `Option`-returning function, in every flavour
+(macro-expanded and source-emitted, crate and inline).
+
+They need no registration at all, and must not depend on one: the generated
+code may be precompiled into a downstream package, and a subtype relation is a
+static property of the type — it survives because it *is* the type. (The
+`ffi_by_value_layout` method table exists for the same reason, one level up: a
+method is precompiled too. This is the cheaper answer for types RustCall itself
+emits, because it needs no call at all.)
+"""
+abstract type FFIByValue end
+
+"""
+    ffi_by_value_layout(::Type{T}) -> Symbol
+
+`:repr_c` when someone has asserted that `T` may cross the boundary **by
+value**, `:unknown` otherwise. The registry of #245, expressed as a **method
+table** rather than a container.
+
+`is_supported_arg_type` used to be `isbitstype(T)`, and `ccall_arg_type` the
+identity — so any isbits Julia struct or tuple was passed by value on the
+assumption that its layout matches the Rust side's. Rust's default
+`repr(Rust)` layout is explicitly unspecified (fields may be reordered, niches
+exploited), so that assumption holds only until a rustc upgrade decides
+otherwise, and then it is silent corruption rather than an error. This function
+is the record of who asserted otherwise, and about which type.
+
+# Why dispatch and not a `Set`
+
+Because a registration has to survive precompilation. `register_ffi_struct` is
+meant to be called at a package's top level, next to the struct it is about —
+and a `push!` into a global that lives in **RustCall** happens during that
+package's precompilation and is *not* replayed when the package is later loaded
+from its cache. The assertion would hold in the session that compiled the
+package and be gone in every session after it, with the by-value call failing
+before it reached Rust.
+
+A **method definition** is precompiled: `register_ffi_struct` defines
+`ffi_by_value_layout(::Type{Point}) = :repr_c` in the module that owns `Point`,
+so the method is stored in that module's cache image and reinstated on load,
+exactly like any other method the package defines. Dispatch also expresses the
+narrow and the wide assertion natively — `::Type{Point{Float64}}` for one
+instantiation, `::Type{<:Point}` for all of them — which a keyed container has
+to fake.
+
+Withdrawal (`unregister_ffi_struct`) deletes the method it is about, and only
+that one, so there is no exception list to keep in step with the table — and no
+bookkeeping container of any kind beside it.
+"""
+ffi_by_value_layout(@nospecialize(::Type)) = :unknown
+
+# RustCall's own boundary types mirror `#[repr(C)]` Rust definitions (see the
+# comments beside each in `src/types.jl`), so the layout assertion #245 asks a
+# user to make is one the package already makes about these. The parametric
+# ones are asserted for *every* instantiation deliberately: `RustPtr{T}` is one
+# pointer whatever `T` is.
+ffi_by_value_layout(::Type{CRustResult}) = :repr_c
+ffi_by_value_layout(::Type{CRustOption}) = :repr_c
+ffi_by_value_layout(::Type{CRustString}) = :repr_c
+ffi_by_value_layout(::Type{CRustStr}) = :repr_c
+ffi_by_value_layout(::Type{CRustVec}) = :repr_c
+ffi_by_value_layout(::Type{CRustSlice}) = :repr_c
+ffi_by_value_layout(::Type{RustStr}) = :repr_c
+ffi_by_value_layout(::Type{<:RustSlice}) = :repr_c
+ffi_by_value_layout(::Type{<:RustPtr}) = :repr_c
+ffi_by_value_layout(::Type{<:RustRef}) = :repr_c
+
+"""
+    _ffi_layout_signature(T) -> Type
+
+The `ffi_by_value_layout` method signature `register_ffi_struct(T)` defines:
+`Tuple{typeof(ffi_by_value_layout), Type{T}}`, for the one concrete type `T`
+and nothing else. Reconstructed rather than remembered, so
+`unregister_ffi_struct` can find a method a *previous* session defined and a
+precompile cache restored.
+"""
+_ffi_layout_signature(@nospecialize(T::Type)) =
+    Tuple{typeof(ffi_by_value_layout), Type{T}}
+
+"""
+    _ffi_layout_method(T) -> Union{Method, Nothing}
+
+The `ffi_by_value_layout` method that `register_ffi_struct(T)` defined for
+**exactly** `T`, or `nothing` when there is none.
+
+Exactness is the point, twice over. A user registration is always for one
+concrete type, but RustCall's own mirrors are asserted with covering methods
+(`ffi_by_value_layout(::Type{<:RustPtr})`), and `which` alone would hand one of
+those back — so a `register_ffi_struct` call could be elided as "already
+asserted", or an `unregister_ffi_struct` could delete the package's own claim
+about every `RustPtr{T}`. Comparing the signature to `_ffi_layout_signature`
+means each operation sees only the assertion `register_ffi_struct(T)` itself
+would make.
+
+`invokelatest`, because the method may have been defined in this very world —
+which is also what lets `ffi_by_value_registered` answer for a registration
+made in the same top-level expression, with no bookkeeping on the side.
+"""
+function _ffi_layout_method(@nospecialize(T::Type))
+    m = try
+        Base.invokelatest(which, ffi_by_value_layout, (Type{T},))
+    catch
+        return nothing
+    end
+    return m.sig === _ffi_layout_signature(T) ? m : nothing
+end
+
+"""
+    _ffi_registration_module(T) -> Module
+
+Where the `ffi_by_value_layout` method for `T` is defined: the module that owns
+`T`, so the method lands in **that** module's precompile cache and comes back
+with it.
+
+A type Julia itself owns (a `Tuple`, whose `parentmodule` is `Core`) has no
+such home; the method goes to RustCall instead, and a registration of one from
+a package's top level is therefore session-local. Register the struct rather
+than the tuple when that matters.
+"""
+function _ffi_registration_module(@nospecialize(T::Type))
+    owner = parentmodule(T)
+    (owner === Core || owner === Base) && return @__MODULE__
+    return owner
+end
+
+"""
+    ffi_is_aggregate(T) -> Bool
+
+Whether `T` is an *aggregate* at the C boundary — a struct with fields, or a
+tuple — as opposed to a scalar whose ABI is fixed by its width.
+
+Primitive types (`Int32`, `Float64`, a user `primitive type`), pointers and
+zero-field singletons are not aggregates: there is nothing about them a layout
+decision can change. Everything else has a field order, and Rust does not
+promise one without `#[repr(C)]`.
+"""
+function ffi_is_aggregate(@nospecialize(T::Type))
+    T <: Tuple && return true
+    T <: Ptr && return false
+    isconcretetype(T) || return false
+    isprimitivetype(T) && return false
+    isstructtype(T) || return false
+    return fieldcount(T) > 0
+end
+
+"""
+    register_ffi_struct(T::Type; repr_c::Bool = true) -> Type
+
+Assert that values of `T` may be passed to and from Rust **by value**, because
+the Rust type they correspond to is declared `#[repr(C)]` and its fields match
+`T`'s in order and in type.
+
+This is the opt-in issue #245 asks for. Without it, `@rust f(x)` with an
+aggregate `x` raises rather than assuming the layouts agree: Rust's default
+`repr(Rust)` layout is unspecified, so an unannotated Julia struct that "works"
+today can be silently reordered by the next rustc.
+
+The assertion is recorded as a **method** of `ffi_by_value_layout`, defined in
+the module that owns `T`. Calling this at a package's top level therefore
+survives precompilation — the method is stored in that package's cache image
+and reinstated when it is loaded, in every later session:
+
+```julia
+module MyPkg
+using RustCall
+
+struct Point   # matches #[repr(C)] pub struct Point { x: f64, y: f64 }
+    x::Float64
+    y::Float64
+end
+RustCall.register_ffi_struct(Point)
+end
+```
+
+You do **not** need this for:
+
+- scalars, pointers, `Cstring`, `Char`, `Bool` — their ABI is their width;
+- the struct wrappers RustCall generates from a `#[julia] struct`
+  (`RustStructInfo`, `src/structs.jl`), which cross the boundary as an opaque
+  handle, never as a field-by-field copy;
+- RustCall's own `#[repr(C)]` mirrors: `CRustString`, `CRustSlice` and friends
+  have `ffi_by_value_layout` methods here, and the `CResult_<fn>` /
+  `COption_<fn>` aggregates the wrapper generators emit subtype `FFIByValue`.
+
+`repr_c = false` is rejected: there is no layout to assert. The keyword exists
+so the call site states what is being claimed.
+
+# Concrete types only
+
+`T` must be a concrete, immutable, `isbitstype` struct. A `UnionAll` or an
+abstract type is rejected: instantiations of `Point{T}` do not share a layout —
+a type parameter changes field sizes, alignment and even ABI register classes —
+and subtypes of an `abstract type Shape{T}` share even less. Registering a
+family would license values you never matched against a Rust struct, which is
+the fail-open behaviour this opt-in exists to remove. Register each concrete
+type you actually pass: `register_ffi_struct(Point{Float64})` says exactly that,
+and says nothing about `Point{Int32}`.
+
+See also `unregister_ffi_struct`, `ffi_by_value_registered`,
+`ffi_by_value_layout`.
+"""
+function register_ffi_struct(@nospecialize(T::Type); repr_c::Bool = true)
+    repr_c || throw(ArgumentError(
+        "register_ffi_struct($T; repr_c = false) asserts nothing: a type may " *
+        "only be passed by value when the Rust type it mirrors is declared " *
+        "`#[repr(C)]`. Fix the Rust definition, or pass the value behind a " *
+        "pointer instead."))
+    T isa UnionAll && throw(ArgumentError(
+        "register_ffi_struct($T): a `UnionAll` cannot be registered. Its " *
+        "instantiations do not share a layout — a type parameter changes field " *
+        "sizes, alignment and even ABI register classes — so asserting one for " *
+        "the whole family would license `$T{...}` instantiations you never " *
+        "matched against a Rust struct, which is the fail-open behaviour this " *
+        "opt-in exists to remove. Register each concrete type you actually " *
+        "pass, e.g. `register_ffi_struct($T{Float64})`."))
+    (isconcretetype(T) && isstructtype(T)) || throw(ArgumentError(
+        "register_ffi_struct($T): only a concrete struct type can be passed by " *
+        "value — $T is $(isabstracttype(T) ? "abstract, and its subtypes share " *
+                                             "no layout" : "not a concrete struct type"). " *
+        "Register the concrete types you actually pass."))
+    isbitstype(T) || throw(ArgumentError(
+        "register_ffi_struct($T): only an `isbitstype` type can be passed by " *
+        "value — $T is not one" *
+        (ismutabletype(T) ? " (it is mutable; a mutable struct is a Julia heap " *
+                            "object, and Rust must receive it behind a " *
+                            "pointer)." : ".")))
+    # The check and the method definition are **one** transaction under
+    # `REGISTRY_LOCK`, paired with the one in `unregister_ffi_struct`. Split,
+    # two tasks racing on the same type could both define the method, or an
+    # unregister could land between them — finding no method, returning `false`,
+    # and leaving the type enabled by the method the other task then installed
+    # (#245 review). There is no bookkeeping beside the method table to keep in
+    # step, because there is no bookkeeping.
+    return lock(REGISTRY_LOCK) do
+        # Skip only an *exact* duplicate. Defining the same method twice warns
+        # under `--warn-overwrite=yes`, which `Pkg.test` sets; anything broader
+        # that happens to cover `T` is a different assertion and must not
+        # suppress this one.
+        _ffi_layout_method(T) === nothing || return T
+        Core.eval(_ffi_registration_module(T),
+                  :($(GlobalRef(@__MODULE__, :ffi_by_value_layout))(::Type{$T}) =
+                        $(QuoteNode(:repr_c))))
+        return T
+    end
+end
+
+"""
+    unregister_ffi_struct(T::Type) -> Bool
+
+Take back the `register_ffi_struct` assertion for `T`. Returns whether there was
+one to take back.
+
+It deletes the `ffi_by_value_layout` method that was defined for **exactly**
+`T` — the narrow one for a concrete type, the `::Type{<:T}` one for a
+`UnionAll` — and nothing else. So withdrawing `Point` after registering it
+leaves any separate `Point{Float64}` assertion standing, and withdrawing
+`Point{Float64}` does not disturb a `Point` assertion that covers its siblings.
+An assertion made in a *previous* session (restored from a precompile cache) is
+withdrawn just as well: the method is found by reconstructing its signature,
+not by remembering it.
+
+Deleting a method invalidates code that dispatched through it, so this is not
+something to do in a loop; it is a correction, made by a test or by a user who
+changed their mind. It runs under `REGISTRY_LOCK`, as one transaction with the
+one in `register_ffi_struct`.
+"""
+function unregister_ffi_struct(@nospecialize(T::Type))
+    # One transaction, paired with `register_ffi_struct`: see the comment there.
+    return lock(REGISTRY_LOCK) do
+        m = _ffi_layout_method(T)
+        m === nothing && return false
+        Base.delete_method(m)
+        return true
+    end
+end
+
+"""
+    ffi_by_value_registered(T) -> Bool
+
+Whether `T` carries a by-value assertion — a `ffi_by_value_layout` method
+covering it, whether that method was defined in an earlier session or a moment
+ago in this one.
+"""
+function ffi_by_value_registered(@nospecialize(T::Type))
+    # `invokelatest`, and no fast path in front of it. A plain call would be
+    # answered in the caller's world, which is stale in **both** directions: it
+    # cannot see a method `register_ffi_struct` defined a moment ago, and — the
+    # half that matters — it still sees one `unregister_ffi_struct` has already
+    # deleted. Being stale-true is fail-open, which is the whole thing this
+    # check exists to prevent, so the latest world is the only acceptable
+    # answer. The cost lands only on aggregates that are not `FFIByValue`, next
+    # to a dynamic `ccall`.
+    return Base.invokelatest(ffi_by_value_layout, T) === :repr_c
+end
+
+"""
+    ffi_by_value_allowed(T) -> Bool
+
+Whether a value of `T` may cross the boundary by value: true for everything
+that is not an aggregate, for RustCall's own generated mirrors (`FFIByValue`),
+and for other aggregates only once asserted.
+"""
+function ffi_by_value_allowed(@nospecialize(T::Type))
+    return !ffi_is_aggregate(T) || T <: FFIByValue || ffi_by_value_registered(T)
+end
+
+"""
+    ffi_by_value_error(T, position) -> RustError
+
+The error raised when an unregistered aggregate reaches the boundary by value.
+`position` names where it appeared, e.g. `"argument 2"` or `"the return type"`.
+"""
+function ffi_by_value_error(@nospecialize(T::Type), position::AbstractString)
+    fields = join(["$(fieldname(T, i))::$(fieldtype(T, i))" for i in 1:fieldcount(T)], ", ")
+    return RustError(
+        "cannot pass `$T` to Rust by value as $position: RustCall has no " *
+        "layout assertion for it (#245). Rust's default `repr(Rust)` layout " *
+        "is unspecified — field order and niche placement may change between " *
+        "compiler versions — so matching `$T`'s fields ($fields) against a " *
+        "Rust struct is a claim only you can make.\n" *
+        "If the Rust side declares that struct `#[repr(C)]` and its fields " *
+        "line up in order and in type, opt in with " *
+        "`RustCall.register_ffi_struct($T)`. Otherwise pass the value behind " *
+        "a pointer, or define the struct on the Rust side with `#[julia]` and " *
+        "let RustCall generate the wrapper (`RustStructInfo`, `src/structs.jl`), " *
+        "which crosses as an opaque handle. The supported-type matrix is in " *
+        "the type-mapping documentation.")
+end
+
+"""
+    ffi_check_by_value(R, arg_types)
+
+Fail closed on any unregistered aggregate in a call's signature, before a
+`ccall` is generated for it. Called from `call_rust_function`, the one runtime
+entry point every `@rust` call goes through — not from the `@generated` body
+below it, because a generated method is not re-generated when
+`register_ffi_struct` is called later.
+"""
+function ffi_check_by_value(@nospecialize(R::Type), arg_types)
+    ffi_by_value_allowed(R) || throw(ffi_by_value_error(R, "the return type"))
+    for (i, T) in enumerate(arg_types)
+        ffi_by_value_allowed(T) || throw(ffi_by_value_error(T, "argument $i"))
+    end
+    return nothing
+end
+

--- a/src/julia_functions.jl
+++ b/src/julia_functions.jl
@@ -497,6 +497,14 @@ struct COptionType{T}
     value::T
 end
 
+# Both mirror a `#[repr(C)]` aggregate the extractor emits (`CResult_<fn>` /
+# `COption_<fn>`, `deps/rustcall_core/src/codegen.rs`), so the by-value layout
+# assertion #245 requires is one RustCall makes about its own types — for every
+# instantiation, since the shape is the discriminant plus a payload whatever the
+# payload is.
+ffi_by_value_layout(::Type{<:CResultType}) = :repr_c
+ffi_by_value_layout(::Type{<:COptionType}) = :repr_c
+
 """
     generate_c_result_struct_type(func_name::String, ok_type::Symbol, err_type::Symbol) -> Expr
 
@@ -505,7 +513,12 @@ Generate a Julia struct definition for the C-compatible Result type.
 function generate_c_result_struct_type(func_name::String, ok_type::Symbol, err_type::Symbol)
     struct_name = Symbol("CResult_", func_name)
     quote
-        struct $struct_name
+        # `<: FFIByValue` is RustCall's own by-value assertion about a mirror it
+        # generated for the extractor's `#[repr(C)]` `CResult_<fn>` (#245). It
+        # is a supertype rather than a `register_ffi_struct` call because this
+        # code may be precompiled into a downstream package, and Julia does not
+        # replay a dependency's global mutations when loading from cache.
+        struct $struct_name <: $(GlobalRef(RustCall, :FFIByValue))
             is_ok::UInt8
             ok_value::$ok_type
             err_value::$err_type
@@ -521,7 +534,8 @@ Generate a Julia struct definition for the C-compatible Option type.
 function generate_c_option_struct_type(func_name::String, inner_type::Symbol)
     struct_name = Symbol("COption_", func_name)
     quote
-        struct $struct_name
+        # See `generate_c_result_struct_type`: RustCall's own mirror (#245).
+        struct $struct_name <: $(GlobalRef(RustCall, :FFIByValue))
             is_some::UInt8
             value::$inner_type
         end

--- a/src/llvmcodegen.jl
+++ b/src/llvmcodegen.jl
@@ -502,6 +502,14 @@ function _rust_llvm_call(func_name::String, args...)
             end
             return call_rust_function(info.func_ptr, info.return_type, args...)
         catch e
+            # A fail-closed error is not a diagnostic to be reworded: the FFI
+            # type contract raises `RustError` for an unregistered by-value
+            # aggregate (#245) or an invalid-UTF-8 argument (#246), and a Rust
+            # panic raises `RustPanicError` (#244). Both name their own cause
+            # and must reach the caller; wrapping them in "Error calling
+            # function ... via @rust_llvm" hid the actionable message behind a
+            # generic one.
+            (e isa RustError || e isa RustPanicError) && rethrow()
             error("""
             Error calling function '$func_name' via @rust_llvm:
             Return type: $(info.return_type)

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -353,14 +353,23 @@ function _rust_call_dynamic(lib_name::String, func_name::String, args...)
                                     channel, func_name)
     end
 
-    # Try to get type info from LLVM analysis
-    try
-        ret_type, expected_arg_types = infer_function_types(lib_name, func_name)
-        return guard_rust_panic_ptr(call_rust_function(func_ptr, ret_type, args...),
-                                    channel, func_name)
+    # Try to get type info from LLVM analysis. The `try` covers the *inference*
+    # and nothing else: it used to wrap the call as well, with a catch that
+    # swallowed every exception but `RustPanicError`, so a fail-closed error
+    # from the FFI type contract — an unregistered by-value aggregate (#245),
+    # an invalid-UTF-8 argument (#246) — was replaced by the unrelated "no
+    # return type" message below. Swallowing a fail-closed error is the
+    # fail-open pattern the contract exists to remove.
+    inferred = try
+        infer_function_types(lib_name, func_name)
     catch e
-        e isa RustPanicError && rethrow()
-        # Fall back to inference from arguments
+        e isa SignatureInferenceError || rethrow()
+        nothing
+    end
+    if inferred !== nothing
+        inferred_ret, _ = inferred
+        return guard_rust_panic_ptr(call_rust_function(func_ptr, inferred_ret, args...),
+                                    channel, func_name)
     end
 
     # No last resort. Guessing the return type from the first argument was the
@@ -394,10 +403,82 @@ function _rust_call_typed(lib_name::String, func_name::String, ret_type::Type, a
         end
     end
 
+    # An annotation that contradicts the manifest is an error, not an override
+    # (#245). `@rust f(x)::Float64` on a function the manifest records as
+    # `-> i32` used to reinterpret the 32-bit result as a `Float64` and return
+    # silent garbage; the declared type and the recorded one come from the same
+    # snapshot, so comparing them costs nothing.
+    _check_return_annotation(target, func_name, ret_type)
+
     # Pointer and channel come from the same snapshot, so the call and the
     # channel read cannot straddle two generations (#244, #277).
     return guard_rust_panic_ptr(call_rust_function(target.func_ptr, ret_type, args...),
                                 target.channel, func_name)
+end
+
+"""
+    _snapshot_return_type(target) -> Union{Type, Nothing}
+
+The return type the resolved generation records for this symbol: the richer
+`FunctionInfo` first, then the per-library hint, and `nothing` when neither
+says anything. Read from the snapshot only — never looked up again by name,
+which is the #277 rule.
+"""
+function _snapshot_return_type(target)
+    info = target.func_info
+    if info !== nothing && info.return_type !== Any
+        return info.return_type
+    end
+    recorded = target.return_type
+    return recorded === Any ? nothing : recorded
+end
+
+"""
+    _return_annotation_agrees(declared, recorded) -> Bool
+
+Whether a `::T` annotation says the same thing as the return type the manifest
+recorded.
+
+Identity is not the test, because the manifest records the **C slot** while an
+annotation names the **surface** type a caller sees, and the two differ where
+the contract says they do: Rust `char` is a `UInt32` code point in the slot and
+a `Char` on the surface, `bool` is a `UInt8` and a `Bool`. `@rust f()::Char` on
+a `-> char` was a correct call before #245 added this check and must stay one.
+
+Two types agree when they lower to the same `ccall` return slot: the generated
+call is then byte-for-byte the same and only `convert_return` differs, which is
+the conversion the annotation was asking for. `::Float64` on a `-> i32` does
+*not* agree — different slot, and reading one as the other is undefined
+behaviour.
+"""
+_return_annotation_agrees(declared::Type, recorded::Type) =
+    declared === recorded || ccall_return_type(declared) === ccall_return_type(recorded)
+
+"""
+    _check_return_annotation(target, func_name, declared)
+
+Raise when a `::T` annotation disagrees with the return type the manifest
+recorded for `func_name`, naming both (#245).
+
+An annotation exists to supply a return type RustCall does not know. When it
+*is* known, a differing annotation is not an override — the ccall would read
+the return slot at the wrong width or in the wrong register class, which is
+undefined behaviour, not a cast. `Cvoid === Nothing` and `Cstring ===
+Ptr{UInt8}` are the same type to `===`, so aliases never trip this, and neither
+does a **surface** annotation over the slot the manifest records
+(`_return_annotation_agrees`).
+"""
+function _check_return_annotation(target, func_name::AbstractString, declared::Type)
+    recorded = _snapshot_return_type(target)
+    (recorded === nothing || _return_annotation_agrees(declared, recorded)) && return nothing
+    throw(RustError(
+        "return type annotation `::$declared` on `@rust $func_name(...)` " *
+        "disagrees with the manifest, which records `$recorded` for " *
+        "'$func_name' in library '$(target.lib_name)' (#245). Reading a " *
+        "`$recorded` return slot as a `$declared` is undefined behaviour, not " *
+        "a conversion. Drop the annotation and let the manifest decide, " *
+        "write `::$recorded`, or change the Rust signature — and convert the " *
+        "result on the Julia side if you wanted a `$declared`."))
 end
 
 """

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -16,6 +16,48 @@ using Test
 using RustCall
 
 # ----------------------------------------------------------------------------
+# Fixtures for "by-value aggregates are opt-in" (#245 item 3). A `struct` needs
+# module scope, so these live outside the testset that uses them.
+# ----------------------------------------------------------------------------
+
+struct Rc245ByValue
+    x::Int32
+    y::Float64
+end
+
+# Same fields, different type: the layout assertion is per type, not per shape.
+struct Rc245ByValueTwin
+    x::Int32
+    y::Float64
+end
+
+mutable struct Rc245Mutable
+    x::Int32
+end
+
+# A parametric aggregate: the parameter changes the layout, so a concrete
+# registration must not license a different instantiation — and the family
+# itself must not be registrable at all.
+struct Rc245Pair{T}
+    a::T
+    b::T
+end
+
+# An abstract family, whose subtypes share nothing but a name.
+abstract type Rc245Shape{T} end
+
+struct Rc245Square{T} <: Rc245Shape{T}
+    side::T
+end
+
+# Stands in for a mirror a wrapper generator emits: the assertion is in the
+# supertype, so it survives precompilation without touching any registry.
+struct Rc245Mirror <: RustCall.FFIByValue
+    is_ok::UInt8
+    value::Int32
+end
+
+# ----------------------------------------------------------------------------
 # The Rust-side acceptance gate, as callable probes
 # ----------------------------------------------------------------------------
 
@@ -667,6 +709,277 @@ const ALL_SPELLINGS = vcat(
         @test RustCall.FFI_STRICT[] === :error
         @test_throws RustCall.RustError RustCall.ffi_return_symbol_or_throw(
             "Vec<f64>", "", "f() -> Vec<f64>")
+    end
+
+
+    @testset "by-value aggregates are opt-in (#245 item 3)" begin
+        # `is_supported_arg_type(::Type{T}) = isbitstype(T)` and
+        # `ccall_arg_type(::Type{T}) = T` accepted *any* isbits Julia struct as
+        # a by-value argument, on the assumption that its layout matches the
+        # Rust side's. Rust's default `repr(Rust)` layout is unspecified, so the
+        # assumption holds only until a rustc upgrade reorders the fields — and
+        # then it is silent corruption, not an error.
+
+        # Scalars, pointers and singletons are not aggregates: their ABI is
+        # their width, and there is no field order to get wrong.
+        for T in (Int8, Int64, UInt128, Float32, Float64, Bool, Char,
+                  Ptr{Cvoid}, Ptr{Float64}, Cstring, Csize_t)
+            @test RustCall.ffi_is_aggregate(T) == false
+            @test RustCall.ffi_by_value_allowed(T)
+        end
+
+        # RustCall's own `#[repr(C)]` mirrors carry the assertion already.
+        for T in (RustCall.CRustString, RustCall.CRustStr, RustCall.CRustVec,
+                  RustCall.CRustSlice, RustCall.CRustResult, RustCall.CRustOption)
+            @test RustCall.ffi_is_aggregate(T)
+            @test RustCall.ffi_by_value_registered(T)
+        end
+        # RustCall asserts the widening form for its own wrappers, which is
+        # the deliberate case: `RustPtr{T}` is one pointer whatever `T` is.
+        @test RustCall.ffi_by_value_layout(RustCall.CRustString) === :repr_c
+        @test RustCall.ffi_by_value_layout(Rc245ByValue) === :unknown
+        @test RustCall.ffi_by_value_registered(RustCall.RustPtr{Int32})
+        @test RustCall.ffi_by_value_registered(RustCall.RustSlice{Float64})
+        @test RustCall.ffi_by_value_registered(RustCall.CResultType{Int32, Int32})
+        @test RustCall.ffi_by_value_registered(RustCall.COptionType{Float64})
+
+        # The mirrors the wrapper generators emit carry the assertion in their
+        # *supertype*, which needs no call at all. A user's own struct carries
+        # it as a `ffi_by_value_layout` method, defined in the module that owns
+        # the type — both are precompiled, which a mutated global would not be.
+        @test isabstracttype(RustCall.FFIByValue)
+        @test RustCall.ffi_by_value_allowed(Rc245Mirror)
+        @test RustCall.ffi_by_value_registered(Rc245Mirror) == false
+        @test RustCall.ffi_check_by_value(Rc245Mirror, Any[]) === nothing
+        @test isbitstype(Rc245Mirror)   # a supertype does not change the layout
+
+        # An arbitrary user struct is not allowed until someone says so.
+        @test RustCall.ffi_is_aggregate(Rc245ByValue)
+        @test RustCall.ffi_by_value_registered(Rc245ByValue) == false
+        @test RustCall.ffi_by_value_allowed(Rc245ByValue) == false
+        # Tuples are aggregates too — a tuple's parameters *are* its layout, so
+        # registering one tuple type must not license another.
+        @test RustCall.ffi_is_aggregate(Tuple{Int32, Float64})
+        @test RustCall.ffi_by_value_allowed(Tuple{Int32, Float64}) == false
+
+        # The error names the type, its fields and the opt-in call to make.
+        err = try
+            RustCall.ffi_check_by_value(Int32, Any[Rc245ByValue])
+            nothing
+        catch e
+            e
+        end
+        @test err isa RustCall.RustError
+        msg = sprint(showerror, err)
+        @test occursin("Rc245ByValue", msg)
+        @test occursin("argument 1", msg)
+        @test occursin("repr(C)", msg)
+        @test occursin("RustCall.register_ffi_struct(", msg)
+        @test occursin("RustStructInfo", msg)   # the generated-wrapper alternative
+        @test occursin("x::Int32", msg)         # the fields it would have matched
+        @test occursin("y::Float64", msg)
+
+        # Registration is **concrete types only** (#245 review). Instantiations
+        # of a parametric struct do not share a layout — a type parameter
+        # changes field sizes, alignment and even ABI register classes — and
+        # subtypes of an abstract family share even less, so a family-wide
+        # assertion would license values nobody ever matched against a Rust
+        # struct. That is the fail-open behaviour the opt-in exists to remove.
+        for family in (Rc245Pair, Rc245Shape)
+            err_family = try
+                RustCall.register_ffi_struct(family)
+                nothing
+            catch e
+                e
+            end
+            @test err_family isa ArgumentError
+            @test occursin("register_ffi_struct($family)", sprint(showerror, err_family))
+        end
+        @test occursin("UnionAll", sprint(showerror, try
+            RustCall.register_ffi_struct(Rc245Pair); catch e; e end))
+        # An abstract *instantiation* is refused for the same reason.
+        @test_throws ArgumentError RustCall.register_ffi_struct(Rc245Shape{Float64})
+        @test RustCall.ffi_by_value_allowed(Rc245Square{Float64}) == false
+
+        # The concrete registration is accepted, and says nothing about a
+        # sibling instantiation.
+        try
+            RustCall.register_ffi_struct(Rc245Pair{Float64})
+            @test RustCall.ffi_by_value_allowed(Rc245Pair{Float64})
+            @test RustCall.ffi_by_value_allowed(Rc245Pair{Int8}) == false
+            @test RustCall.ffi_by_value_allowed(Rc245Pair{Float32}) == false
+            @test_throws RustCall.RustError RustCall.ffi_check_by_value(
+                Int32, Any[Rc245Pair{Int8}])
+            # Registering it again is idempotent: one method, one withdrawal.
+            @test RustCall.register_ffi_struct(Rc245Pair{Float64}) === Rc245Pair{Float64}
+        finally
+            @test RustCall.unregister_ffi_struct(Rc245Pair{Float64})
+        end
+        @test RustCall.ffi_by_value_allowed(Rc245Pair{Float64}) == false
+        # A withdrawal takes effect in the world that made it, not one later:
+        # being stale-*true* here would be fail-open.
+        @test RustCall.unregister_ffi_struct(Rc245Pair{Float64}) == false
+
+        # RustCall's own covering assertions (`::Type{<:RustPtr}`) are the
+        # package's claim about its own mirrors, not something
+        # `register_ffi_struct` can produce — and not something
+        # `unregister_ffi_struct` can delete by accident either, because it
+        # only ever deletes the exact `Type{T}` method.
+        @test RustCall.unregister_ffi_struct(RustCall.RustPtr{Int32}) == false
+        @test RustCall.ffi_by_value_registered(RustCall.RustPtr{Int32})
+
+        # A tuple is never widened: its parameters *are* its layout.
+        try
+            RustCall.register_ffi_struct(Tuple{Int32, Float64})
+            @test RustCall.ffi_by_value_allowed(Tuple{Int32, Float64})
+            @test RustCall.ffi_by_value_allowed(Tuple{Int32, Float32}) == false
+            @test RustCall.ffi_by_value_allowed(Tuple{Int32}) == false
+        finally
+            @test RustCall.unregister_ffi_struct(Tuple{Int32, Float64})
+        end
+
+        # Return position is reported as such.
+        ret_err = try
+            RustCall.ffi_check_by_value(Rc245ByValue, Any[])
+            nothing
+        catch e
+            e
+        end
+        @test ret_err isa RustCall.RustError
+        @test occursin("the return type", sprint(showerror, ret_err))
+
+        # `call_rust_function` is the runtime door every `@rust` call goes
+        # through, and it refuses before a `ccall` is built — the pointer is
+        # never dereferenced, so a null one is safe here. Both directions:
+        # the aggregate as an argument, and as the return type.
+        @test_throws RustCall.RustError RustCall.call_rust_function(
+            C_NULL, Int32, Rc245ByValue(Int32(1), 2.0))
+        @test_throws RustCall.RustError RustCall.call_rust_function(
+            C_NULL, Rc245ByValue, Int32(1))
+        @test_throws RustCall.RustError RustCall.call_rust_function(
+            C_NULL, Int32, Type[Rc245ByValue], Rc245ByValue(Int32(1), 2.0))
+        @test_throws RustCall.RustError RustCall.call_rust_function(
+            C_NULL, Int32, Tuple{Rc245ByValue}, Rc245ByValue(Int32(1), 2.0))
+
+        # Opting in makes exactly that type acceptable, and withdrawing the
+        # assertion puts it back.
+        try
+            @test RustCall.register_ffi_struct(Rc245ByValue) === Rc245ByValue
+            @test RustCall.ffi_by_value_registered(Rc245ByValue)
+            @test RustCall.ffi_by_value_allowed(Rc245ByValue)
+            @test RustCall.ffi_check_by_value(Int32, Any[Rc245ByValue]) === nothing
+            # A different struct with the same fields is still refused: the
+            # assertion is per type, not per shape.
+            @test RustCall.ffi_by_value_allowed(Rc245ByValueTwin) == false
+        finally
+            @test RustCall.unregister_ffi_struct(Rc245ByValue)
+        end
+        @test RustCall.ffi_by_value_allowed(Rc245ByValue) == false
+        @test RustCall.unregister_ffi_struct(Rc245ByValue) == false
+
+        # The keyword exists so the call site states what it claims; there is
+        # no layout to assert without `#[repr(C)]`, and a mutable struct is a
+        # Julia heap object that cannot be copied into a register pair at all.
+        @test_throws ArgumentError RustCall.register_ffi_struct(Rc245ByValue; repr_c = false)
+        @test_throws ArgumentError RustCall.register_ffi_struct(Rc245Mutable)
+        @test RustCall.ffi_by_value_allowed(Rc245ByValue) == false
+    end
+
+    @testset "a generated mirror survives precompilation (#245 review)" begin
+        # A `register_ffi_struct` call in a generated `@rust_crate` module — or
+        # in a `#[julia]` wrapper expanded inside a downstream package — mutates
+        # a global that lives in *RustCall*. Julia does not replay a
+        # dependency's global mutations when a package is loaded from its
+        # precompile cache, so such a registration would hold in the session
+        # that compiled the package and be gone in every later one: every
+        # `Result`-returning wrapper would then fail in `call_rust_function`
+        # before reaching Rust. `<: FFIByValue` is a property of the type, so
+        # there is nothing to replay.
+
+        # 1. The generators emit the supertype, and no registration call.
+        res = string(RustCall.generate_c_result_struct_type("probe", :Int32, :Int32))
+        opt = string(RustCall.generate_c_option_struct_type("probe", :Float64))
+        for src in (res, opt)
+            @test occursin("FFIByValue", src)
+            @test !occursin("register_ffi_struct", src)
+        end
+
+        # 2. And so does the source-text emitter used for written-out bindings.
+        sig = RustCall.RustFunctionSignature(
+            "probe", ["a"], ["i32"], "Result<i32, i32>", false, String[];
+            symbol = "rustcall_probe", return_kind = :result,
+            ok_type = "i32", err_type = "i32")
+        emitted = RustCall._emit_result_function_code(sig, "a", "Int32(a)")
+        @test occursin("struct CResult_probe <: FFIByValue", emitted)
+        @test !occursin("register_ffi_struct", emitted)
+
+        # 3. The real thing: a package that both defines such a mirror **and**
+        #    registers a struct of its own at top level, loaded in a *fresh*
+        #    process from its precompile cache. Neither assertion may depend on
+        #    the session that compiled the package.
+        depot = mktempdir()
+        pkgdir_ = joinpath(depot, "Rc245Mirror245", "src")
+        mkpath(pkgdir_)
+        write(joinpath(depot, "Rc245Mirror245", "Project.toml"), """
+        name = "Rc245Mirror245"
+        uuid = "4a1d5f2e-9b3c-4c7a-8d6e-1f2a3b4c5d6e"
+        version = "0.1.0"
+
+        [deps]
+        RustCall = "$(Base.PkgId(RustCall).uuid)"
+        """)
+        write(joinpath(pkgdir_, "Rc245Mirror245.jl"), """
+        module Rc245Mirror245
+        import RustCall
+
+        # A mirror the wrapper generators would have emitted.
+        struct CResult_probe <: RustCall.FFIByValue
+            is_ok::UInt8
+            ok_value::Int32
+            err_value::Int32
+        end
+
+        # ...and a user's own struct, registered the documented way: at top
+        # level, next to the struct it is about.
+        struct Pt
+            x::Float64
+            y::Float64
+        end
+        RustCall.register_ffi_struct(Pt)
+
+        struct Pair2{T}
+            a::T
+            b::T
+        end
+        RustCall.register_ffi_struct(Pair2{Float64})
+        end
+        """)
+        try
+            script = """
+            using Rc245Mirror245, RustCall
+            M = Rc245Mirror245
+            print(RustCall.ffi_by_value_allowed(M.CResult_probe), " ",
+                  RustCall.ffi_by_value_registered(M.CResult_probe), " ",
+                  isbitstype(M.CResult_probe), " ",
+                  RustCall.ffi_by_value_allowed(M.Pt), " ",
+                  RustCall.ffi_by_value_allowed(M.Pair2{Float64}), " ",
+                  RustCall.ffi_by_value_allowed(M.Pair2{Int8}))
+            """
+            project = pkgdir(RustCall)
+            out = withenv("JULIA_LOAD_PATH" => string(project, Sys.iswindows() ? ";" : ":", depot,
+                                                      Sys.iswindows() ? ";" : ":", "@stdlib")) do
+                readchomp(`$(Base.julia_cmd()) --startup-file=no -e $script`)
+            end
+            # The mirror: allowed, *not* registered (its assertion is the
+            # supertype), and still isbits — a supertype does not change the
+            # layout. The user's struct: allowed, because
+            # `register_ffi_struct` defined a `ffi_by_value_layout` method in
+            # `Rc245Mirror245`, which its precompile cache carries. And the
+            # concrete parametric registration still licenses only itself.
+            @test out == "true false true true true false"
+        finally
+            rm(depot; recursive = true, force = true)
+        end
     end
 
     @testset "ownership: the contract names the symbol generated code calls" begin

--- a/test/test_julia_to_rust_generic.jl
+++ b/test/test_julia_to_rust_generic.jl
@@ -14,6 +14,13 @@ using Test
         y::T
     end
 
+    # Opt in to passing it by value (#245). The *concrete* instantiation is
+    # what is registered — the only thing `register_ffi_struct` accepts, since
+    # a type parameter changes field sizes, alignment and even ABI register
+    # classes, so `Point{Float64}` matching the Rust `#[repr(C)] { f64, f64 }`
+    # below says nothing about `Point{Int32}`.
+    RustCall.register_ffi_struct(Point{Float64})
+
     @testset "Passing Generic Struct" begin
         rust"""
         #[repr(C)]

--- a/test/test_julia_to_rust_struct.jl
+++ b/test/test_julia_to_rust_struct.jl
@@ -14,6 +14,13 @@ using Test
         y::Float64
     end
 
+    # Passing an aggregate by value is opt-in since #245: `#[repr(C)]` on the
+    # Rust side below is what makes the field order a contract, and this is
+    # where that claim is recorded. Without it the call raises rather than
+    # assuming the two layouts agree. `Point` is concrete, which is the only
+    # thing `register_ffi_struct` accepts.
+    RustCall.register_ffi_struct(Point)
+
     @testset "Passing Struct by Value" begin
         rust"""
         #[repr(C)]

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -1090,6 +1090,13 @@ end
 # regression tests for the three bugs that came out of having five of them.
 # ---------------------------------------------------------------------------
 
+# Fixture for "#245: an unregistered struct is not passed by value" — a `struct`
+# needs module scope, so it cannot live inside the testset that uses it.
+struct Rc245Vec2Julia
+    x::Float64
+    y::Float64
+end
+
 # #245: `rustcall_core` accepts `i128`, `u128` and `char`, and generates a
 # wrapper for them — but every Julia table stopped at 13 primitives, so the
 # generated `ccall` slot was `Any` (or the `Int64` guess). Same for a `u16`
@@ -1157,6 +1164,189 @@ end
         value = RustCall._rust_call_dynamic(lib, "rc245_usize_len")
         @test value === Csize_t(7)
         @test RustCall.get_function_return_type(lib, "rc245_usize_len") === Csize_t
+    end
+end
+
+# #245: `is_supported_arg_type(::Type{T}) = isbitstype(T)` passed *any* isbits
+# Julia struct to Rust by value, assuming its layout matched. Rust's default
+# `repr(Rust)` layout is unspecified, so that is a claim only the user can make
+# — and it is now one they have to make out loud.
+@testset "#245: an unregistered struct is not passed by value" begin
+    if !RustCall.check_rustc_available()
+        @test_skip "rustc is required"
+    else
+        rust"""
+        #[repr(C)]
+        pub struct Rc245Vec2 { pub x: f64, pub y: f64 }
+
+        #[no_mangle]
+        pub extern "C" fn rc245_norm2(v: Rc245Vec2) -> f64 { v.x * v.x + v.y * v.y }
+        """
+
+        v = Rc245Vec2Julia(3.0, 4.0)
+        @test RustCall.ffi_by_value_registered(Rc245Vec2Julia) == false
+
+        err = try
+            @rust rc245_norm2(v)::Float64
+            nothing
+        catch e
+            e
+        end
+        @test err isa RustCall.RustError
+        msg = sprint(showerror, err)
+        @test occursin("Rc245Vec2Julia", msg)
+        @test occursin("register_ffi_struct", msg)
+        @test occursin("repr(C)", msg)
+
+        # The opt-in is what makes it work, and it works.
+        try
+            RustCall.register_ffi_struct(Rc245Vec2Julia)
+            @test (@rust rc245_norm2(v)::Float64) == 25.0
+        finally
+            RustCall.unregister_ffi_struct(Rc245Vec2Julia)
+        end
+        # ... and withdrawing the assertion closes the door again.
+        @test_throws RustCall.RustError (@rust rc245_norm2(v)::Float64)
+    end
+end
+
+# #245: the fail-closed contract error has to *reach* the caller.
+# `_rust_call_dynamic` tries LLVM inference as one of several ways to learn a
+# return type, inside a `try` whose `catch` swallowed everything but
+# `RustPanicError` — so a `RustError` from the type contract was replaced by
+# the unrelated "no return type" message. Swallowing a fail-closed error is the
+# fail-open pattern the contract exists to remove.
+@testset "#245: a contract error is not swallowed by return-type inference" begin
+    if !RustCall.check_rustc_available()
+        @test_skip "rustc is required"
+    else
+        code = """
+        #[repr(C)]
+        pub struct Rc245InferVec2 { pub x: f64, pub y: f64 }
+
+        #[no_mangle]
+        pub extern "C" fn rc245_infer_norm2(v: Rc245InferVec2) -> f64 { v.x * v.x + v.y * v.y }
+        """
+        lib = RustCall._compile_and_load_rust(code, "test_regressions", 0)
+        v = Rc245Vec2Julia(3.0, 4.0)
+        @test RustCall.ffi_by_value_registered(Rc245Vec2Julia) == false
+
+        # Unannotated: the manifest records nothing for a plain `#[no_mangle]`
+        # function with a struct argument, so the call reaches the inference
+        # branch — and the contract's refusal is what must come out.
+        err = try
+            RustCall._rust_call_dynamic(lib, "rc245_infer_norm2", v)
+            nothing
+        catch e
+            e
+        end
+        @test err isa RustCall.RustError
+        msg = sprint(showerror, err)
+        @test occursin("Rc245Vec2Julia", msg)
+        @test occursin("register_ffi_struct", msg)
+        # ...*not* the generic fallback message the swallowing catch produced.
+        @test !occursin("has no return type", msg)
+
+        # Annotated, the same refusal comes through the typed door too.
+        @test_throws RustCall.RustError RustCall._rust_call_typed(
+            lib, "rc245_infer_norm2", Float64, v)
+
+        # The inference failure itself is now a named type, which is what makes
+        # the narrow catch possible.
+        @test_throws RustCall.SignatureInferenceError RustCall.infer_function_types(
+            lib, "rc245_no_such_function")
+        infer_err = try
+            RustCall.infer_function_types(lib, "rc245_no_such_function")
+            nothing
+        catch e
+            e
+        end
+        @test occursin("rc245_no_such_function", sprint(showerror, infer_err))
+    end
+end
+
+# #245: a `::T` annotation that disagrees with the manifest used to win, and
+# the ccall then read the return slot as a `T` it is not — `@rust f(x)::Float64`
+# on a `-> i32` returned the 32 bits reinterpreted as a `Float64`. An annotation
+# supplies a return type RustCall does not know; it does not override one it
+# does.
+@testset "#245: a return annotation that contradicts the manifest is an error" begin
+    if !RustCall.check_rustc_available()
+        @test_skip "rustc is required"
+    else
+        rust"""
+        #[julia]
+        pub fn rc245_mismatch(a: i32) -> i32 { a * 2 }
+        """
+
+        # The manifest's own answer still works, annotated or not.
+        @test rc245_mismatch(Int32(21)) === Int32(42)
+        @test (@rust rc245_mismatch(Int32(21))) === Int32(42)
+        @test (@rust rc245_mismatch(Int32(21))::Int32) === Int32(42)
+
+        err = try
+            @rust rc245_mismatch(Int32(21))::Float64
+            nothing
+        catch e
+            e
+        end
+        @test err isa RustCall.RustError
+        msg = sprint(showerror, err)
+        # Both types are named, so the message says what to change.
+        @test occursin("Float64", msg)
+        @test occursin("Int32", msg)
+        @test occursin("rc245_mismatch", msg)
+        @test occursin("#245", msg)
+
+        # A same-width lie is refused too: this is not about whether the bits
+        # fit, it is about how the return slot is read.
+        @test_throws RustCall.RustError (@rust rc245_mismatch(Int32(21))::Float32)
+        @test_throws RustCall.RustError (@rust rc245_mismatch(Int32(21))::UInt32)
+
+        # The manifest records the **C slot**; an annotation names the
+        # **surface** type. For Rust `char` those differ — the slot is a
+        # `UInt32` code point, the surface a `Char` — and `::Char` was a
+        # correct call before this check existed. It has to stay one (#245
+        # review): agreement is "same ccall return slot", not "same type".
+        rust"""
+        #[julia]
+        pub fn rc245_upper_char(c: char) -> char { c.to_ascii_uppercase() }
+        """
+        @test rc245_upper_char('a') === 'A'
+        @test (@rust rc245_upper_char('a')::Char) === 'A'
+        # The slot itself is still accepted — it is the same call, read raw.
+        @test (@rust rc245_upper_char('a')::UInt32) === UInt32('A')
+        # Unannotated, the `@rust` path uses what the manifest recorded, which
+        # is the slot: it yields the code point. That is unchanged by this PR —
+        # the generated `#[julia]` wrapper above is the surface-typed door —
+        # and it is exactly why `::Char` has to keep working.
+        @test (@rust rc245_upper_char('q')) === UInt32('Q')
+        # ...and a type that lowers to a *different* slot is not.
+        @test_throws RustCall.RustError (@rust rc245_upper_char('a')::Int32)
+        @test_throws RustCall.RustError (@rust rc245_upper_char('a')::Float64)
+
+        # The rule, stated directly.
+        @test RustCall._return_annotation_agrees(Char, UInt32)
+        @test RustCall._return_annotation_agrees(UInt32, UInt32)
+        @test RustCall._return_annotation_agrees(Bool, UInt8)
+        @test RustCall._return_annotation_agrees(Cvoid, Nothing)
+        @test !RustCall._return_annotation_agrees(Int32, UInt32)
+        @test !RustCall._return_annotation_agrees(Float64, Int64)
+
+        # Aliases are the same type to `===`, so they never trip the check.
+        @test RustCall._check_return_annotation(
+            RustCall.resolve_call_target(RustCall.get_current_library(),
+                                         "rc245_mismatch"),
+            "rc245_mismatch", Int32) === nothing
+
+        # A snapshot that records nothing still accepts any annotation — that
+        # is what an annotation is for, and the whole `@rust f(x)::T` surface
+        # depends on it.
+        blank = RustCall.CallTarget(C_NULL, C_NULL, C_NULL, Ref(true), C_NULL,
+                                    "no-such-lib", nothing, nothing, 0)
+        @test RustCall._snapshot_return_type(blank) === nothing
+        @test RustCall._check_return_annotation(blank, "rc245_unrecorded", Int32) === nothing
+        @test RustCall._check_return_annotation(blank, "rc245_unrecorded", Float64) === nothing
     end
 end
 


### PR DESCRIPTION
## What

Two of #245's four acceptance criteria were closed by #276 (the return-type guess is gone; one shared type table). This is the other two.

### An unregistered Julia struct is no longer passed by value

`is_supported_arg_type(::Type{T}) = isbitstype(T)` and `ccall_arg_type(::Type{T}) = T` accepted **any** isbits Julia struct or tuple in argument or return position and copied its fields straight into the argument registers, on the assumption that the Rust type on the other side has the same layout. Rust's default `repr(Rust)` layout is explicitly unspecified — fields may be reordered, niches exploited, and the compiler may change its mind between versions — so an unannotated struct that works today is a silent miscompile waiting for a toolchain upgrade, with no error at any point.

`RustCall.register_ffi_struct(T)` is where that claim is now made:

```julia
struct Point            # matches #[repr(C)] pub struct Point { x: f64, y: f64 }
    x::Float64
    y::Float64
end
RustCall.register_ffi_struct(Point)
```

`ffi_check_by_value` refuses an aggregate that carries no claim, naming the type, its fields and the opt-in call to make. Four details worth review:

- **The registry is a method table.** `ffi_by_value_layout(::Type{T})`, with `register_ffi_struct` defining the method in `parentmodule(T)`. A `push!` into a global that lives in *RustCall* happens during a downstream package's precompilation and is **not** replayed when that package is loaded from its cache — the assertion would hold in the session that compiled the package and be gone in every one after it. A method is stored in that module's cache image and reinstated on load, like any other method the package defines.
- **Concrete types only.** `register_ffi_struct(Point)` on a parametric struct, or on an abstract type, is an `ArgumentError`: instantiations of `Point{T}` do not share a layout, and subtypes of an `abstract type Shape{T}` share even less, so a family-wide assertion would license values nobody ever matched against a Rust struct. `register_ffi_struct(Point{Float64})` says exactly what it says. RustCall's own covering assertions (`::Type{<:RustPtr}`) are methods written in the package — a claim it may make about its own mirrors, and one the public API will not make on a caller's behalf.
- **Register and unregister are each one locked transaction**, and `unregister_ffi_struct` deletes the method for *exactly* `T` (found by reconstructing its signature, so an assertion restored from a precompile cache is withdrawn too) — which is also why it cannot delete the package's own covering methods.
- **The lookup goes through `invokelatest`**, with no fast path. Plain dispatch in the caller's world is stale in both directions: it cannot see a method just defined, and it still sees one just deleted. Stale-*true* is fail-open, which is what this check exists to prevent.
- **Scalars are untouched.** `ffi_is_aggregate` is false for primitives, pointers and zero-field singletons — their ABI is their width. The per-function `CResult_<fn>` / `COption_<fn>` mirrors the wrapper generators emit subtype `RustCall.FFIByValue`, an assertion that needs no call at all and survives precompilation for the same structural reason.
- **The check runs in `call_rust_function`, not in the `@generated` `_call_rust_function`.** A generated method is not re-generated when `register_ffi_struct` is called later.

### A `::T` annotation may no longer contradict the manifest

`_rust_call_typed` took the annotation and ignored what the resolved generation records, so `@rust f(x)::Float64` on a `-> i32` read a 32-bit return slot as a `Float64` and returned garbage. `_check_return_annotation` compares the two — both from the *same snapshot*, per the #277 rule — and raises naming each.

Agreement is *the same `ccall` return slot*, not the same Julia type: the manifest records the slot while an annotation names the surface type, so `::Char` and `::UInt32` both agree with a `-> char` and `::Int32` does not.

### A contract error is no longer swallowed

`_rust_call_dynamic` tried LLVM inference inside a `try` whose `catch` swallowed everything but `RustPanicError`, so a fail-closed `RustError` was replaced by the unrelated "no return type" message. `infer_function_types` raises a named `SignatureInferenceError`, the `try` covers the inference and nothing else, and every other exception propagates. `@rust_llvm`'s call site, which rewrote every exception into a generic message, now rethrows `RustError` and `RustPanicError` first.

## Acceptance criteria → test

| #245 criterion | test |
| --- | --- |
| Calling an unannotated function whose signature wasn't parsed throws an informative error | `test/test_ffi_contract.jl` → `"the return-type guess is gone (#245 item 1)"`; `test/test_regressions.jl` → `"#245: an unannotated usize return is not the Int64 guess"` (existing, #276) |
| All four codegen paths resolve types through one shared table | `test/test_ffi_contract.jl` in full — the `(#245 item 2)` divergence testsets (existing, #276) |
| Passing an unregistered Julia struct by value errors with a pointer to the opt-in API | **new** `test/test_ffi_contract.jl` → `"by-value aggregates are opt-in (#245 item 3)"` and `"a generated mirror survives precompilation (#245 review)"`; **new** `test/test_regressions.jl` → `"#245: an unregistered struct is not passed by value"` (end to end through `@rust`) and `"#245: a contract error is not swallowed by return-type inference"` |
| Regression tests cover: unparsed return type, mismatched annotation, unregistered struct | the rows above, plus **new** `test/test_regressions.jl` → `"#245: a return annotation that contradicts the manifest is an error"` (including the `-> char` surface/slot case) |

The precompilation test is the interesting one: it builds a real package that defines a generated-style mirror **and** calls `register_ffi_struct` at top level, lets Julia precompile it, and in a **fresh process** asserts the mirror, the struct and the concrete parametric registration are all allowed while a sibling instantiation is not.

## Migration

`test/test_julia_to_rust_struct.jl` and `test/test_julia_to_rust_generic.jl` now call `RustCall.register_ffi_struct(Point)` / `(Point{Float64})` — the one-line migration every user of the by-value feature makes. Documented on the FFI type contract page (generated, so the prose lives in `docs/generate_type_matrix.jl`). `CHANGELOG.md` records both breaking changes.

`BINDINGS_FORMAT_VERSION` goes to **4**: a written-out bindings file now imports `RustCall.FFIByValue`. (#297 took `3` for `ffi_string_argument`; this branch is rebased onto it and takes the next number, with its own line in the version history.)

## Verification

Rebased onto `origin/main` (with #294, #297 and #298 in it) and squashed to one commit. Full `Pkg.test()` green at **1 and 4 threads** (7407 pass, 2 pre-existing broken), all five `scripts/lint_*.sh src`, `julia --project=docs docs/make.jl` exit 0.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
