### PR TITLE
Read a module's RustCall bindings in the latest world, and close the chase test's libraries

### DIFF
--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -171,11 +171,31 @@ function _alias_reloaded_library(mod::Module, stored_name::String, actual_name::
     # last registered for that name. The alias also shares the library's
     # liveness flag, so unloading either name retires both (#277 Phase B).
     alias_artifact!(inline_rustc_policy(), actual_name, stored_name)
-    if isdefined(mod, :__RUSTCALL_ACTIVE_LIB)
-        active = getfield(mod, :__RUSTCALL_ACTIVE_LIB)
+    active = _module_binding(mod, :__RUSTCALL_ACTIVE_LIB)
+    if active !== nothing
         active[] == stored_name && (active[] = actual_name)
     end
     return nothing
+end
+
+"""
+    _module_binding(mod, name) -> Any
+
+The value bound to `name` in `mod`, or `nothing` when there is none.
+
+`getfield` is invoked in the **latest** world. A `rust\"\"\"` block defines
+`__RUSTCALL_LIBS` and `__RUSTCALL_ACTIVE_LIB` in `mod`, and a `@rust` call in
+the same top-level expression — or a test that builds a module and calls
+straight into it — reads them from a world older than the one that defined
+them. Julia 1.12 warns about that access ("in a world prior to its definition
+world") and says it will become an error; `invokelatest` is the documented way
+to say "resolve this now", which is what these two bindings need: they are
+plain mutable containers whose *identity* is what matters, not something the
+compiler should specialize on.
+"""
+function _module_binding(mod::Module, name::Symbol)
+    isdefined(mod, name) || return nothing
+    return Base.invokelatest(getfield, mod, name)
 end
 
 """
@@ -189,8 +209,8 @@ the fallback function lookup across libraries in `get_function_pointer`.
 function _resolve_lib(mod::Module, lib_name::String)
     # Ensure ALL libraries from this module are loaded first
     # This is needed because get_function_pointer does fallback search across all libraries
-    if isdefined(mod, :__RUSTCALL_LIBS)
-        libs = getfield(mod, :__RUSTCALL_LIBS)
+    libs = _module_binding(mod, :__RUSTCALL_LIBS)
+    if libs !== nothing
         # `collect` first: a reload rebinds entries, and a Dict must not be
         # mutated while it is iterated.
         for (lname, code) in collect(libs)
@@ -213,11 +233,9 @@ function _resolve_lib(mod::Module, lib_name::String)
     # If no library name specified (e.g. @rust func() without a prior rust"""..."""),
     # try to use the module's active library.
     if isempty(lib_name)
-        if isdefined(mod, :__RUSTCALL_ACTIVE_LIB)
-            lib_name = getfield(mod, :__RUSTCALL_ACTIVE_LIB)[]
-        else
-            return get_current_library()
-        end
+        active = _module_binding(mod, :__RUSTCALL_ACTIVE_LIB)
+        active === nothing && return get_current_library()
+        lib_name = active[]
     end
 
     return lib_name

--- a/test/test_hot_reload_transaction.jl
+++ b/test/test_hot_reload_transaction.jl
@@ -681,10 +681,17 @@ end
                     # The bound exists and is small.
                     @test RustCall.MAX_RELOAD_CHASES == 3
                 finally
+                    # `close = true`, not a bare unload: every reload retires
+                    # the previous image and leaves it mapped, and Cargo built
+                    # each one inside `dir`. A mapped file cannot be deleted on
+                    # Windows, so `mktempdir`'s cleanup fails with ENOTEMPTY
+                    # under `chase/target/release` and logs it at Error level.
+                    # Closing first is what makes the cleanup succeed.
                     try
-                        RustCall.unload_library(lib_name)
+                        RustCall.unload_library(lib_name; close = true)
                     catch
                     end
+                    RustCall.close_retired_handles!()
                 end
             end
         end

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -1309,14 +1309,20 @@ end
             mod = Module(:RC278ResolveProbe)
             Core.eval(mod, :(const __RUSTCALL_LIBS = Dict{String, Any}()))
             Core.eval(mod, :(const __RUSTCALL_ACTIVE_LIB = Ref("")))
-            libs = getfield(mod, :__RUSTCALL_LIBS)
+            # The bindings were defined a moment ago, in a newer world than the
+            # one this code was compiled in. Julia 1.12 warns on a direct
+            # `getfield` here ("in a world prior to its definition world") and
+            # says it will error in a future version, so read them the same way
+            # `_resolve_lib` does — `@invokelatest`.
+            libs = @invokelatest getfield(mod, :__RUSTCALL_LIBS)
+            active = @invokelatest getfield(mod, :__RUSTCALL_ACTIVE_LIB)
             libs[stale] = old
-            getfield(mod, :__RUSTCALL_ACTIVE_LIB)[] = stale
+            active[] = stale
 
             RustCall._resolve_lib(mod, "")
             @test haskey(libs, actual)
             @test !haskey(libs, stale)
-            @test getfield(mod, :__RUSTCALL_ACTIVE_LIB)[] == actual
+            @test active[] == actual
             @test lock(() -> haskey(RustCall.RUST_LIBRARIES, stale), RustCall.REGISTRY_LOCK)
         finally
             lock(RustCall.REGISTRY_LOCK) do


### PR DESCRIPTION
Two sources of CI log noise, spotted on #297's Windows job. Both turned out to be hiding a real defect rather than being merely noisy.

## World-age access to `__RUSTCALL_LIBS` / `__RUSTCALL_ACTIVE_LIB`

Julia 1.12 prints:

```
WARNING: Detected access to binding RC278ResolveProbe.__RUSTCALL_LIBS in a world
prior to its definition world ... will error in future versions
```

`_resolve_lib` and `_alias_reloaded_library` read those two module bindings with a bare `getfield`. A `rust"""` block defines them, and a `@rust` call in the *same top-level expression* — or a test that builds a module and calls straight into it — reads them from a world older than the one that defined them. That is exactly the case the warning describes, and it is scheduled to become an error, so the fix belongs in `src/` and not only in the test.

`_module_binding` wraps the lookup in `Base.invokelatest`, the documented way to say "resolve this now". Nothing is lost by it: these are plain mutable containers (a `Dict` and a `Ref`) whose *identity* is what matters, not something the compiler should specialize on. The test reads them the same way, through `@invokelatest`.

## `mktempdir` cleanup failing under the hot-reload chase test

`Error: mktempdir cleanup` × 3 on Windows, `ENOTEMPTY` under `chase/target/release`. Every reload retires the previous image and leaves it **mapped**, and Cargo built each one inside the temp directory; the test unloaded without closing, so the mapped DLLs could not be deleted. It now unloads with `close = true` and drains the retired handles — the pattern the neighbouring reload tests already use, and what AGENTS.md requires ("unload libraries before deleting temp trees; a mapped DLL cannot be removed").

## Verification

Full `Pkg.test()` green (6995 pass, 2 pre-existing broken), all five `scripts/lint_*.sh src`, `julia --project=docs docs/make.jl` exit 0. `test/test_regressions.jl` now emits **zero** `Detected access to binding` warnings, which is the check for the first half; the second is only observable on Windows, where the CI job's log is the evidence.

The third noise source seen on that job — 2500+ `thread '<unnamed>' panicked at …` lines from the deliberate panic-boundary stress tests — is a `deps/rustcall_core/src/codegen.rs` change with golden regeneration and comes separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
