### PR TITLE
CLAUDE.md: request Codex review right after every push, not after CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ The project conventions live in `CLAUDE.md` (the `@CLAUDE.md` line above include
 ## Pull request loop
 
 1. Branch off `origin/main`, never commit to `main`. Open a **draft** PR; commit in steps that each leave `Pkg.test()` green.
-2. When CI is green, comment `@codex review`. Codex re-reviews on every push; do not push mid-round.
+2. Comment `@codex review` the moment a push lands — the first push and every fix push — without waiting for CI; CI and Codex run in parallel. Codex does **not** re-review on its own here: a push without a fresh request gets no review. Do not push mid-round.
 3. Track CI and Codex **per head SHA**.
 4. For every finding: fix it with a regression test, reply on the thread with the fixing SHA, resolve. Do not resolve threads you did not act on.
 5. When findings converge on one class that a tech-debt issue owns, post a "scope decision" comment naming that issue, stop re-requesting review, merge on green, and record the deferred items on the issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ A replaced image is **retired, not closed**, so a call already inside one stays 
 Every change goes through this loop; the definition of done is the issue's acceptance criteria, not "the cause is gone".
 
 1. **Open a draft PR** from a topic branch off `origin/main`. Commit in logical steps, each leaving `Pkg.test()` green. Commit messages and the PR body carry the attribution trailers the session was given.
-2. **Request review**: comment `@codex review` once CI is green. Codex re-reviews automatically on every later push, so keep the branch quiet until a round is answered.
+2. **Request review the moment a push lands**: comment `@codex review` right after every push (the first one and each fix), without waiting for CI — CI and Codex run in parallel. Codex does **not** re-review on its own in this repository; a push without a fresh request gets no review. Keep the branch quiet until the round is answered, then fix, push, request again.
 3. **Monitor per head SHA**: CI results (`gh pr checks`) and Codex reviews are tracked against the current head; a green result on an older SHA means nothing.
 4. **Answer every finding**: fix real ones (with a regression test), reply on the thread with the fixing SHA, resolve the thread. Never resolve a thread you did not act on.
 5. **Scope decision**: when findings converge on one class that a tech-debt issue solves structurally, fix the current round, post a "scope decision" comment naming that issue, stop re-requesting review, and merge on green. Record the deferred items on the issue.


### PR DESCRIPTION
## Summary

Step 2 of the PR workflow in `CLAUDE.md` told the agent to comment `@codex review` only once CI was green and claimed Codex re-reviews automatically on every push. Neither is true here: Codex reviews only on an explicit request, and waiting for CI first serialises two independent ~10-minute waits. The step now says to request review the moment a push lands (first push and every fix push) and to watch CI and Codex in parallel; the merge rule in step 7 is unchanged.

Documentation-only change (`CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw