### PR TITLE
Pin // cargo-deps: builds to a persisted Cargo.lock; --locked, --offline, resolution in the key (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/src/pyo3.md` gains "Migrating from `#[julia_pyo3]`".
 
 ### Added
+- **`// cargo-deps:` builds are pinned and reproducible**
+  ([#256](https://github.com/AtelierArith/RustCall.jl/issues/256)). The first
+  build of a dependency set resolves it once (`cargo generate-lockfile`) and
+  persists the `Cargo.lock` under `<cache dir>/lockfiles/`, named by the
+  declared set alone (`RustCall.lockfile_path`, `cargo_lockfile_id`); every
+  later build — of any block with the same dependencies, on any machine that
+  has the file — replays it with `cargo build --locked`. The lockfile's content
+  is part of the block's artifact identity, so a changed resolution is a new
+  artifact rather than a stale cache hit. `RUSTCALL_OFFLINE=1` adds `--offline`
+  to every Cargo invocation and fails loudly without a warm registry cache. The
+  generated project's package name is now the constant
+  `RustCall.CARGO_BLOCK_PACKAGE`, so one lockfile fits every block.
 - **`@rust_crate` binds a PyO3 crate that carries no RustCall attribute**
   ([#275](https://github.com/AtelierArith/RustCall.jl/issues/275), Phase 2).
   RustCall generates a *second* crate that depends on the target, emits one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has the file — replays it with `cargo build --locked`. The lockfile's content
   is part of the block's artifact identity, so a changed resolution is a new
   artifact rather than a stale cache hit. `RUSTCALL_OFFLINE=1` adds `--offline`
-  to every Cargo invocation and fails loudly without a warm registry cache. The
-  generated project's package name is now the constant
-  `RustCall.CARGO_BLOCK_PACKAGE`, so one lockfile fits every block.
+  to every Cargo invocation and fails loudly without a warm registry cache.
+  `clear_cache` keeps the lockfiles (they are inputs, not output);
+  `RustCall.clear_lockfiles()` discards them. The generated project's package
+  name is now the constant `RustCall.CARGO_BLOCK_PACKAGE`, so one lockfile fits
+  every block.
 - **`@rust_crate` binds a PyO3 crate that carries no RustCall attribute**
   ([#275](https://github.com/AtelierArith/RustCall.jl/issues/275), Phase 2).
   RustCall generates a *second* crate that depends on the target, emits one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to every Cargo invocation and fails loudly without a warm registry cache.
   `clear_cache` keeps the lockfiles (they are inputs, not output);
   `RustCall.clear_lockfiles()` discards them. The generated project's package
-  name is now the constant `RustCall.CARGO_BLOCK_PACKAGE`, so one lockfile fits
-  every block.
+  name is now derived from the dependency set (`RustCall.cargo_block_package`),
+  so one lockfile fits every block declaring it.
 - **`@rust_crate` binds a PyO3 crate that carries no RustCall attribute**
   ([#275](https://github.com/AtelierArith/RustCall.jl/issues/275), Phase 2).
   RustCall generates a *second* crate that depends on the target, emits one

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -73,6 +73,40 @@ The compiler in the key is the compiler that runs: versions come from
 toolchain that cannot be identified raises a `RustError` on any path about to
 compile, rather than caching everything under the string `"unknown"`.
 
+### Pinned, lockfile-driven dependency builds
+
+A `// cargo-deps:` block names version *ranges*; what Cargo resolves them to is
+a separate fact, and it is the fact that decides the binary. RustCall therefore
+persists one `Cargo.lock` per dependency set and builds against it (issue #256):
+
+- **Where.** `RustCall.lockfile_path(deps)` — or `lockfile_path(source)` for a
+  block's source text — is `<cache dir>/lockfiles/<key>.lock`, where the key is
+  `artifact_key(cargo_lockfile_id(deps))`: the declared dependency set and
+  nothing else (no toolchain), so the same set on any machine looks in the same
+  place. The generated project's package is always named
+  `RustCall.CARGO_BLOCK_PACKAGE`, so one lockfile fits every block declaring the
+  set.
+- **First build.** With no persisted lockfile, `cargo generate-lockfile`
+  resolves the set once and the result is stored. Every later build — of this
+  block or any other with the same dependencies — copies the file in and runs
+  `cargo build --locked`, so Cargo builds exactly the pinned graph or fails; it
+  never re-resolves behind the cache key.
+- **Identity.** The lockfile's *content* is part of the block's `ArtifactId`
+  (`cargo-lock`). A changed resolution is a different artifact; a cache hit can
+  never answer for another graph.
+- **Sharing and refreshing.** Copy or commit the file to reproduce a build on
+  another machine; delete it to resolve afresh. `clear_cache` leaves lockfiles
+  alone — they are inputs of a build, not outputs.
+- **Offline.** `RUSTCALL_OFFLINE=1` adds `--offline` to every Cargo invocation.
+  With a warm registry cache the pinned build succeeds without the network; with
+  a cold one Cargo fails at once with its own message (surfaced as a
+  `CargoBuildError`), rather than hanging on a download.
+
+`@rust_crate` wrapper crates depend on your crate by path and are built as their
+own Cargo root; a PyO3 wrapper carries your crate's `Cargo.lock` and `[patch]`
+table (see [PyO3 crates](pyo3.md)). Persisting *their* resolution is not covered
+here.
+
 ### Cache Management
 
 ```julia

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -98,6 +98,13 @@ persists one `Cargo.lock` per dependency set and builds against it (issue #256):
   another machine; delete it to resolve afresh. `clear_cache` leaves lockfiles
   alone — they are inputs of a build, not outputs — and
   `RustCall.clear_lockfiles()` is the one operation that discards them all.
+- **One resolution wins.** Two processes (or machines sharing the store) that
+  both find it empty publish through an exclusive-create claim file beside the
+  entry: the first to claim publishes, the other waits and replays the
+  published file, so both build one graph. A claim is never expired by age; if
+  a build ever reports that another process holds the claim and nothing was
+  published, and no other process is resolving that set, a previous one died
+  holding it — delete the named `.claim` file (or run `clear_lockfiles()`).
 - **Offline.** `RUSTCALL_OFFLINE=1` adds `--offline` to every Cargo invocation.
   With a warm registry cache the pinned build succeeds without the network; with
   a cold one Cargo fails at once with its own message (surfaced as a

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -85,7 +85,10 @@ persists one `Cargo.lock` per dependency set and builds against it (issue #256):
   nothing else (no toolchain), so the same set on any machine looks in the same
   place. The generated project's package is named from the set
   (`RustCall.cargo_block_package(deps)`), so one lockfile fits every block
-  declaring it, and no fixed name is reserved that your own crate might use.
+  declaring it, and no fixed name is reserved that your own crate might use. A
+  stored file that does not name that package — a hand-edited file, or one
+  written under an older naming scheme — is not this set's resolution and is
+  resolved afresh rather than replayed.
 - **First build.** With no persisted lockfile, `cargo generate-lockfile`
   resolves the set once and the result is stored. Every later build — of this
   block or any other with the same dependencies — copies the file in and runs

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -83,9 +83,9 @@ persists one `Cargo.lock` per dependency set and builds against it (issue #256):
   block's source text — is `<cache dir>/lockfiles/<key>.lock`, where the key is
   `artifact_key(cargo_lockfile_id(deps))`: the declared dependency set and
   nothing else (no toolchain), so the same set on any machine looks in the same
-  place. The generated project's package is always named
-  `RustCall.CARGO_BLOCK_PACKAGE`, so one lockfile fits every block declaring the
-  set.
+  place. The generated project's package is named from the set
+  (`RustCall.cargo_block_package(deps)`), so one lockfile fits every block
+  declaring it, and no fixed name is reserved that your own crate might use.
 - **First build.** With no persisted lockfile, `cargo generate-lockfile`
   resolves the set once and the result is stored. Every later build — of this
   block or any other with the same dependencies — copies the file in and runs

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -96,7 +96,8 @@ persists one `Cargo.lock` per dependency set and builds against it (issue #256):
   never answer for another graph.
 - **Sharing and refreshing.** Copy or commit the file to reproduce a build on
   another machine; delete it to resolve afresh. `clear_cache` leaves lockfiles
-  alone — they are inputs of a build, not outputs.
+  alone — they are inputs of a build, not outputs — and
+  `RustCall.clear_lockfiles()` is the one operation that discards them all.
 - **Offline.** `RUSTCALL_OFFLINE=1` adds `--offline` to every Cargo invocation.
   With a warm registry cache the pinned build succeeds without the network; with
   a cold one Cargo fails at once with its own message (surfaced as a

--- a/src/artifact_id.jl
+++ b/src/artifact_id.jl
@@ -373,11 +373,15 @@ distinct specs can never collapse onto the same string.
 
 # How each kind of dependency is identified
 
-- **Registry** dependencies: name, version requirement and feature set. The
-  *resolved* version from `Cargo.lock` is deliberately out of scope (see #256);
-  folding lockfile resolution into the key is tracked there.
+- **Registry** dependencies: name, version requirement and feature set — the
+  *requested* range. The *resolved* version is not in the string on purpose:
+  the strings name a dependency set, and `cargo_lockfile_id` uses exactly them
+  to name the `Cargo.lock` persisted for that set, which must be the same file
+  on every machine. The resolution reaches a **build's** key as the content
+  digest of that lockfile (`_cargo_block_id`'s `cargo_lock`, #256).
 - **Git** dependencies: name and the git URL (plus rev/branch/tag when the spec
-  carries them). Resolving a floating branch to a commit is likewise #256.
+  carries them). A floating branch is resolved to a commit in the same
+  lockfile.
 - **Local path** dependencies: a content digest of the crate's inputs (see
   `artifact_path_dependency_digest`), **not** the path text. Editing a
   local dependency's sources therefore changes the key, while moving the
@@ -410,6 +414,32 @@ function artifact_dependency_strings(deps)::Vector{String}
         push!(out, String(take!(io)))
     end
     return sort!(out)
+end
+
+"""
+    cargo_lockfile_id(deps) -> ArtifactId
+
+The identity of the **resolution** of a dependency set: what names the
+`Cargo.lock` RustCall persists for a `// cargo-deps:` block (`lockfile_path`,
+#256). Deliberately narrower than a build's identity — the dependency strings
+of `artifact_dependency_strings` and nothing else, with the toolchain and
+compiler fields empty — because the point of the persisted lockfile is to be
+the same file on every machine that declares the same dependencies, whatever
+`rustc` each of them runs; the *build* key then folds the lockfile's content
+in (`_cargo_block_id`'s `cargo_lock`), so the resolved versions, not the
+requested ranges, decide a cache hit.
+
+A `path =` dependency contributes its content digest, as in every dependency
+string, so editing a local crate re-resolves rather than replaying a lockfile
+that pins the old graph.
+"""
+function cargo_lockfile_id(deps)::ArtifactId
+    return ArtifactId(
+        kind = "cargo-lockfile",
+        dependencies = artifact_dependency_strings(deps),
+        toolchain = "",
+        compiler = "",
+    )
 end
 
 # ----------------------------------------------------------------------------

--- a/src/artifact_id.jl
+++ b/src/artifact_id.jl
@@ -432,6 +432,13 @@ requested ranges, decide a cache hit.
 A `path =` dependency contributes its content digest, as in every dependency
 string, so editing a local crate re-resolves rather than replaying a lockfile
 that pins the old graph.
+
+The root package's naming scheme (`CARGO_BLOCK_PACKAGE_PREFIX`) is in the key
+too: the root appears in `Cargo.lock` by name, so a lockfile written under one
+scheme does not fit a project named under another. A scheme change therefore
+names a new store entry rather than replaying a file `--locked` would reject —
+which is what a CI cache that carries the scratch space across runs would
+otherwise do (#313 review).
 """
 function cargo_lockfile_id(deps)::ArtifactId
     return ArtifactId(
@@ -439,6 +446,7 @@ function cargo_lockfile_id(deps)::ArtifactId
         dependencies = artifact_dependency_strings(deps),
         toolchain = "",
         compiler = "",
+        extra = Pair{String, String}["root-package-prefix" => CARGO_BLOCK_PACKAGE_PREFIX],
     )
 end
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -754,6 +754,11 @@ The pre-#252 tree under `_legacy_cache_root()` is removed only with
 RustCall (see the warning there), so removing it is opt-in even though every
 name matched is exact.
 
+The persisted `Cargo.lock` files (`lockfile_dir`, #256) are **kept**: they are
+inputs of a build — the resolution a `// cargo-deps:` block is pinned to — not
+compiled output, and clearing compiled artifacts must not silently re-resolve
+every dependency set. `clear_lockfiles()` removes them on request.
+
 On Windows, some files may be locked and cannot be deleted immediately.
 """
 function clear_cache(; sweep_legacy::Bool = false)
@@ -762,44 +767,34 @@ function clear_cache(; sweep_legacy::Bool = false)
     end
 end
 
+"""
+    CACHE_INPUT_DIRS
+
+Entries directly under the cache directory that `clear_cache` leaves in place:
+they hold build *inputs* RustCall persisted, not compiled output. Today the
+`lockfiles` store (#256).
+"""
+const CACHE_INPUT_DIRS = ("lockfiles",)
+
 function _clear_cache_unlocked(; sweep_legacy::Bool = false)
     # Clearing "the cache" means every format this RustCall is responsible for,
     # not just the current one, or a `clear_cache()` would leave older scratch
     # spaces on disk forever.
     sweep_stale_cache_formats(; legacy = sweep_legacy)
     cache_dir = get_cache_dir()
-    if isdir(cache_dir)
+    isdir(cache_dir) || return nothing
+    # Entry by entry, never the directory as a whole: the `lockfiles` store is
+    # an input and stays (#256), and on Windows a still-mapped library refuses
+    # to be deleted — the rest of the cache is cleared around it rather than
+    # the whole operation failing.
+    for entry in readdir(cache_dir)
+        entry in CACHE_INPUT_DIRS && continue
+        path = joinpath(cache_dir, entry)
         try
-            # Try to remove the directory recursively
-            rm(cache_dir, recursive=true, force=true)
+            rm(path, recursive = true, force = true)
         catch e
-            # On Windows, files may be locked (e.g., by Julia's compiled modules)
-            # Check if it's a directory not empty or busy error
-            if isa(e, Base.IOError)
-                error_msg = string(e)
-                if occursin("not empty", error_msg) || occursin("ENOTEMPTY", error_msg) ||
-                   occursin("busy", error_msg) || occursin("EBUSY", error_msg)
-                    # Try to remove files individually, ignoring errors for locked files
-                    for file in readdir(cache_dir)
-                        file_path = joinpath(cache_dir, file)
-                        try
-                            if isfile(file_path)
-                                rm(file_path, force=true)
-                            elseif isdir(file_path)
-                                rm(file_path, recursive=true, force=true)
-                            end
-                        catch
-                            # Ignore errors for individual files (may be locked)
-                        end
-                    end
-                else
-                    # Re-throw if it's a different error
-                    rethrow(e)
-                end
-            else
-                # Re-throw if it's not an IOError
-                rethrow(e)
-            end
+            e isa Base.IOError || rethrow(e)
+            @debug "Could not remove a cache entry (file may be in use)" path exception = e
         end
     end
     return nothing
@@ -818,6 +813,10 @@ function get_cache_size()
 
     total_size = Int64(0)
     for (root, dirs, files) in walkdir(cache_dir)
+        # The size of the *compiled* cache: the persisted lockfiles are inputs
+        # (`CACHE_INPUT_DIRS`), survive `clear_cache`, and are not counted —
+        # otherwise a cleared cache would never read as empty (#256).
+        root == cache_dir && filter!(d -> !(d in CACHE_INPUT_DIRS), dirs)
         for file in files
             file_path = joinpath(root, file)
             if isfile(file_path)

--- a/src/cargobuild.jl
+++ b/src/cargobuild.jl
@@ -46,19 +46,131 @@ function _cargo_feature_args(features::Vector{String}, default_features::Bool)
 end
 
 """
-    _cargo_build_args(release, features, default_features) -> Vector{String}
+    cargo_offline() -> Bool
+
+Whether `RUSTCALL_OFFLINE` asks for air-gapped builds (`1`, `true`, `yes`; case
+insensitive). Every `cargo` invocation that could touch the network —
+`generate-lockfile`, `build` — then carries `--offline`, and Cargo fails at once,
+with its own message, on anything the local registry cache does not hold,
+rather than hanging on a download (#256). The flag changes where Cargo looks,
+not what it builds, so it is not part of any artifact identity.
+"""
+cargo_offline() = lowercase(strip(get(ENV, "RUSTCALL_OFFLINE", ""))) in ("1", "true", "yes")
+
+# The network half of a `cargo` argument vector: `--offline` under
+# `RUSTCALL_OFFLINE`, nothing otherwise.
+_cargo_network_args() = cargo_offline() ? ["--offline"] : String[]
+
+"""
+    _cargo_build_args(release, features, default_features; locked = false) -> Vector{String}
 
 The argument vector of the `cargo build` a project is built with: the profile,
-then the feature set (`_cargo_feature_args`). A plain `@rust_crate` build made
-with `features = ...` / `default_features = false` passes them here, so the
-crate is built with the configuration that was asked for and not its default
-one (#307 review).
+then the feature set (`_cargo_feature_args`), then `--locked` when the project's
+`Cargo.lock` is authoritative — it came from the lockfile store or was just
+generated for exactly this project (`ensure_cargo_lockfile!`) — so Cargo builds
+the resolved graph the identity describes or fails, never re-resolving behind
+the key (#256); and `--offline` under `RUSTCALL_OFFLINE`. A plain `@rust_crate`
+build made with `features = ...` / `default_features = false` passes them here,
+so the crate is built with the configuration that was asked for and not its
+default one (#307 review).
 """
-function _cargo_build_args(release::Bool, features::Vector{String}, default_features::Bool)
+function _cargo_build_args(release::Bool, features::Vector{String}, default_features::Bool;
+                           locked::Bool = false)
     args = ["build"]
     release && push!(args, "--release")
     append!(args, _cargo_feature_args(features, default_features))
+    locked && push!(args, "--locked")
+    append!(args, _cargo_network_args())
     return args
+end
+
+"""
+    lockfile_dir() -> String
+
+The directory of the persisted `Cargo.lock` files (`<cache dir>/lockfiles`),
+created on demand. Lockfiles are *inputs* of a build, not outputs, so
+`clear_cache` / `clear_cargo_cache` leave them alone: delete one to re-resolve
+its dependency set (`lockfile_path`).
+"""
+function lockfile_dir()
+    dir = joinpath(get_cache_dir(), "lockfiles")
+    mkpath(dir)
+    return dir
+end
+
+"""
+    lockfile_path(deps::Vector{DependencySpec}) -> String
+    lockfile_path(code::AbstractString) -> String
+
+Where RustCall keeps the `Cargo.lock` of a `// cargo-deps:` dependency set —
+named by `artifact_key(cargo_lockfile_id(deps))`, so the same declared set on
+any machine looks in the same place. The second form parses the dependency
+comments of a block's source (`parse_dependencies_from_code`).
+
+The file is written the first time the set is resolved (`cargo generate-lockfile`,
+`ensure_cargo_lockfile!`) and replayed with `--locked` on every later build, on
+this machine or another one that has the file. Commit it, copy it, or delete it
+to resolve afresh; its content is part of every build's identity, so a changed
+lockfile is a rebuild and never a stale cache hit (#256).
+"""
+lockfile_path(deps::Vector{DependencySpec}) =
+    joinpath(lockfile_dir(), artifact_key(cargo_lockfile_id(deps)) * ".lock")
+lockfile_path(code::AbstractString) = lockfile_path(parse_dependencies_from_code(String(code)))
+
+"""
+    ensure_cargo_lockfile!(project::CargoProject; env = nothing) -> Union{String, Nothing}
+
+Give a generated project an authoritative `Cargo.lock` and return its content
+digest — `nothing` for a project that declares no dependencies of its own
+(`project.dependencies` empty, e.g. a `@rust_crate` wrapper whose manifest was
+written by hand), which has no entry in the lockfile store.
+
+When the store has a lockfile for the project's dependency set
+(`lockfile_path`), it is copied in and nothing is resolved: the build that
+follows is `--locked`, so it either builds exactly the graph the file pins or
+fails. Otherwise `cargo generate-lockfile` resolves the set once — `--offline`
+under `RUSTCALL_OFFLINE`, failing loudly when the local registry lacks
+something — and the result is persisted for every later build of the same set
+(#256). The generated project's root package is `CARGO_BLOCK_PACKAGE` for every
+block, which is what makes one lockfile fit them all.
+
+Throws `CargoBuildError` with Cargo's own message when resolution fails.
+"""
+function ensure_cargo_lockfile!(project::CargoProject;
+                                env::Union{Nothing, AbstractDict} = nothing)
+    isempty(project.dependencies) && return nothing
+    stored = lockfile_path(project.dependencies)
+    target = joinpath(project.path, "Cargo.lock")
+    if isfile(stored)
+        cp(stored, target; force = true)
+        return _file_content_digest(target)
+    end
+    args = ["generate-lockfile"]
+    append!(args, _cargo_network_args())
+    cmd = setenv(`$(cargo()) $args`, Dict{String, String}(env === nothing ? ENV : env);
+                 dir = project.path)
+    stderr_io = IOBuffer()
+    ok = try
+        success(pipeline(cmd; stdout = devnull, stderr = stderr_io))
+    catch e
+        throw(CargoBuildError("Unexpected error while resolving dependencies: $e", "",
+                              project.path))
+    end
+    ok || throw(CargoBuildError(
+        cargo_offline() ?
+            "Cargo could not resolve the dependencies offline (RUSTCALL_OFFLINE is set and " *
+            "the local registry cache does not hold them)" :
+            "Cargo could not resolve the dependencies",
+        String(take!(stderr_io)), project.path))
+    isfile(target) || throw(CargoBuildError("cargo generate-lockfile produced no Cargo.lock",
+                                            "", project.path))
+    # Persist atomically: a concurrent build of the same set must see a whole
+    # file or none.
+    mkpath(dirname(stored))
+    tmp = stored * ".tmp-$(getpid())-$(rand(UInt32))"
+    cp(target, tmp; force = true)
+    mv(tmp, stored; force = true)
+    return _file_content_digest(target)
 end
 
 """
@@ -82,10 +194,11 @@ function build_cargo_project(project::CargoProject; release::Bool = true,
                              env::Union{Nothing, AbstractDict} = nothing,
                              policy::LoadPolicy = inline_cargo_policy(),
                              features::Vector{String} = String[],
-                             default_features::Bool = true)
+                             default_features::Bool = true,
+                             locked::Bool = false)
     # Build command
     cargo_cmd = cargo()
-    build_args = _cargo_build_args(release, features, default_features)
+    build_args = _cargo_build_args(release, features, default_features; locked = locked)
 
     # The panic strategy is pinned twice: in the generated manifest and here,
     # in the environment Cargo runs under (#244). The manifest key already
@@ -290,7 +403,8 @@ function build_cargo_project_cached(
     project::CargoProject,
     id::ArtifactId;
     release::Bool = true,
-    env::Union{Nothing, AbstractDict} = nothing
+    env::Union{Nothing, AbstractDict} = nothing,
+    locked::Bool = false
 )
     # `id` is already the complete identity of this build — the caller computed
     # it once and looked the artifact up under it. Deriving a *richer* key here
@@ -309,7 +423,7 @@ function build_cargo_project_cached(
     end
 
     # Build the project
-    lib_path = build_cargo_project(project, release=release, env=env)
+    lib_path = build_cargo_project(project, release=release, env=env, locked=locked)
 
     # Cache the result
     try

--- a/src/cargobuild.jl
+++ b/src/cargobuild.jl
@@ -198,7 +198,7 @@ function ensure_cargo_lockfile!(project::CargoProject;
 end
 
 """
-    _publish_lockfile!(stored, target; wait = 10.0, stale_after = 60.0) -> String
+    _publish_lockfile!(stored, target; wait = 10.0) -> String
 
 Publish the lockfile a project just resolved (`target`) to the store (`stored`)
 so that exactly one resolution wins, and return the digest of the file the
@@ -212,15 +212,21 @@ it stages the content beside the entry and renames it into place (a whole file
 or none), then removes the claim. Every other process is a loser: it waits up
 to `wait` seconds for the published file to appear, discards its own
 resolution, copies the published file into its project and returns *that*
-digest — so every racer builds the published graph (#313 review). A claim older
-than `stale_after` seconds with no published file behind it is a publisher that
-died; the next comer removes it and claims for itself.
+digest — so every racer builds the published graph (#313 review).
 
-Throws `CargoBuildError` when the claim is held and nothing is published within
-`wait` seconds.
+A claim is never expired by age. Deciding that a publisher is dead from a
+file's mtime against this process's clock is wrong across machines sharing the
+store (their clocks need not agree), and a takeover of a *live* claim is
+precisely the two-publisher race the claim exists to prevent. A claim that
+outlives `wait` with nothing published behind it therefore fails loudly, naming
+the file: if no other RustCall process is resolving the set, a previous one
+died holding the claim — delete that file (or run `clear_lockfiles()`) and
+build again.
+
+Throws `CargoBuildError` in that case.
 """
 function _publish_lockfile!(stored::AbstractString, target::AbstractString;
-                            wait::Real = 10.0, stale_after::Real = 60.0)
+                            wait::Real = 10.0)
     stored = String(stored)
     target = String(target)
     mkpath(dirname(stored))
@@ -239,16 +245,13 @@ function _publish_lockfile!(stored::AbstractString, target::AbstractString;
     else
         deadline = time() + Float64(wait)
         while !isfile(stored) && time() < deadline
-            if isfile(claim) && time() - mtime(claim) > Float64(stale_after)
-                # The publisher died holding the claim: take it over.
-                rm(claim; force = true)
-                return _publish_lockfile!(stored, target; wait = wait, stale_after = stale_after)
-            end
             sleep(0.05)
         end
         isfile(stored) || throw(CargoBuildError(
-            "Another process is resolving the same dependency set and has not published " *
-            "its Cargo.lock within $(wait)s",
+            "Another RustCall process holds the claim on this dependency set's Cargo.lock " *
+            "and published nothing within $(wait)s. If no other process is resolving it, " *
+            "a previous one died holding the claim: delete `$(claim)` (or run " *
+            "`RustCall.clear_lockfiles()`) and build again",
             "claim: $(claim)", dirname(target)))
     end
     # Whoever published, the project builds the published file.

--- a/src/cargobuild.jl
+++ b/src/cargobuild.jl
@@ -198,49 +198,76 @@ function ensure_cargo_lockfile!(project::CargoProject;
 end
 
 """
-    _publish_lockfile!(stored, target) -> String
+    _publish_lockfile!(stored, target; wait = 10.0, stale_after = 60.0) -> String
 
 Publish the lockfile a project just resolved (`target`) to the store (`stored`)
-without clobbering, and return the digest of the file the project ends up with.
+so that exactly one resolution wins, and return the digest of the file the
+project ends up with.
 
-A whole file or none: the content is staged next to `stored` and linked into
-place with `hardlink`, which fails with `EEXIST` when another process published
-first (a plain rename would silently replace the winner). When that happens —
-or when `hardlink` is unavailable and `stored` appeared in between — the
-project's own resolution is discarded, the published file is copied into the
-project, and its digest is returned: every racer builds the published graph.
+The primitive is an exclusive create (`O_CREAT | O_EXCL`) of a claim file
+beside the entry (`_claim_lockfile!`), which every filesystem makes atomic — a
+rename guarded by an `isfile` check is not, and two first-time builders could
+pass the check together. The process that creates the claim is the publisher:
+it stages the content beside the entry and renames it into place (a whole file
+or none), then removes the claim. Every other process is a loser: it waits up
+to `wait` seconds for the published file to appear, discards its own
+resolution, copies the published file into its project and returns *that*
+digest — so every racer builds the published graph (#313 review). A claim older
+than `stale_after` seconds with no published file behind it is a publisher that
+died; the next comer removes it and claims for itself.
+
+Throws `CargoBuildError` when the claim is held and nothing is published within
+`wait` seconds.
 """
-function _publish_lockfile!(stored::AbstractString, target::AbstractString)
+function _publish_lockfile!(stored::AbstractString, target::AbstractString;
+                            wait::Real = 10.0, stale_after::Real = 60.0)
     stored = String(stored)
     target = String(target)
     mkpath(dirname(stored))
-    tmp = stored * ".tmp-$(getpid())-$(rand(UInt32))"
-    cp(target, tmp; force = true)
-    published = try
-        if isfile(stored)
-            false
-        else
-            try
-                hardlink(tmp, stored)
-                true
-            catch e
-                e isa Base.IOError || rethrow(e)
-                # `EEXIST`: somebody else landed first. Any other failure
-                # (a filesystem without hardlinks) falls back to a rename that
-                # is no-clobber up to a check.
-                if isfile(stored)
-                    false
-                else
-                    mv(tmp, stored; force = false)
-                    true
-                end
+    claim = stored * ".claim"
+    if _claim_lockfile!(claim)
+        try
+            if !isfile(stored)
+                tmp = stored * ".tmp-$(getpid())-$(rand(UInt32))"
+                cp(target, tmp; force = true)
+                # Only the claim holder renames, so this replaces nothing.
+                mv(tmp, stored; force = true)
             end
+        finally
+            rm(claim; force = true)
         end
-    finally
-        rm(tmp; force = true)
+    else
+        deadline = time() + Float64(wait)
+        while !isfile(stored) && time() < deadline
+            if isfile(claim) && time() - mtime(claim) > Float64(stale_after)
+                # The publisher died holding the claim: take it over.
+                rm(claim; force = true)
+                return _publish_lockfile!(stored, target; wait = wait, stale_after = stale_after)
+            end
+            sleep(0.05)
+        end
+        isfile(stored) || throw(CargoBuildError(
+            "Another process is resolving the same dependency set and has not published " *
+            "its Cargo.lock within $(wait)s",
+            "claim: $(claim)", dirname(target)))
     end
-    published || cp(stored, target; force = true)
+    # Whoever published, the project builds the published file.
+    cp(stored, target; force = true)
     return _file_content_digest(target)
+end
+
+# Exclusive create of `claim`: `true` when this call made it, `false` when it
+# already existed. The one atomic no-clobber primitive every filesystem has.
+function _claim_lockfile!(claim::AbstractString)
+    flags = Base.Filesystem.JL_O_WRONLY | Base.Filesystem.JL_O_CREAT | Base.Filesystem.JL_O_EXCL
+    f = try
+        Base.Filesystem.open(String(claim), flags, 0o644)
+    catch e
+        (e isa Base.IOError && e.code == Base.UV_EEXIST) && return false
+        rethrow(e)
+    end
+    close(f)
+    return true
 end
 
 """

--- a/src/cargobuild.jl
+++ b/src/cargobuild.jl
@@ -154,8 +154,9 @@ follows is `--locked`, so it either builds exactly the graph the file pins or
 fails. Otherwise `cargo generate-lockfile` resolves the set once — `--offline`
 under `RUSTCALL_OFFLINE`, failing loudly when the local registry lacks
 something — and the result is persisted for every later build of the same set
-(#256). The generated project's root package is `CARGO_BLOCK_PACKAGE` for every
-block, which is what makes one lockfile fit them all.
+(#256). The generated project's root package is named from the dependency set
+(`cargo_block_package`) for every block declaring it, which is what makes one
+lockfile fit them all.
 
 Two processes — or two machines sharing the store — that both find it empty
 resolve independently, possibly from different registry snapshots. Publication

--- a/src/cargobuild.jl
+++ b/src/cargobuild.jl
@@ -157,6 +157,13 @@ something — and the result is persisted for every later build of the same set
 (#256). The generated project's root package is `CARGO_BLOCK_PACKAGE` for every
 block, which is what makes one lockfile fit them all.
 
+Two processes — or two machines sharing the store — that both find it empty
+resolve independently, possibly from different registry snapshots. Publication
+is therefore **no-clobber** (`_publish_lockfile!`): the first file to land is
+the resolution of the set, and whoever loses discards its own, replays the
+published file into its project and returns *that* digest — so both builds are
+of one graph, which is the point of the store (#313 review).
+
 Throws `CargoBuildError` with Cargo's own message when resolution fails.
 """
 function ensure_cargo_lockfile!(project::CargoProject;
@@ -187,12 +194,52 @@ function ensure_cargo_lockfile!(project::CargoProject;
         String(take!(stderr_io)), project.path))
     isfile(target) || throw(CargoBuildError("cargo generate-lockfile produced no Cargo.lock",
                                             "", project.path))
-    # Persist atomically: a concurrent build of the same set must see a whole
-    # file or none.
+    return _publish_lockfile!(stored, target)
+end
+
+"""
+    _publish_lockfile!(stored, target) -> String
+
+Publish the lockfile a project just resolved (`target`) to the store (`stored`)
+without clobbering, and return the digest of the file the project ends up with.
+
+A whole file or none: the content is staged next to `stored` and linked into
+place with `hardlink`, which fails with `EEXIST` when another process published
+first (a plain rename would silently replace the winner). When that happens —
+or when `hardlink` is unavailable and `stored` appeared in between — the
+project's own resolution is discarded, the published file is copied into the
+project, and its digest is returned: every racer builds the published graph.
+"""
+function _publish_lockfile!(stored::AbstractString, target::AbstractString)
+    stored = String(stored)
+    target = String(target)
     mkpath(dirname(stored))
     tmp = stored * ".tmp-$(getpid())-$(rand(UInt32))"
     cp(target, tmp; force = true)
-    mv(tmp, stored; force = true)
+    published = try
+        if isfile(stored)
+            false
+        else
+            try
+                hardlink(tmp, stored)
+                true
+            catch e
+                e isa Base.IOError || rethrow(e)
+                # `EEXIST`: somebody else landed first. Any other failure
+                # (a filesystem without hardlinks) falls back to a rename that
+                # is no-clobber up to a check.
+                if isfile(stored)
+                    false
+                else
+                    mv(tmp, stored; force = false)
+                    true
+                end
+            end
+        end
+    finally
+        rm(tmp; force = true)
+    end
+    published || cp(stored, target; force = true)
     return _file_content_digest(target)
 end
 

--- a/src/cargobuild.jl
+++ b/src/cargobuild.jl
@@ -99,6 +99,29 @@ function lockfile_dir()
 end
 
 """
+    clear_lockfiles()
+
+Remove every persisted `Cargo.lock` (`lockfile_dir`), so the next build of each
+`// cargo-deps:` dependency set resolves it afresh. This is the one operation
+that discards resolutions: `clear_cache` keeps them, because they are inputs of
+a build and not compiled output (#256). To re-resolve a single set, delete
+`lockfile_path(deps)` instead.
+"""
+function clear_lockfiles()
+    dir = joinpath(get_cache_dir(), "lockfiles")
+    isdir(dir) || return nothing
+    for entry in readdir(dir; join = true)
+        try
+            rm(entry; force = true)
+        catch e
+            e isa Base.IOError || rethrow(e)
+            @debug "Could not remove a lockfile" entry exception = e
+        end
+    end
+    return nothing
+end
+
+"""
     lockfile_path(deps::Vector{DependencySpec}) -> String
     lockfile_path(code::AbstractString) -> String
 

--- a/src/cargobuild.jl
+++ b/src/cargobuild.jl
@@ -172,10 +172,16 @@ function ensure_cargo_lockfile!(project::CargoProject;
     isempty(project.dependencies) && return nothing
     stored = lockfile_path(project.dependencies)
     target = joinpath(project.path, "Cargo.lock")
-    if isfile(stored)
+    if isfile(stored) && _lockfile_names_root(stored, project.name)
         cp(stored, target; force = true)
         return _file_content_digest(target)
     end
+    # Either no resolution yet, or a file that is not this set's resolution: it
+    # does not name the project's root package (a stale scheme, a hand-edited
+    # file), and `--locked` would reject it. Resolve afresh and publish over
+    # it (`replace`), rather than fail every build of the set until someone
+    # deletes the file by hand.
+    replace_stale = isfile(stored)
     args = ["generate-lockfile"]
     append!(args, _cargo_network_args())
     cmd = setenv(`$(cargo()) $args`, Dict{String, String}(env === nothing ? ENV : env);
@@ -195,7 +201,15 @@ function ensure_cargo_lockfile!(project::CargoProject;
         String(take!(stderr_io)), project.path))
     isfile(target) || throw(CargoBuildError("cargo generate-lockfile produced no Cargo.lock",
                                             "", project.path))
-    return _publish_lockfile!(stored, target)
+    return _publish_lockfile!(stored, target; replace = replace_stale)
+end
+
+# Whether the lockfile at `path` carries a `[[package]]` entry for `root` — the
+# generated project's own package, which every lockfile Cargo writes for it
+# names. A stored file that does not is not this project's resolution.
+function _lockfile_names_root(path::AbstractString, root::AbstractString)
+    needle = "name = \"$(root)\""
+    return any(l -> strip(l) == needle, eachline(String(path)))
 end
 
 """
@@ -224,17 +238,21 @@ the file: if no other RustCall process is resolving the set, a previous one
 died holding the claim — delete that file (or run `clear_lockfiles()`) and
 build again.
 
+With `replace = true` the claim holder publishes over an existing file: the
+caller has established that the stored file is not this set's resolution
+(`_lockfile_names_root`), and the claim still serialises the writers.
+
 Throws `CargoBuildError` in that case.
 """
 function _publish_lockfile!(stored::AbstractString, target::AbstractString;
-                            wait::Real = 10.0)
+                            wait::Real = 10.0, replace::Bool = false)
     stored = String(stored)
     target = String(target)
     mkpath(dirname(stored))
     claim = stored * ".claim"
     if _claim_lockfile!(claim)
         try
-            if !isfile(stored)
+            if replace || !isfile(stored)
                 tmp = stored * ".tmp-$(getpid())-$(rand(UInt32))"
                 cp(target, tmp; force = true)
                 # Only the claim holder renames, so this replaces nothing.
@@ -341,8 +359,16 @@ function build_cargo_project(project::CargoProject; release::Bool = true,
                 close(stderr_io)
                 close(stdout_io)
 
+                message = "Cargo build failed"
+                if locked && occursin("lock file", stderr_str)
+                    # The pinned resolution no longer fits the manifest: the
+                    # persisted lockfile is the input to change (#256).
+                    message *= ": the persisted Cargo.lock no longer matches this dependency " *
+                               "set. Delete it to resolve afresh — `RustCall.lockfile_path(deps)` " *
+                               "names the file, `RustCall.clear_lockfiles()` removes them all"
+                end
                 throw(CargoBuildError(
-                    "Cargo build failed",
+                    message,
                     stderr_str,
                     project.path
                 ))

--- a/src/cargoproject.jl
+++ b/src/cargoproject.jl
@@ -39,6 +39,20 @@ struct CargoProject
 end
 
 """
+    CARGO_BLOCK_PACKAGE
+
+The `[package] name` of every Cargo project RustCall generates for a
+`// cargo-deps:` block. It is a constant, not derived from the block's key,
+because the root package appears in `Cargo.lock` by name: a lockfile persisted
+for one dependency set (`lockfile_path`) must fit every block that declares
+that set, or it could not be shared between blocks — or between machines
+(#256). The project directory, not the package name, is what keeps concurrent
+builds apart (`create_cargo_project` makes a fresh temporary directory each
+time), and the built library is copied into the cache under the block's key.
+"""
+const CARGO_BLOCK_PACKAGE = "rustcall_block"
+
+"""
     create_cargo_project(name::String, dependencies::Vector{DependencySpec}; kwargs...) -> CargoProject
 
 Create a temporary Cargo project with the specified dependencies.

--- a/src/cargoproject.jl
+++ b/src/cargoproject.jl
@@ -39,18 +39,34 @@ struct CargoProject
 end
 
 """
-    CARGO_BLOCK_PACKAGE
+    CARGO_BLOCK_PACKAGE_PREFIX
 
-The `[package] name` of every Cargo project RustCall generates for a
-`// cargo-deps:` block. It is a constant, not derived from the block's key,
-because the root package appears in `Cargo.lock` by name: a lockfile persisted
-for one dependency set (`lockfile_path`) must fit every block that declares
-that set, or it could not be shared between blocks — or between machines
-(#256). The project directory, not the package name, is what keeps concurrent
-builds apart (`create_cargo_project` makes a fresh temporary directory each
-time), and the built library is copied into the cache under the block's key.
+The prefix of the `[package] name` of every Cargo project RustCall generates
+for a `// cargo-deps:` block; see `cargo_block_package`.
 """
-const CARGO_BLOCK_PACKAGE = "rustcall_block"
+const CARGO_BLOCK_PACKAGE_PREFIX = "rustcall_block_"
+
+"""
+    cargo_block_package(deps) -> String
+
+The `[package] name` of the Cargo project generated for a `// cargo-deps:`
+block declaring `deps`: `CARGO_BLOCK_PACKAGE_PREFIX` followed by a short id of
+the dependency set's key (`cargo_lockfile_id`).
+
+It is derived from the *dependency set*, not from the block, because the root
+package appears in `Cargo.lock` by name: a lockfile persisted for one set
+(`lockfile_path`) must fit every block that declares that set, or it could not
+be shared between blocks — or between machines (#256). And it is not one fixed
+name, because a fixed name reserves a package identity a user's own crate may
+hold: a block depending on a path crate named `rustcall_block` at the same
+version could not be resolved at all (Cargo refuses two packages of one
+name and version from different sources in a lockfile; #313 review). The
+project directory, not the package name, is what keeps concurrent builds apart
+(`create_cargo_project` makes a fresh temporary directory each time), and the
+built library is copied into the cache under the block's key.
+"""
+cargo_block_package(deps) =
+    CARGO_BLOCK_PACKAGE_PREFIX * artifact_short_id(artifact_key(cargo_lockfile_id(deps)), 12)
 
 """
     create_cargo_project(name::String, dependencies::Vector{DependencySpec}; kwargs...) -> CargoProject

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -637,68 +637,112 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
     # that is the directory whose chain reaches the build, and it is knowable
     # before the project exists — which is what lets this be computed once.
     cargo_config = _cargo_config_digest(ENV; dir = tempdir())
-    cargo_id = _cargo_block_id(augmented_code, dependencies, build_env_key;
-                               cargo_config = cargo_config)
-    # THE key for this block: the in-memory name, the project name, the disk
-    # lookup, the build and the save all use this one value (#278, #287). If a
-    # second formula ever appears downstream, `build_cargo_project_cached`
-    # refuses the build rather than silently caching under two keys.
-    code_hash = artifact_key(cargo_id)
 
-    # Project and library names. `artifact_short_id` is the only truncation in
-    # the design and is never a lookup key (#278).
-    project_name = "rustcall_$(artifact_short_id(code_hash, 12))"
-    lib_name = "rust_cargo_$(artifact_short_id(code_hash, 16))"
-
-    # Check if already compiled and loaded in memory
-    is_in_memory = lock(REGISTRY_LOCK) do
-        haskey(RUST_LIBRARIES, lib_name)
-    end
-    # As in the rustc path: the re-check happens inside `_register_manifest`'s
-    # critical section, so a concurrent unload sends us down the build path
-    # rather than leaving metadata for a library that is gone.
-    policy = inline_cargo_policy()
-    if is_in_memory &&
-       _register_manifest(expanded, lib_name; cargo_backed = true, policy,
-                          snapshot_env = build_env, require_loaded = true)
-        @debug "Using cached Cargo library from memory" lib_name=lib_name
-        return lib_name
-    end
-
-    # The block identity *is* the cache key: re-mixing already-mixed material
-    # under a second, hand-rolled formula (and truncating it to 32 characters)
-    # was the Cargo half of #278, and deriving a *richer* key inside the builder
-    # while looking up with the base one was #287 — same bug, other direction.
-    cache_key = code_hash
-
-    cached_lib = get_cargo_cached_library(cache_key)
-    if !isnothing(cached_lib) && isfile(cached_lib)
-        # Load from cache through the one loader (#277 Phase B). A failure to
-        # open the cached file is not fatal: fall through and rebuild.
-        loaded = try
-            _register_manifest(expanded, lib_name; cargo_backed = true, policy,
-                               load_path = cached_lib, snapshot_env = build_env)
-        catch e
-            @debug "Failed to load the cached Cargo library; rebuilding" exception = e
-            false
-        end
-        if loaded
-            @debug "Loaded Cargo library from cache" lib_name=lib_name cache_key=artifact_short_id(cache_key, 8)
-
-            return lib_name
+    # The resolved dependency graph is part of the identity, not only the
+    # requested ranges: `ndarray = "0.15"` resolves to one set of versions today
+    # and another after an upstream patch release, and a key over the range
+    # alone served the old binary for the new graph — or built a new graph
+    # behind an unchanged key (#256). The graph lives in a `Cargo.lock`
+    # persisted per dependency set (`lockfile_path`): when it exists, its
+    # content is known before any project does; when it does not, the set is
+    # resolved once, in the project that will be built, and persisted. The
+    # project's root package has one fixed name (`CARGO_BLOCK_PACKAGE`) so the
+    # lockfile fits every block declaring the set.
+    project = nothing
+    compiler = get_default_compiler()
+    cleanup = () -> begin
+        project === nothing && return
+        # Clean up the temporary project (kept for debugging in debug mode).
+        if !compiler.debug_mode
+            try
+                cleanup_cargo_project(project)
+            catch e
+                @debug "Failed to cleanup Cargo project: $e"
+            end
+        else
+            @info "Debug mode: keeping Cargo project at $(project.path)"
         end
     end
-
-    # Build necessary if not in cache or cache load failed
-    @info "Building Rust code with external dependencies..." dependencies=length(dependencies) project=project_name
-
-    project = create_cargo_project(project_name, dependencies)
 
     try
+        stored_lock = lockfile_path(dependencies)
+        cargo_lock = if isfile(stored_lock)
+            _file_content_digest(stored_lock)
+        else
+            project = create_cargo_project(CARGO_BLOCK_PACKAGE, dependencies)
+            something(ensure_cargo_lockfile!(project; env = build_env), "")
+        end
+        cargo_id = _cargo_block_id(augmented_code, dependencies, build_env_key;
+                                   cargo_config = cargo_config, cargo_lock = cargo_lock)
+        # THE key for this block: the in-memory name, the disk lookup, the build
+        # and the save all use this one value (#278, #287). If a second formula
+        # ever appears downstream, `build_cargo_project_cached` refuses the build
+        # rather than silently caching under two keys.
+        code_hash = artifact_key(cargo_id)
+
+        # The library name. `artifact_short_id` is the only truncation in the
+        # design and is never a lookup key (#278).
+        lib_name = "rust_cargo_$(artifact_short_id(code_hash, 16))"
+
+        # Check if already compiled and loaded in memory
+        is_in_memory = lock(REGISTRY_LOCK) do
+            haskey(RUST_LIBRARIES, lib_name)
+        end
+        # As in the rustc path: the re-check happens inside `_register_manifest`'s
+        # critical section, so a concurrent unload sends us down the build path
+        # rather than leaving metadata for a library that is gone.
+        policy = inline_cargo_policy()
+        if is_in_memory &&
+           _register_manifest(expanded, lib_name; cargo_backed = true, policy,
+                              snapshot_env = build_env, require_loaded = true)
+            @debug "Using cached Cargo library from memory" lib_name=lib_name
+            return lib_name
+        end
+
+        # The block identity *is* the cache key: re-mixing already-mixed material
+        # under a second, hand-rolled formula (and truncating it to 32 characters)
+        # was the Cargo half of #278, and deriving a *richer* key inside the builder
+        # while looking up with the base one was #287 — same bug, other direction.
+        cache_key = code_hash
+
+        cached_lib = get_cargo_cached_library(cache_key)
+        if !isnothing(cached_lib) && isfile(cached_lib)
+            # Load from cache through the one loader (#277 Phase B). A failure to
+            # open the cached file is not fatal: fall through and rebuild.
+            loaded = try
+                _register_manifest(expanded, lib_name; cargo_backed = true, policy,
+                                   load_path = cached_lib, snapshot_env = build_env)
+            catch e
+                @debug "Failed to load the cached Cargo library; rebuilding" exception = e
+                false
+            end
+            if loaded
+                @debug "Loaded Cargo library from cache" lib_name=lib_name cache_key=artifact_short_id(cache_key, 8)
+                return lib_name
+            end
+        end
+
+        # Build necessary if not in cache or cache load failed
+        @info "Building Rust code with external dependencies..." dependencies=length(dependencies) lib_name=lib_name
+
+        if project === nothing
+            project = create_cargo_project(CARGO_BLOCK_PACKAGE, dependencies)
+            # The store had a lockfile when the identity was computed; the
+            # build must be of exactly that graph. A file that changed in
+            # between would make the key describe another build — refuse.
+            replayed = something(ensure_cargo_lockfile!(project; env = build_env), "")
+            replayed == cargo_lock || throw(CargoBuildError(
+                "The persisted Cargo.lock changed while this block was being prepared",
+                "lockfile: $(stored_lock)", project.path))
+        end
+
         # Ensure the code with wrappers is written to the project
         write_rust_code_to_project(project, augmented_code)
 
-        lib_path = build_cargo_project_cached(project, cargo_id, release=true, env=build_env)
+        # `--locked`: the project's lockfile is authoritative, so Cargo builds
+        # the graph the key describes or fails; it never re-resolves silently.
+        lib_path = build_cargo_project_cached(project, cargo_id, release=true, env=build_env,
+                                              locked = !isempty(cargo_lock))
 
         # Cache the built library (if it wasn't already in cache)
         try
@@ -713,21 +757,10 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
                            load_path = lib_path, snapshot_env = build_env)
 
         @info "Successfully built Rust code with Cargo" lib_name=lib_name
+        return lib_name
     finally
-        # Clean up temporary project (keep for debugging if debug mode is enabled)
-        compiler = get_default_compiler()
-        if !compiler.debug_mode
-            try
-                cleanup_cargo_project(project)
-            catch e
-                @debug "Failed to cleanup Cargo project: $e"
-            end
-        else
-            @info "Debug mode: keeping Cargo project at $(project.path)"
-        end
+        cleanup()
     end
-
-    return lib_name
 end
 
 
@@ -745,10 +778,15 @@ fingerprint and the identity of the compiler that runs, both defaulted by
 `cargo_config` is the digest of the effective `.cargo/config.toml` chain above
 the directory the build will run in (`_cargo_config_digest`); the caller passes
 it because it must be the *same* digest the whole evaluation uses.
+`cargo_lock` is the content digest of the `Cargo.lock` the build is made with —
+the resolved graph, persisted per dependency set (`lockfile_path`,
+`ensure_cargo_lockfile!`, #256) — so two builds of one source and one requested
+range that resolve differently are two artifacts.
 
-`artifact_key` of this record is the in-memory library name, the temporary
-project name, the disk cache key, the build key and the save key — one value
-per block evaluation. The Cargo path used to hash the block once and then
+`artifact_key` of this record is the in-memory library name, the disk cache
+key, the build key and the save key — one value per block evaluation (the
+generated project's package name is the constant `CARGO_BLOCK_PACKAGE`, so a
+persisted lockfile fits every block). The Cargo path used to hash the block once and then
 re-mix that digest under a second formula for the cache key (#278); the first
 fix then left `build_cargo_project_cached` deriving a *richer* key than the one
 the outer lookup used, so a Cargo-config change still hit the old binary
@@ -757,7 +795,12 @@ the outer lookup used, so a Cargo-config change still hit the old binary
 function _cargo_block_id(expanded_source::AbstractString, dependencies,
                          cargo_env::AbstractString = "";
                          cargo_config::AbstractString = "",
+                         cargo_lock::AbstractString = "",
                          release::Bool = true)
+    # `cargo_lock` is the content digest of the `Cargo.lock` the build is made
+    # with (`ensure_cargo_lockfile!`): the *resolved* graph, where
+    # `dependencies` names only the requested ranges (#256). "" when the block
+    # has none — a set with no dependency to resolve.
     return ArtifactId(
         kind = "cargo",
         source = String(expanded_source),
@@ -767,6 +810,7 @@ function _cargo_block_id(expanded_source::AbstractString, dependencies,
             "cargo-env" => String(cargo_env),
             "cargo-config" => String(cargo_config),
         ],
+        extra = Pair{String, String}["cargo-lock" => String(cargo_lock)],
     )
 end
 

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -646,8 +646,8 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
     # persisted per dependency set (`lockfile_path`): when it exists, its
     # content is known before any project does; when it does not, the set is
     # resolved once, in the project that will be built, and persisted. The
-    # project's root package has one fixed name (`CARGO_BLOCK_PACKAGE`) so the
-    # lockfile fits every block declaring the set.
+    # project's root package is named from the set (`cargo_block_package`) so
+    # the lockfile fits every block declaring it.
     project = nothing
     compiler = get_default_compiler()
     cleanup = () -> begin
@@ -669,7 +669,7 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
         cargo_lock = if isfile(stored_lock)
             _file_content_digest(stored_lock)
         else
-            project = create_cargo_project(CARGO_BLOCK_PACKAGE, dependencies)
+            project = create_cargo_project(cargo_block_package(dependencies), dependencies)
             something(ensure_cargo_lockfile!(project; env = build_env), "")
         end
         cargo_id = _cargo_block_id(augmented_code, dependencies, build_env_key;
@@ -726,7 +726,7 @@ function _compile_and_load_rust_with_cargo(code::String, source_file::String, so
         @info "Building Rust code with external dependencies..." dependencies=length(dependencies) lib_name=lib_name
 
         if project === nothing
-            project = create_cargo_project(CARGO_BLOCK_PACKAGE, dependencies)
+            project = create_cargo_project(cargo_block_package(dependencies), dependencies)
             # The store had a lockfile when the identity was computed; the
             # build must be of exactly that graph. A file that changed in
             # between would make the key describe another build — refuse.
@@ -785,8 +785,9 @@ range that resolve differently are two artifacts.
 
 `artifact_key` of this record is the in-memory library name, the disk cache
 key, the build key and the save key — one value per block evaluation (the
-generated project's package name is the constant `CARGO_BLOCK_PACKAGE`, so a
-persisted lockfile fits every block). The Cargo path used to hash the block once and then
+generated project's package name is derived from the dependency set,
+`cargo_block_package`, so a persisted lockfile fits every block declaring it).
+The Cargo path used to hash the block once and then
 re-mix that digest under a second formula for the cache key (#278); the first
 fix then left `build_cargo_project_cached` deriving a *richer* key than the one
 the outer lookup used, so a Cargo-config change still hit the old binary

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -432,8 +432,11 @@ end
         expanded = RustCall.expand_inline(block; cfg = :cargo)
         deps = RustCall.parse_dependencies_from_code(block)
         _, build_env_key = RustCall._cargo_build_env_for(nothing)
+        # ... including the resolved graph: the lockfile the build persisted
+        # for this dependency set is part of the identity (#256).
         id = RustCall._cargo_block_id(expanded.source, deps, build_env_key;
-            cargo_config = RustCall._cargo_config_digest(ENV; dir = tempdir()))
+            cargo_config = RustCall._cargo_config_digest(ENV; dir = tempdir()),
+            cargo_lock = RustCall._file_content_digest(RustCall.lockfile_path(deps)))
         key = RustCall.artifact_key(id)
         # Named by this block's own key, whatever else is in the directory:
         # the assertion the testset is really making is "this block produced
@@ -598,5 +601,177 @@ end
         @test !isdir(foreign)
         @test !isdir(joinpath(project_dir, "config-elsewhere"))
         rm(sandbox; recursive = true, force = true)
+    end
+end
+
+@testset "Pinned, lockfile-driven dependency builds (#256)" begin
+    # A `// cargo-deps:` block used to be resolved afresh on every build, with
+    # no lockfile and a cache key over the *requested* ranges: two machines
+    # (or one machine a week apart) built different graphs for the same
+    # source, and a cache hit could serve a binary built from a graph that no
+    # longer resolves. The resolution is now persisted per dependency set and
+    # its content is part of the build's identity.
+    deps = [RustCall.DependencySpec("itoa"; version = "1.0")]
+    same = [RustCall.DependencySpec("itoa"; version = "1.0")]
+    other = [RustCall.DependencySpec("itoa"; version = "1.0.11")]
+
+    @testset "the lockfile is named by the dependency set alone" begin
+        with_isolated_cargo_cache() do
+            path = RustCall.lockfile_path(deps)
+            @test startswith(path, RustCall.lockfile_dir())
+            @test endswith(path, ".lock")
+            @test RustCall.lockfile_path(same) == path
+            @test RustCall.lockfile_path(other) != path
+            # The block's own comments name the same file.
+            @test RustCall.lockfile_path("// cargo-deps: itoa=\"1.0\"\n") == path
+            # Not the toolchain: the same declared set on another machine, with
+            # another rustc, looks in the same place — that is what sharing the
+            # file between machines means.
+            id = RustCall.cargo_lockfile_id(deps)
+            @test id.kind == "cargo-lockfile"
+            @test id.toolchain == "" && id.compiler == ""
+            @test id.dependencies == RustCall.artifact_dependency_strings(deps)
+        end
+    end
+
+    @testset "the resolved graph is in the build key" begin
+        # Same source, same requested ranges, different resolution: different
+        # artifact — the cache describes what was built, not what was asked.
+        base = RustCall._cargo_block_id("fn f() {}", deps, "env"; cargo_lock = "aaaa")
+        @test RustCall.artifact_key(base) !=
+              RustCall.artifact_key(RustCall._cargo_block_id("fn f() {}", deps, "env";
+                                                             cargo_lock = "bbbb"))
+        @test RustCall.artifact_key(base) !=
+              RustCall.artifact_key(RustCall._cargo_block_id("fn f() {}", deps, "env"))
+        @test any(p -> p == ("cargo-lock" => "aaaa"), base.extra)
+    end
+
+    @testset "--locked and --offline reach cargo" begin
+        args = RustCall._cargo_build_args(true, String[], true; locked = true)
+        @test "--locked" in args
+        @test !("--locked" in RustCall._cargo_build_args(true, String[], true))
+        withenv("RUSTCALL_OFFLINE" => nothing) do
+            @test !RustCall.cargo_offline()
+            @test !("--offline" in RustCall._cargo_build_args(true, String[], true))
+        end
+        for v in ("1", "true", "YES")
+            withenv("RUSTCALL_OFFLINE" => v) do
+                @test RustCall.cargo_offline()
+                @test "--offline" in RustCall._cargo_build_args(true, String[], true)
+            end
+        end
+        withenv("RUSTCALL_OFFLINE" => "0") do
+            @test !RustCall.cargo_offline()
+        end
+    end
+
+    if !RustCall.check_rustc_available()
+        @test_skip "rustc/cargo are required for a Cargo-backed block"
+    else
+        @testset "one resolution, replayed byte for byte" begin
+            with_isolated_cargo_cache() do
+                block = """
+                // cargo-deps: itoa="1.0"
+
+                #[no_mangle]
+                pub extern "C" fn rc256_pinned() -> i32 { 256 }
+                """
+                lockfile = RustCall.lockfile_path(block)
+                @test !isfile(lockfile)
+                lib = RustCall._compile_and_load_rust(block, "pinned", 0)
+                @test ccall(RustCall.get_function_pointer(lib, "rc256_pinned"), Int32, ()) == 256
+                # The first build resolved and persisted the set.
+                @test isfile(lockfile)
+                content = read(lockfile, String)
+                @test occursin("name = \"itoa\"", content)
+                @test occursin("name = \"$(RustCall.CARGO_BLOCK_PACKAGE)\"", content)
+                # The block's cache entry is keyed with that file's content.
+                expanded = RustCall.expand_inline(block; cfg = :cargo)
+                _, build_env_key = RustCall._cargo_build_env_for(nothing)
+                id = RustCall._cargo_block_id(expanded.source, deps, build_env_key;
+                    cargo_config = RustCall._cargo_config_digest(ENV; dir = tempdir()),
+                    cargo_lock = RustCall._file_content_digest(lockfile))
+                @test RustCall.get_cargo_cached_library(RustCall.artifact_key(id)) !== nothing
+
+                # A second block declaring the same set — another machine, or
+                # this one later — replays the file: no re-resolution (the file
+                # is untouched) and a project seeded from it carries the
+                # identical bytes, which is what `--locked` then enforces.
+                stamp = mtime(lockfile)
+                second = replace(block, "rc256_pinned() -> i32 { 256 }" =>
+                                        "rc256_again() -> i32 { 257 }")
+                lib2 = RustCall._compile_and_load_rust(second, "pinned-again", 0)
+                @test ccall(RustCall.get_function_pointer(lib2, "rc256_again"), Int32, ()) == 257
+                @test mtime(lockfile) == stamp
+                @test read(lockfile, String) == content
+                project = RustCall.create_cargo_project(RustCall.CARGO_BLOCK_PACKAGE, deps)
+                try
+                    digest = RustCall.ensure_cargo_lockfile!(project)
+                    @test digest == RustCall._file_content_digest(lockfile)
+                    @test read(joinpath(project.path, "Cargo.lock"), String) == content
+                finally
+                    RustCall.cleanup_cargo_project(project)
+                end
+                # A project with no dependencies of its own has no store entry.
+                bare = RustCall.create_cargo_project("rc256_bare", RustCall.DependencySpec[])
+                try
+                    @test RustCall.ensure_cargo_lockfile!(bare) === nothing
+                finally
+                    RustCall.cleanup_cargo_project(bare)
+                end
+
+                # A changed resolution is a different artifact: rewrite the
+                # persisted file and the key moves, so a cache hit can never
+                # answer for another graph.
+                moved = RustCall._cargo_block_id(expanded.source, deps, build_env_key;
+                    cargo_config = RustCall._cargo_config_digest(ENV; dir = tempdir()),
+                    cargo_lock = RustCall._file_content_digest(lockfile) * "-other")
+                @test RustCall.artifact_key(moved) != RustCall.artifact_key(id)
+
+                # Offline: with the registry warm from the build above, the same
+                # set builds again — `--locked --offline` — after the cache is
+                # cleared; the lockfile survives `clear_cargo_cache`, being an
+                # input and not an output.
+                RustCall.clear_cargo_cache()
+                @test isfile(lockfile)
+                lib3 = withenv("RUSTCALL_OFFLINE" => "1") do
+                    RustCall._compile_and_load_rust(second, "pinned-offline", 0)
+                end
+                @test ccall(RustCall.get_function_pointer(lib3, "rc256_again"), Int32, ()) == 257
+                for name in unique([lib, lib2, lib3])
+                    try
+                        RustCall.unload_library(name)
+                    catch
+                    end
+                end
+            end
+        end
+
+        @testset "offline without a registry cache fails loudly, not slowly" begin
+            with_isolated_cargo_cache() do
+                # A package no registry has: offline resolution must come back
+                # with Cargo's error at once, not hang on a download.
+                missing = [RustCall.DependencySpec("rustcall-no-such-package-ever";
+                                                   version = "=99.99.99")]
+                project = RustCall.create_cargo_project(RustCall.CARGO_BLOCK_PACKAGE, missing)
+                try
+                    started = time()
+                    err = withenv("RUSTCALL_OFFLINE" => "1") do
+                        try
+                            RustCall.ensure_cargo_lockfile!(project)
+                            nothing
+                        catch e
+                            e
+                        end
+                    end
+                    @test err isa RustCall.CargoBuildError
+                    @test occursin("RUSTCALL_OFFLINE", sprint(showerror, err))
+                    @test time() - started < 60
+                    @test !isfile(RustCall.lockfile_path(missing))
+                finally
+                    RustCall.cleanup_cargo_project(project)
+                end
+            end
+        end
     end
 end

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -731,13 +731,26 @@ end
                 # Offline: with the registry warm from the build above, the same
                 # set builds again — `--locked --offline` — after the cache is
                 # cleared; the lockfile survives `clear_cargo_cache`, being an
-                # input and not an output.
+                # input and not an output. The block's library is unloaded
+                # first and the disk cache emptied, so neither the in-memory
+                # fast path nor a cached binary can answer: the only way to a
+                # working `lib3` is a Cargo build, which is what leaves exactly
+                # one fresh entry in the cleared cache (#313 review).
+                RustCall.unload_library(lib2)
                 RustCall.clear_cargo_cache()
                 @test isfile(lockfile)
+                lib_ext = RustCall.get_library_extension()
+                @test isempty(filter(f -> endswith(f, lib_ext),
+                                     readdir(RustCall.get_cargo_cache_dir())))
                 lib3 = withenv("RUSTCALL_OFFLINE" => "1") do
                     RustCall._compile_and_load_rust(second, "pinned-offline", 0)
                 end
                 @test ccall(RustCall.get_function_pointer(lib3, "rc256_again"), Int32, ()) == 257
+                @test length(filter(f -> endswith(f, lib_ext),
+                                    readdir(RustCall.get_cargo_cache_dir()))) == 1
+                # ... and it was the pinned graph that was built: the lockfile
+                # is untouched by the rebuild.
+                @test read(lockfile, String) == content
                 for name in unique([lib, lib2, lib3])
                     try
                         RustCall.unload_library(name)

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -684,7 +684,7 @@ end
                 @test isfile(lockfile)
                 content = read(lockfile, String)
                 @test occursin("name = \"itoa\"", content)
-                @test occursin("name = \"$(RustCall.CARGO_BLOCK_PACKAGE)\"", content)
+                @test occursin("name = \"$(RustCall.cargo_block_package(deps))\"", content)
                 # The block's cache entry is keyed with that file's content.
                 expanded = RustCall.expand_inline(block; cfg = :cargo)
                 _, build_env_key = RustCall._cargo_build_env_for(nothing)
@@ -704,7 +704,7 @@ end
                 @test ccall(RustCall.get_function_pointer(lib2, "rc256_again"), Int32, ()) == 257
                 @test mtime(lockfile) == stamp
                 @test read(lockfile, String) == content
-                project = RustCall.create_cargo_project(RustCall.CARGO_BLOCK_PACKAGE, deps)
+                project = RustCall.create_cargo_project(RustCall.cargo_block_package(deps), deps)
                 try
                     digest = RustCall.ensure_cargo_lockfile!(project)
                     @test digest == RustCall._file_content_digest(lockfile)
@@ -766,7 +766,7 @@ end
                 # with Cargo's error at once, not hang on a download.
                 missing = [RustCall.DependencySpec("rustcall-no-such-package-ever";
                                                    version = "=99.99.99")]
-                project = RustCall.create_cargo_project(RustCall.CARGO_BLOCK_PACKAGE, missing)
+                project = RustCall.create_cargo_project(RustCall.cargo_block_package(missing), missing)
                 try
                     started = time()
                     err = withenv("RUSTCALL_OFFLINE" => "1") do
@@ -900,5 +900,50 @@ end
         # No temporary or claim file is left behind by any path.
         @test all(f -> !occursin(".tmp-", f) && !endswith(f, ".claim"),
                   readdir(RustCall.lockfile_dir()))
+    end
+end
+
+@testset "the generated package is named from the set, and reserves no name (#313 review)" begin
+    # The root package appears in `Cargo.lock` by name, so it is derived from
+    # the dependency set — every block declaring the set shares the lockfile —
+    # and not fixed, so a user's own crate can carry any name at all.
+    deps = [RustCall.DependencySpec("itoa"; version = "1.0")]
+    name = RustCall.cargo_block_package(deps)
+    @test startswith(name, RustCall.CARGO_BLOCK_PACKAGE_PREFIX)
+    @test name == RustCall.cargo_block_package([RustCall.DependencySpec("itoa"; version = "1.0")])
+    @test name != RustCall.cargo_block_package([RustCall.DependencySpec("itoa"; version = "1.0.11")])
+    @test occursin(r"^[a-z0-9_]+$", name)
+    if !RustCall.check_rustc_available()
+        @test_skip "cargo is required to resolve a dependency set"
+    else
+        with_isolated_cargo_cache() do
+            # A path dependency that takes the very name a fixed root package
+            # used to reserve: Cargo refuses two packages of one name and
+            # version from different sources in a lockfile, so the block could
+            # not be resolved at all.
+            mktempdir() do dir
+                crate = joinpath(dir, "rustcall_block")
+                mkpath(joinpath(crate, "src"))
+                write(joinpath(crate, "Cargo.toml"), """
+                    [package]
+                    name = "rustcall_block"
+                    version = "0.1.0"
+                    edition = "2021"
+                    """)
+                write(joinpath(crate, "src", "lib.rs"), "pub fn one() -> i32 { 1 }\n")
+                local_deps = [RustCall.DependencySpec("rustcall_block"; path = crate)]
+                project = RustCall.create_cargo_project(RustCall.cargo_block_package(local_deps),
+                                                        local_deps)
+                try
+                    digest = RustCall.ensure_cargo_lockfile!(project)
+                    @test digest isa String
+                    content = read(joinpath(project.path, "Cargo.lock"), String)
+                    @test occursin("name = \"rustcall_block\"", content)
+                    @test occursin("name = \"$(RustCall.cargo_block_package(local_deps))\"", content)
+                finally
+                    RustCall.cleanup_cargo_project(project)
+                end
+            end
+        end
     end
 end

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -854,23 +854,30 @@ end
         @test RustCall._claim_lockfile!(claim)
         @test !RustCall._claim_lockfile!(claim)
         # A held claim with nothing published behind it: the loser waits for
-        # the publisher, and gives up loudly rather than hanging.
+        # the publisher, and gives up loudly rather than hanging. A claim is
+        # never expired by age — a dead publisher is reported, with the file
+        # to delete, not taken over on this machine's reading of the clock.
         rm(stored; force = true)
         mktempdir() do c
             waiting = joinpath(c, "Cargo.lock")
             write(waiting, "# resolution C\n")
             err = try
-                RustCall._publish_lockfile!(stored, waiting; wait = 0.3, stale_after = 60.0)
+                RustCall._publish_lockfile!(stored, waiting; wait = 0.3)
                 nothing
             catch e
                 e
             end
             @test err isa RustCall.CargoBuildError
-            @test occursin("resolving the same dependency set", sprint(showerror, err))
+            msg = sprint(showerror, err)
+            @test occursin("holds the claim", msg)
+            @test occursin(claim, msg)
+            @test occursin("clear_lockfiles", msg)
             @test !isfile(stored)
-            # ... unless the claim is stale — the publisher died — in which
-            # case the next comer takes it over and publishes.
-            digest = RustCall._publish_lockfile!(stored, waiting; wait = 0.3, stale_after = 0.0)
+            @test isfile(claim)
+            # Recovery is the documented one: remove the claim (here, as
+            # `clear_lockfiles` would) and publish again.
+            rm(claim)
+            digest = RustCall._publish_lockfile!(stored, waiting; wait = 0.3)
             @test read(stored, String) == "# resolution C\n"
             @test digest == RustCall._file_content_digest(stored)
             @test !isfile(claim)

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -815,3 +815,38 @@ end
         @test "lockfiles" in RustCall.CACHE_INPUT_DIRS
     end
 end
+
+@testset "the first resolution is published once; a racing loser replays the winner (#313 review)" begin
+    # Two processes (or machines sharing the store) that both find the store
+    # empty resolve independently, from possibly different registry snapshots.
+    # Publication is no-clobber: the first file to land is the resolution, and
+    # whoever loses replays *that* file into its project and digests it — so
+    # both builds are of one graph, never each of its own.
+    with_isolated_cargo_cache() do
+        deps = [RustCall.DependencySpec("itoa"; version = "1.0")]
+        stored = RustCall.lockfile_path(deps)
+        mktempdir() do a
+            # No file in the store yet: this project's resolution is published.
+            mine = joinpath(a, "Cargo.lock")
+            write(mine, "# resolution A\n")
+            digest = RustCall._publish_lockfile!(stored, mine)
+            @test isfile(stored)
+            @test read(stored, String) == "# resolution A\n"
+            @test digest == RustCall._file_content_digest(stored)
+            @test read(mine, String) == "# resolution A\n"
+        end
+        mktempdir() do b
+            # The store was filled in between: the loser's own resolution is
+            # discarded, the published one is replayed into its project, and
+            # the digest is the published file's.
+            theirs = joinpath(b, "Cargo.lock")
+            write(theirs, "# resolution B\n")
+            digest = RustCall._publish_lockfile!(stored, theirs)
+            @test read(stored, String) == "# resolution A\n"
+            @test read(theirs, String) == "# resolution A\n"
+            @test digest == RustCall._file_content_digest(stored)
+        end
+        # No temporary file is left behind either way.
+        @test all(f -> !occursin(".tmp-", f), readdir(RustCall.lockfile_dir()))
+    end
+end

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -947,3 +947,67 @@ end
         end
     end
 end
+
+@testset "a stored lockfile that does not name this set's root is not replayed (#313 CI)" begin
+    # CI carries the scratch space across runs (julia-actions/cache), so a
+    # store written under an older root-package scheme met a project named
+    # under the new one, and `--locked` refused every build of the set. Two
+    # defences: the scheme is in the lockfile key, so a new scheme is a new
+    # entry; and a stored file that does not name the project's root is
+    # re-resolved and replaced rather than replayed.
+    deps = [RustCall.DependencySpec("itoa"; version = "1.0")]
+    id = RustCall.cargo_lockfile_id(deps)
+    @test ("root-package-prefix" => RustCall.CARGO_BLOCK_PACKAGE_PREFIX) in id.extra
+    if !RustCall.check_rustc_available()
+        @test_skip "cargo is required to resolve a dependency set"
+    else
+        with_isolated_cargo_cache() do
+            stored = RustCall.lockfile_path(deps)
+            root = RustCall.cargo_block_package(deps)
+            mktempdir() do dir
+                write(joinpath(dir, "Cargo.lock"), """
+                    version = 4
+
+                    [[package]]
+                    name = "rustcall_block"
+                    version = "0.1.0"
+                    """)
+                @test RustCall._lockfile_names_root(joinpath(dir, "Cargo.lock"), "rustcall_block")
+                @test !RustCall._lockfile_names_root(joinpath(dir, "Cargo.lock"), root)
+                # Seed the store with the stale file.
+                mkpath(dirname(stored))
+                cp(joinpath(dir, "Cargo.lock"), stored; force = true)
+            end
+            project = RustCall.create_cargo_project(root, deps)
+            try
+                digest = RustCall.ensure_cargo_lockfile!(project)
+                # Re-resolved and published over the stale file: the store now
+                # names this root, and the project carries the same bytes.
+                @test RustCall._lockfile_names_root(stored, root)
+                @test occursin("name = \"itoa\"", read(stored, String))
+                @test read(joinpath(project.path, "Cargo.lock"), String) == read(stored, String)
+                @test digest == RustCall._file_content_digest(stored)
+                @test !isfile(stored * ".claim")
+                # A build against a lockfile that no longer fits says which
+                # file to delete, rather than only quoting Cargo.
+                # (The CI shape: a valid lockfile whose root is the old
+                # scheme's name, which Cargo would have to rewrite.)
+                doctored = replace(read(stored, String), "name = \"$(root)\"" => "name = \"rustcall_block\"")
+                @test doctored != read(stored, String)
+                write(joinpath(project.path, "Cargo.lock"), doctored)
+                RustCall.write_rust_code_to_project(project, "pub fn f() -> i32 { 1 }\n")
+                err = try
+                    RustCall.build_cargo_project(project; release = true, locked = true)
+                    nothing
+                catch e
+                    e
+                end
+                @test err isa RustCall.CargoBuildError
+                @test occursin("lockfile_path", sprint(showerror, err))
+                @test occursin("clear_lockfiles", sprint(showerror, err))
+            finally
+                RustCall.cleanup_cargo_project(project)
+            end
+        end
+    end
+end

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -819,18 +819,22 @@ end
 @testset "the first resolution is published once; a racing loser replays the winner (#313 review)" begin
     # Two processes (or machines sharing the store) that both find the store
     # empty resolve independently, from possibly different registry snapshots.
-    # Publication is no-clobber: the first file to land is the resolution, and
-    # whoever loses replays *that* file into its project and digests it — so
-    # both builds are of one graph, never each of its own.
+    # Publication goes through an exclusive-create claim — the one atomic
+    # no-clobber primitive every filesystem has — so exactly one resolution
+    # lands, and whoever loses replays *that* file into its project and
+    # digests it: every build is of one graph, never each of its own.
     with_isolated_cargo_cache() do
         deps = [RustCall.DependencySpec("itoa"; version = "1.0")]
         stored = RustCall.lockfile_path(deps)
+        claim = stored * ".claim"
         mktempdir() do a
-            # No file in the store yet: this project's resolution is published.
+            # No file in the store yet: this project's resolution is published,
+            # and the claim is released.
             mine = joinpath(a, "Cargo.lock")
             write(mine, "# resolution A\n")
             digest = RustCall._publish_lockfile!(stored, mine)
             @test isfile(stored)
+            @test !isfile(claim)
             @test read(stored, String) == "# resolution A\n"
             @test digest == RustCall._file_content_digest(stored)
             @test read(mine, String) == "# resolution A\n"
@@ -846,7 +850,48 @@ end
             @test read(theirs, String) == "# resolution A\n"
             @test digest == RustCall._file_content_digest(stored)
         end
-        # No temporary file is left behind either way.
-        @test all(f -> !occursin(".tmp-", f), readdir(RustCall.lockfile_dir()))
+        # The claim itself is atomic: a second claimant is refused.
+        @test RustCall._claim_lockfile!(claim)
+        @test !RustCall._claim_lockfile!(claim)
+        # A held claim with nothing published behind it: the loser waits for
+        # the publisher, and gives up loudly rather than hanging.
+        rm(stored; force = true)
+        mktempdir() do c
+            waiting = joinpath(c, "Cargo.lock")
+            write(waiting, "# resolution C\n")
+            err = try
+                RustCall._publish_lockfile!(stored, waiting; wait = 0.3, stale_after = 60.0)
+                nothing
+            catch e
+                e
+            end
+            @test err isa RustCall.CargoBuildError
+            @test occursin("resolving the same dependency set", sprint(showerror, err))
+            @test !isfile(stored)
+            # ... unless the claim is stale — the publisher died — in which
+            # case the next comer takes it over and publishes.
+            digest = RustCall._publish_lockfile!(stored, waiting; wait = 0.3, stale_after = 0.0)
+            @test read(stored, String) == "# resolution C\n"
+            @test digest == RustCall._file_content_digest(stored)
+            @test !isfile(claim)
+        end
+        # Racing publishers, interleaved at every yield: exactly one content
+        # wins, every racer ends up with it, and nothing is left behind.
+        rm(stored; force = true)
+        racers = 8
+        dirs = [mktempdir() for _ in 1:racers]
+        for (i, d) in enumerate(dirs)
+            write(joinpath(d, "Cargo.lock"), "# resolution $(i)\n")
+        end
+        digests = fetch.([Threads.@spawn(RustCall._publish_lockfile!(stored, joinpath(d, "Cargo.lock")))
+                          for d in dirs])
+        winner = read(stored, String)
+        @test winner in ["# resolution $(i)\n" for i in 1:racers]
+        @test all(==(RustCall._file_content_digest(stored)), digests)
+        @test all(d -> read(joinpath(d, "Cargo.lock"), String) == winner, dirs)
+        foreach(d -> rm(d; recursive = true, force = true), dirs)
+        # No temporary or claim file is left behind by any path.
+        @test all(f -> !occursin(".tmp-", f) && !endswith(f, ".claim"),
+                  readdir(RustCall.lockfile_dir()))
     end
 end

--- a/test/test_cargo.jl
+++ b/test/test_cargo.jl
@@ -775,3 +775,30 @@ end
         end
     end
 end
+
+@testset "clear_cache keeps the lockfiles; clear_lockfiles removes them (#256 review)" begin
+    # A lockfile is an input of a build, not compiled output: clearing the
+    # compiled cache must not silently re-resolve every dependency set. The
+    # store lives under the cache directory, so `clear_cache` removes the
+    # directory entry by entry and skips it.
+    with_isolated_cargo_cache() do
+        deps = [RustCall.DependencySpec("itoa"; version = "1.0")]
+        lockfile = RustCall.lockfile_path(deps)
+        write(lockfile, "# a pinned resolution\n")
+        # Something to clear next to it.
+        cargo_dir = RustCall.get_cargo_cache_dir()
+        write(joinpath(cargo_dir, "stale.bin"), "x")
+        RustCall.clear_cache()
+        @test isfile(lockfile)
+        @test read(lockfile, String) == "# a pinned resolution\n"
+        @test !isfile(joinpath(cargo_dir, "stale.bin"))
+        # ... and a cleared cache reads as empty: the size is that of the
+        # compiled cache, not of the inputs kept beside it.
+        @test RustCall.get_cache_size() == 0
+        # The explicit operation is the one that discards resolutions.
+        RustCall.clear_lockfiles()
+        @test !isfile(lockfile)
+        @test isdir(RustCall.lockfile_dir())
+        @test "lockfiles" in RustCall.CACHE_INPUT_DIRS
+    end
+end


### PR DESCRIPTION
Closes #256.

A `// cargo-deps:` block was resolved afresh on every build — no lockfile, no `--locked` — and its cache key covered the *requested* ranges only, so two machines built different graphs for one source, and a cache hit could serve a binary built from a graph that no longer resolves.

## What changes

- **One resolution per dependency set, persisted.** The first build runs `cargo generate-lockfile` once and stores the result under `<cache dir>/lockfiles/<key>.lock`, named by `artifact_key(cargo_lockfile_id(deps))` — the declared set alone, no toolchain, so the same set on any machine looks in the same place (`RustCall.lockfile_path(deps)` / `lockfile_path(source)`). Every later build, of any block declaring that set, copies the file in and runs `cargo build --locked` (`ensure_cargo_lockfile!`): Cargo builds exactly the pinned graph or fails, never re-resolving behind the key.
- **The resolution is in the identity.** The lockfile's content digest is part of the block's `ArtifactId` (`_cargo_block_id`'s `cargo_lock`, folded in through `src/artifact_id.jl`), so a changed resolution is a new artifact rather than a stale cache hit. `clear_cache` leaves lockfiles alone — they are inputs, not outputs; delete one to re-resolve.
- **Offline.** `RUSTCALL_OFFLINE=1` adds `--offline` to `generate-lockfile` and `build`. With a warm registry cache the pinned build succeeds without the network; with a cold one Cargo fails at once and the message is surfaced as a `CargoBuildError` naming `RUSTCALL_OFFLINE`.
- **A constant package name.** The generated project's `[package] name` is `RustCall.CARGO_BLOCK_PACKAGE` (`rustcall_block`) instead of `rustcall_<short key>`: the root package is named in `Cargo.lock`, and one file must fit every block declaring the set. The per-build temporary directory is what keeps concurrent builds apart; the library is cached under the block's key as before.

Docs: a "Pinned, lockfile-driven dependency builds" section in `docs/src/performance.md`; CHANGELOG entry.

## Acceptance criteria → tests (`test/test_cargo.jl`, "Pinned, lockfile-driven dependency builds (#256)")

| criterion | test |
| --- | --- |
| Same `// cargo-deps:` block builds byte-identical dependency sets on two machines sharing the persisted lockfile | "one resolution, replayed byte for byte": a second block with the same set replays the stored file untouched (mtime and bytes), and a project seeded from the store carries the identical `Cargo.lock`, which `--locked` then enforces; "the lockfile is named by the dependency set alone" (no toolchain in the name) |
| Cache entries are invalidated when the resolved (not requested) versions change | "the resolved graph is in the build key" (identity differs by `cargo_lock`), plus the `moved` key in the end-to-end testset; the `#287` "exactly one key" testset now includes the digest |
| `RUSTCALL_OFFLINE=1` builds succeed with a warm cargo registry cache and fail loudly (not hang) without one | the offline rebuild after `clear_cargo_cache()` in "one resolution, replayed byte for byte"; "offline without a registry cache fails loudly, not slowly" (unknown package, `CargoBuildError` within seconds, nothing persisted) |

Not covered here: the *wrapper crates* `@rust_crate` generates depend on the target crate by path and are built as their own root; a PyO3 wrapper already carries the crate's own `Cargo.lock` and `[patch]` (#307). Persisting *their* resolution is a separate change and is noted in the docs section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw