### PR TITLE
@register_ffi_struct: a by-value assertion that precompiles whatever the type is (#245)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,14 +99,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       x::Float64
       y::Float64
   end
-  RustCall.register_ffi_struct(Point)
+  @register_ffi_struct Point
   ```
 
   Without it the call raises a `RustError` naming the type, its fields and the
   opt-in. Registration is for **concrete types only**: `Point{Float64}` says
   nothing about `Point{Int32}` — a parameter changes sizes, alignment and
   register classes — and registering the `UnionAll` `Point`, or an abstract
-  type, is an error rather than a family-wide claim. Scalars, pointers,
+  type, is an error rather than a family-wide claim. `@register_ffi_struct` is
+  the form to use at a package's top level: it expands in the calling module, so
+  the method it defines is carried by that package's precompile cache whatever
+  `T` is — including a `Tuple`, whose `parentmodule` is `Core` and for which the
+  function form has no home but RustCall itself. Scalars, pointers,
   `Cstring`, `Char` and
   `Bool` are unaffected — their ABI is their width. So are the wrappers
   RustCall generates from a `#[julia] struct`, which cross as opaque handles,

--- a/docs/generate_type_matrix.jl
+++ b/docs/generate_type_matrix.jl
@@ -192,7 +192,7 @@ Declare the Rust struct `#[repr(C)]` — which *does* fix the field order — an
 record the claim once:
 
 ```julia
-RustCall.register_ffi_struct(Point)
+@register_ffi_struct Point
 
 @rust process_point(Point(3.0, 4.0))::Float64   # 25.0
 ```
@@ -201,9 +201,23 @@ RustCall.register_ffi_struct(Point)
 and that its fields line up with the Julia struct's in order and in type.
 RustCall cannot check that for you; the call is where you take responsibility
 for it. The assertion is recorded as a **method** of
-`RustCall.ffi_by_value_layout`, defined in the module that owns the type, so
-calling `register_ffi_struct` at a package's top level survives that package's
-precompilation and holds in every later session.
+`RustCall.ffi_by_value_layout`.
+
+At a package's top level, use the macro:
+
+```julia
+@register_ffi_struct Point
+@register_ffi_struct Tuple{Int32, Float64}
+```
+
+It expands in the *calling* module, so Julia stores the method in that module's
+precompile cache and reinstates it on load, like any other method the package
+defines. The function form, `register_ffi_struct(Point)`, defines the method in
+`parentmodule(T)` — the same thing for a struct the package itself defines, but
+for a type Julia owns (a `Tuple`, whose `parentmodule` is `Core`) it lands in
+RustCall, and a cross-module mutation of a dependency is not replayed from a
+downstream package's cache. Keep the function for the REPL, a script, or inside
+a function; use the macro when the registration has to survive precompilation.
 
 Registration is for **concrete types only**. `register_ffi_struct(Point)` on a
 parametric struct, or on an abstract type, is an error: instantiations of

--- a/docs/src/type_contract.md
+++ b/docs/src/type_contract.md
@@ -210,7 +210,7 @@ Declare the Rust struct `#[repr(C)]` — which *does* fix the field order — an
 record the claim once:
 
 ```julia
-RustCall.register_ffi_struct(Point)
+@register_ffi_struct Point
 
 @rust process_point(Point(3.0, 4.0))::Float64   # 25.0
 ```
@@ -219,9 +219,23 @@ RustCall.register_ffi_struct(Point)
 and that its fields line up with the Julia struct's in order and in type.
 RustCall cannot check that for you; the call is where you take responsibility
 for it. The assertion is recorded as a **method** of
-`RustCall.ffi_by_value_layout`, defined in the module that owns the type, so
-calling `register_ffi_struct` at a package's top level survives that package's
-precompilation and holds in every later session.
+`RustCall.ffi_by_value_layout`.
+
+At a package's top level, use the macro:
+
+```julia
+@register_ffi_struct Point
+@register_ffi_struct Tuple{Int32, Float64}
+```
+
+It expands in the *calling* module, so Julia stores the method in that module's
+precompile cache and reinstates it on load, like any other method the package
+defines. The function form, `register_ffi_struct(Point)`, defines the method in
+`parentmodule(T)` — the same thing for a struct the package itself defines, but
+for a type Julia owns (a `Tuple`, whose `parentmodule` is `Core`) it lands in
+RustCall, and a cross-module mutation of a dependency is not replayed from a
+downstream package's cache. Keep the function for the REPL, a script, or inside
+a function; use the macro when the registration has to survive precompilation.
 
 Registration is for **concrete types only**. `register_ffi_struct(Point)` on a
 parametric struct, or on an abstract type, is an error: instantiations of

--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -95,6 +95,9 @@ include("hot_reload.jl")
 export @rust, @rust_str, @irust, @irust_str
 export @rust_llvm
 export @rust_crate
+# The by-value opt-in of #245. A macro, because it must define its method in
+# the *calling* module for that method to survive the caller's precompilation.
+export @register_ffi_struct
 
 # Module initialization
 function __init__()

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -1374,6 +1374,55 @@ function ffi_is_aggregate(@nospecialize(T::Type))
 end
 
 """
+    _validate_ffi_by_value(T; repr_c = true, form = "register_ffi_struct")
+
+Everything `register_ffi_struct` refuses, in one place, so the macro form
+refuses exactly the same things. `form` is how the call was spelled, so the
+message quotes back what the caller wrote.
+
+Returns `T`, or throws `ArgumentError`.
+"""
+function _validate_ffi_by_value(@nospecialize(T::Type); repr_c::Bool = true,
+                                form::AbstractString = "register_ffi_struct")
+    call = form == "register_ffi_struct" ? "register_ffi_struct($T)" :
+                                           "@register_ffi_struct $T"
+    repr_c || throw(ArgumentError(
+        "$call with `repr_c = false` asserts nothing: a type may " *
+        "only be passed by value when the Rust type it mirrors is declared " *
+        "`#[repr(C)]`. Fix the Rust definition, or pass the value behind a " *
+        "pointer instead."))
+    T isa UnionAll && throw(ArgumentError(
+        "$call: a `UnionAll` cannot be registered. Its " *
+        "instantiations do not share a layout — a type parameter changes field " *
+        "sizes, alignment and even ABI register classes — so asserting one for " *
+        "the whole family would license `$T{...}` instantiations you never " *
+        "matched against a Rust struct, which is the fail-open behaviour this " *
+        "opt-in exists to remove. Register each concrete type you actually " *
+        "pass, e.g. `$T{Float64}`."))
+    (isconcretetype(T) && isstructtype(T)) || throw(ArgumentError(
+        "$call: only a concrete struct type can be passed by " *
+        "value — $T is $(isabstracttype(T) ? "abstract, and its subtypes share " *
+                                             "no layout" : "not a concrete struct type"). " *
+        "Register the concrete types you actually pass."))
+    isbitstype(T) || throw(ArgumentError(
+        "$call: only an `isbitstype` type can be passed by " *
+        "value — $T is not one" *
+        (ismutabletype(T) ? " (it is mutable; a mutable struct is a Julia heap " *
+                            "object, and Rust must receive it behind a " *
+                            "pointer)." : ".")))
+    return T
+end
+
+"""
+    _ffi_by_value_needs_method(T) -> Bool
+
+Whether a `ffi_by_value_layout` method for **exactly** `T` still has to be
+defined. Caller holds `REGISTRY_LOCK`; see `register_ffi_struct` for why only an
+exact duplicate is skipped.
+"""
+_ffi_by_value_needs_method(@nospecialize(T::Type)) = _ffi_layout_method(T) === nothing
+
+"""
     register_ffi_struct(T::Type; repr_c::Bool = true) -> Type
 
 Assert that values of `T` may be passed to and from Rust **by value**, because
@@ -1426,34 +1475,23 @@ the fail-open behaviour this opt-in exists to remove. Register each concrete
 type you actually pass: `register_ffi_struct(Point{Float64})` says exactly that,
 and says nothing about `Point{Int32}`.
 
-See also `unregister_ffi_struct`, `ffi_by_value_registered`,
-`ffi_by_value_layout`.
+!!! warning "Not precompile-safe for a type Julia owns"
+    `parentmodule(Tuple{Int32, Float64})` is `Core`, and there is no method
+    RustCall may add there — so the method lands in RustCall itself, which is a
+    cross-module mutation of a dependency and is **not** replayed from a
+    downstream package's precompile cache. The assertion would hold in the
+    session that compiled the package and be gone in every one after it.
+
+    Use `@register_ffi_struct` at a package's top level. It expands in the
+    *calling* module and is precompile-safe for every `T`. This function is the
+    runtime form: fine in the REPL, in a script, or inside a function.
+
+See also `@register_ffi_struct`, `unregister_ffi_struct`,
+`ffi_by_value_registered`, `ffi_by_value_layout`.
 """
+
 function register_ffi_struct(@nospecialize(T::Type); repr_c::Bool = true)
-    repr_c || throw(ArgumentError(
-        "register_ffi_struct($T; repr_c = false) asserts nothing: a type may " *
-        "only be passed by value when the Rust type it mirrors is declared " *
-        "`#[repr(C)]`. Fix the Rust definition, or pass the value behind a " *
-        "pointer instead."))
-    T isa UnionAll && throw(ArgumentError(
-        "register_ffi_struct($T): a `UnionAll` cannot be registered. Its " *
-        "instantiations do not share a layout — a type parameter changes field " *
-        "sizes, alignment and even ABI register classes — so asserting one for " *
-        "the whole family would license `$T{...}` instantiations you never " *
-        "matched against a Rust struct, which is the fail-open behaviour this " *
-        "opt-in exists to remove. Register each concrete type you actually " *
-        "pass, e.g. `register_ffi_struct($T{Float64})`."))
-    (isconcretetype(T) && isstructtype(T)) || throw(ArgumentError(
-        "register_ffi_struct($T): only a concrete struct type can be passed by " *
-        "value — $T is $(isabstracttype(T) ? "abstract, and its subtypes share " *
-                                             "no layout" : "not a concrete struct type"). " *
-        "Register the concrete types you actually pass."))
-    isbitstype(T) || throw(ArgumentError(
-        "register_ffi_struct($T): only an `isbitstype` type can be passed by " *
-        "value — $T is not one" *
-        (ismutabletype(T) ? " (it is mutable; a mutable struct is a Julia heap " *
-                            "object, and Rust must receive it behind a " *
-                            "pointer)." : ".")))
+    _validate_ffi_by_value(T; repr_c = repr_c)
     # The check and the method definition are **one** transaction under
     # `REGISTRY_LOCK`, paired with the one in `unregister_ffi_struct`. Split,
     # two tasks racing on the same type could both define the method, or an
@@ -1471,6 +1509,71 @@ function register_ffi_struct(@nospecialize(T::Type); repr_c::Bool = true)
                   :($(GlobalRef(@__MODULE__, :ffi_by_value_layout))(::Type{$T}) =
                         $(QuoteNode(:repr_c))))
         return T
+    end
+end
+
+"""
+    @register_ffi_struct T
+
+Assert that values of `T` may cross the boundary **by value** — the same claim
+`register_ffi_struct(T)` makes, recorded in a way that survives *this* module's
+precompilation whatever `T` is.
+
+Use this at a package's top level. It expands to a method definition:
+
+```julia
+RustCall.ffi_by_value_layout(::Type{T}) = :repr_c
+```
+
+written **in the calling module**, so Julia stores it in that module's cache
+image and reinstates it on load, like any other method the package defines.
+
+# Why the macro exists
+
+`register_ffi_struct(T)` is a function and cannot define a method in its
+caller's module; it uses `parentmodule(T)` instead. For a struct the package
+itself defines, that *is* the caller's module and everything works. For a type
+Julia owns — a `Tuple{Int32, Float64}`, whose `parentmodule` is `Core` — there
+is no such home, the method lands in RustCall, and a cross-module mutation of a
+dependency is **not** replayed from a downstream package's cache: the assertion
+would hold in the session that compiled the package and be gone in every one
+after it (#245 review). A macro has the caller's module by construction and has
+neither problem.
+
+```julia
+module MyPkg
+using RustCall
+
+struct Point
+    x::Float64
+    y::Float64
+end
+
+@register_ffi_struct Point
+@register_ffi_struct Tuple{Int32, Float64}
+end
+```
+
+The same rules apply as to the function: concrete, immutable, `isbitstype`
+struct types only, and the Rust type it mirrors must be `#[repr(C)]`. A
+`UnionAll` or an abstract type raises an `ArgumentError` where the macro's
+expansion runs — during precompilation, if that is where you wrote it, so a bad
+assertion fails the build rather than the first call.
+
+See also `register_ffi_struct` (the runtime form), `unregister_ffi_struct`,
+`ffi_by_value_layout`.
+"""
+macro register_ffi_struct(T)
+    ty = esc(T)
+    validate = GlobalRef(@__MODULE__, :_validate_ffi_by_value)
+    layout = GlobalRef(@__MODULE__, :ffi_by_value_layout)
+    return quote
+        # Validation first, and as its own statement: a type that cannot be
+        # asserted must raise rather than leave a method behind. `form` so the
+        # message quotes the macro back at the caller, not the function.
+        $validate($ty; form = "@register_ffi_struct")
+        $layout(::Type{$ty}) = $(QuoteNode(:repr_c))
+        $ty
     end
 end
 

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -1417,10 +1417,44 @@ end
     _ffi_by_value_needs_method(T) -> Bool
 
 Whether a `ffi_by_value_layout` method for **exactly** `T` still has to be
-defined. Caller holds `REGISTRY_LOCK`; see `register_ffi_struct` for why only an
-exact duplicate is skipped.
+defined. See `register_ffi_struct` for why only an exact duplicate is skipped.
+
+Takes `REGISTRY_LOCK` itself (it is reentrant, so the function form's larger
+transaction may call it), because the macro form cannot hold the lock across
+its definition: a method definition has to be a top-level expression in the
+calling module, and a `lock(...) do ... end` body would make it a local.
+Serializing the check alone is enough there — a macro used at a module's top
+level expands while that module is being loaded, on one task.
 """
-_ffi_by_value_needs_method(@nospecialize(T::Type)) = _ffi_layout_method(T) === nothing
+_ffi_by_value_needs_method(@nospecialize(T::Type)) =
+    lock(() -> _ffi_layout_method(T) === nothing, REGISTRY_LOCK)
+
+"""
+    _ffi_by_value_agrees(T, layout) -> Nothing
+
+Raise when `T` already carries an *exact* assertion recording a different
+layout than the one now being made.
+
+A re-registration that says the same thing is idempotent — the same claim, made
+twice — and silently redefining the method would warn under
+`--warn-overwrite=yes` and be rejected during package precompilation. A
+re-registration that says something *else* is not a duplicate at all: one of the
+two callers is wrong about the Rust type, and quietly keeping either answer is
+how a layout assertion stops meaning anything.
+
+Today `:repr_c` is the only layout there is, so this can only fire if a future
+kind is added — which is exactly when it must.
+"""
+function _ffi_by_value_agrees(@nospecialize(T::Type), layout::Symbol)
+    existing = Base.invokelatest(ffi_by_value_layout, T)
+    existing === layout && return nothing
+    throw(ArgumentError(
+        "$T is already asserted as `$existing`, and this registration says " *
+        "`$layout`. Two different layouts for one type cannot both be true: " *
+        "one of the two callers has the wrong Rust type in mind. Withdraw the " *
+        "first with `unregister_ffi_struct($T)` if the second is the correct " *
+        "one."))
+end
 
 """
     register_ffi_struct(T::Type; repr_c::Bool = true) -> Type
@@ -1504,7 +1538,12 @@ function register_ffi_struct(@nospecialize(T::Type); repr_c::Bool = true)
         # under `--warn-overwrite=yes`, which `Pkg.test` sets; anything broader
         # that happens to cover `T` is a different assertion and must not
         # suppress this one.
-        _ffi_layout_method(T) === nothing || return T
+        if !_ffi_by_value_needs_method(T)
+            # Already asserted: idempotent when it says the same thing, an
+            # error when it does not (see `_ffi_by_value_agrees`).
+            _ffi_by_value_agrees(T, :repr_c)
+            return T
+        end
         Core.eval(_ffi_registration_module(T),
                   :($(GlobalRef(@__MODULE__, :ffi_by_value_layout))(::Type{$T}) =
                         $(QuoteNode(:repr_c))))
@@ -1567,12 +1606,27 @@ macro register_ffi_struct(T)
     ty = esc(T)
     validate = GlobalRef(@__MODULE__, :_validate_ffi_by_value)
     layout = GlobalRef(@__MODULE__, :ffi_by_value_layout)
+    needs = GlobalRef(@__MODULE__, :_ffi_by_value_needs_method)
+    agrees = GlobalRef(@__MODULE__, :_ffi_by_value_agrees)
     return quote
         # Validation first, and as its own statement: a type that cannot be
         # asserted must raise rather than leave a method behind. `form` so the
         # message quotes the macro back at the caller, not the function.
         $validate($ty; form = "@register_ffi_struct")
-        $layout(::Type{$ty}) = $(QuoteNode(:repr_c))
+        # Idempotent, exactly as the function form is. Expanding the macro
+        # twice for one `T` — or after `register_ffi_struct(T)` already
+        # registered it — would otherwise redefine the same method, which warns
+        # under `--warn-overwrite=yes` and is rejected outright during package
+        # precompilation, in the very place this macro is documented for
+        # (#245 review). Only an *exact* duplicate is skipped; a broader method
+        # that happens to cover `T` is a different assertion.
+        if $needs($ty)
+            $layout(::Type{$ty}) = $(QuoteNode(:repr_c))
+        else
+            # Already asserted. Idempotent when it says the same thing, an
+            # error when it does not.
+            $agrees($ty, $(QuoteNode(:repr_c)))
+        end
         $ty
     end
 end

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -771,6 +771,36 @@ const ALL_SPELLINGS = vcat(
             @test RustCall.ffi_by_value_allowed(Rc245ByValueTwin)
             @test RustCall._ffi_layout_method(Rc245ByValueTwin).module === @__MODULE__
             @test RustCall._ffi_layout_method(Rc245ByValueTwin).module !== RustCall
+            # Idempotent, exactly as the function form is: expanding twice — or
+            # after the function already registered it — must not redefine the
+            # method. Redefinition warns under `--warn-overwrite=yes` (which
+            # `Pkg.test` sets, so this testset running clean *is* the assertion)
+            # and is rejected outright during package precompilation, where the
+            # macro is meant to be used (#245 review).
+            @test (@register_ffi_struct Rc245ByValueTwin) === Rc245ByValueTwin
+            @test RustCall.register_ffi_struct(Rc245ByValueTwin) === Rc245ByValueTwin
+            @test (@register_ffi_struct Rc245ByValueTwin) === Rc245ByValueTwin
+            @test length(methods(RustCall.ffi_by_value_layout,
+                                 (Type{Rc245ByValueTwin},))) == 1
+            @test RustCall.ffi_by_value_allowed(Rc245ByValueTwin)
+
+            # Idempotent means "the same claim, twice". A *different* claim is
+            # not a duplicate: one of the two callers has the wrong Rust type
+            # in mind, and quietly keeping either answer is how a layout
+            # assertion stops meaning anything. `:repr_c` is the only layout
+            # there is today, so the guard is asserted directly.
+            @test RustCall._ffi_by_value_agrees(Rc245ByValueTwin, :repr_c) === nothing
+            conflict = try
+                RustCall._ffi_by_value_agrees(Rc245ByValueTwin, :something_else)
+                nothing
+            catch e
+                e
+            end
+            @test conflict isa ArgumentError
+            @test occursin("repr_c", sprint(showerror, conflict))
+            @test occursin("something_else", sprint(showerror, conflict))
+            @test occursin("unregister_ffi_struct", sprint(showerror, conflict))
+            # ...and one withdrawal is still enough.
         finally
             @test RustCall.unregister_ffi_struct(Rc245ByValueTwin)
         end
@@ -778,7 +808,10 @@ const ALL_SPELLINGS = vcat(
 
         try
             @test (@register_ffi_struct Tuple{Int8, Int8}) === Tuple{Int8, Int8}
+            @test (@register_ffi_struct Tuple{Int8, Int8}) === Tuple{Int8, Int8}
             @test RustCall.ffi_by_value_allowed(Tuple{Int8, Int8})
+            @test length(methods(RustCall.ffi_by_value_layout,
+                                 (Type{Tuple{Int8, Int8}},))) == 1
             @test RustCall.ffi_by_value_allowed(Tuple{Int8, Int16}) == false
             # The function form would have put it in RustCall; the macro does
             # not, which is the whole point.

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -762,6 +762,47 @@ const ALL_SPELLINGS = vcat(
         @test RustCall.ffi_is_aggregate(Tuple{Int32, Float64})
         @test RustCall.ffi_by_value_allowed(Tuple{Int32, Float64}) == false
 
+        # The macro form defines the method in the **calling** module, which is
+        # what makes it precompile-safe for a type Julia owns — a `Tuple`,
+        # whose `parentmodule` is `Core` and where the function form has no
+        # home but RustCall (#245 review).
+        try
+            @test (@register_ffi_struct Rc245ByValueTwin) === Rc245ByValueTwin
+            @test RustCall.ffi_by_value_allowed(Rc245ByValueTwin)
+            @test RustCall._ffi_layout_method(Rc245ByValueTwin).module === @__MODULE__
+            @test RustCall._ffi_layout_method(Rc245ByValueTwin).module !== RustCall
+        finally
+            @test RustCall.unregister_ffi_struct(Rc245ByValueTwin)
+        end
+        @test RustCall.ffi_by_value_allowed(Rc245ByValueTwin) == false
+
+        try
+            @test (@register_ffi_struct Tuple{Int8, Int8}) === Tuple{Int8, Int8}
+            @test RustCall.ffi_by_value_allowed(Tuple{Int8, Int8})
+            @test RustCall.ffi_by_value_allowed(Tuple{Int8, Int16}) == false
+            # The function form would have put it in RustCall; the macro does
+            # not, which is the whole point.
+            @test RustCall._ffi_layout_method(Tuple{Int8, Int8}).module === @__MODULE__
+        finally
+            @test RustCall.unregister_ffi_struct(Tuple{Int8, Int8})
+        end
+        @test RustCall.ffi_by_value_allowed(Tuple{Int8, Int8}) == false
+
+        # It refuses exactly what the function refuses, and says so as the
+        # macro rather than as the function.
+        macro_err = try
+            @eval @register_ffi_struct $Rc245Pair
+            nothing
+        catch e
+            e
+        end
+        @test macro_err isa ArgumentError ||
+              (macro_err isa LoadError && macro_err.error isa ArgumentError)
+        @test occursin("@register_ffi_struct", sprint(showerror, macro_err))
+        @test_throws Exception (@eval @register_ffi_struct $Rc245Shape)
+        @test_throws Exception (@eval @register_ffi_struct $Rc245Mutable)
+        @test RustCall.ffi_by_value_allowed(Rc245Pair{Float64}) == false
+
         # The error names the type, its fields and the opt-in call to make.
         err = try
             RustCall.ffi_check_by_value(Int32, Any[Rc245ByValue])
@@ -952,6 +993,20 @@ const ALL_SPELLINGS = vcat(
             b::T
         end
         RustCall.register_ffi_struct(Pair2{Float64})
+
+        # A type Julia owns: `parentmodule(Tuple{...})` is `Core`, so the
+        # function form would define the method in RustCall — a cross-module
+        # mutation of a dependency, which is not replayed from this package's
+        # cache. The macro expands here and defines it here.
+        RustCall.@register_ffi_struct Tuple{Int32, Float64}
+
+        # ...and the macro is the right answer for an ordinary struct too.
+        struct Macro3
+            a::Int32
+            b::Int32
+            c::Int32
+        end
+        RustCall.@register_ffi_struct Macro3
         end
         """)
         try
@@ -963,7 +1018,10 @@ const ALL_SPELLINGS = vcat(
                   isbitstype(M.CResult_probe), " ",
                   RustCall.ffi_by_value_allowed(M.Pt), " ",
                   RustCall.ffi_by_value_allowed(M.Pair2{Float64}), " ",
-                  RustCall.ffi_by_value_allowed(M.Pair2{Int8}))
+                  RustCall.ffi_by_value_allowed(M.Pair2{Int8}), " ",
+                  RustCall.ffi_by_value_allowed(Tuple{Int32, Float64}), " ",
+                  RustCall.ffi_by_value_allowed(Tuple{Int32, Float32}), " ",
+                  RustCall.ffi_by_value_allowed(M.Macro3))
             """
             project = pkgdir(RustCall)
             out = withenv("JULIA_LOAD_PATH" => string(project, Sys.iswindows() ? ";" : ":", depot,
@@ -974,9 +1032,12 @@ const ALL_SPELLINGS = vcat(
             # supertype), and still isbits — a supertype does not change the
             # layout. The user's struct: allowed, because
             # `register_ffi_struct` defined a `ffi_by_value_layout` method in
-            # `Rc245Mirror245`, which its precompile cache carries. And the
-            # concrete parametric registration still licenses only itself.
-            @test out == "true false true true true false"
+            # `Rc245Mirror245`, which its precompile cache carries. The
+            # concrete parametric registration still licenses only itself. And
+            # the macro's two — a `Tuple`, which the function form could only
+            # have registered *in RustCall*, and an ordinary struct — come back
+            # as well, still without licensing a sibling tuple.
+            @test out == "true false true true true false true false true"
         finally
             rm(depot; recursive = true, force = true)
         end


### PR DESCRIPTION
Follow-up to the post-merge P2 on #295 (`src/ffi_contract.jl:1352`).

## What was still broken

`register_ffi_struct` is a **function**, so it cannot define a method in its caller's module; it uses `parentmodule(T)`. For a struct the calling package defines, that *is* the caller's module and the assertion is carried by that package's precompile cache — which is what #295 established and tested.

For a type **Julia** owns it is not. `parentmodule(Tuple{Int32, Float64})` is `Core`, so the method lands in RustCall itself; a cross-module mutation of a dependency is not replayed from a downstream package's cache, and the assertion holds in the session that compiled the package and is gone in every one after it. Same class as the P1 fixed for structs, with the tuple branch still on the old path.

## The fix

`@register_ffi_struct T` expands in the **calling** module:

```julia
RustCall.ffi_by_value_layout(::Type{T}) = :repr_c
```

so Julia stores the method in that module's cache image and reinstates it on load, like any other method the package defines — whatever `T` is. Exported, as the end-user macro it is.

```julia
module MyPkg
using RustCall

struct Point
    x::Float64
    y::Float64
end

@register_ffi_struct Point
@register_ffi_struct Tuple{Int32, Float64}
end
```

The function stays as the runtime form (REPL, script, inside a function), documented with a `!!! warning` naming exactly when it is not precompile-safe and pointing at the macro.

Both go through one `_validate_ffi_by_value`, so they refuse exactly the same things — `UnionAll`, abstract, mutable, non-`isbits` — and the message quotes back the form the caller actually wrote. The macro validates in a *separate statement* before defining anything, so a bad type raises where the expansion runs — during precompilation, if that is where it was written — rather than leaving a method behind.

## Tests

- `test/test_ffi_contract.jl` → `"by-value aggregates are opt-in (#245 item 3)"`: the macro on a struct **and on a `Tuple`**, asserting in both cases that `_ffi_layout_method(T).module` is the test's own module and **not** `RustCall`, that a sibling tuple stays unregistered, that `unregister_ffi_struct` withdraws it, and that the macro refuses a `UnionAll`, an abstract type and a mutable one with a message naming `@register_ffi_struct`.
- `test/test_ffi_contract.jl` → `"a generated mirror survives precompilation (#245 review)"`: the temp package now also registers `Tuple{Int32, Float64}` and a struct **through the macro**; the fresh process asserts both come back, while `Tuple{Int32, Float32}` does not.

## Sequencing

Independent of #302, which touches only `test/test_hot_reload_transaction.jl` and `test/test_loadpolicy.jl` — no file overlap, so the two can land in either order. Branched off `main` at 1a9798b (#295 merged).

## Verification

Full `Pkg.test()` green (7424 pass, 2 pre-existing broken), all five `scripts/lint_*.sh src`, `julia --project=docs docs/make.jl` exit 0.

Advances #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bqtry6ehnv5YzeEdrTPCTD
