### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -992,5 +992,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation examples tests
 
 [Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/atelierarith/RustCall.jl/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/atelierarith/RustCall.jl/releases/tag/v0.1.0
+[0.2.0]: https://github.com/atelierarith/RustCall.jl/compare/6e98d5cb62c0a0ca8b2f894c6fe53af209d9d3ea...v0.2.0
+[0.1.0]: https://github.com/atelierarith/RustCall.jl/commit/6e98d5cb62c0a0ca8b2f894c6fe53af209d9d3ea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-07
+
 ### Deprecated
 - **`#[julia_pyo3]`** ([#275](https://github.com/AtelierArith/RustCall.jl/issues/275),
   Phase 3). `#[julia]` is additive since #279 and composes with PyO3's own
@@ -989,5 +991,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for Rust helpers library
 - Documentation examples tests
 
-[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/atelierarith/RustCall.jl/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/atelierarith/RustCall.jl/releases/tag/v0.1.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustCall"
 uuid = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
 
 [deps]

--- a/examples/MyExample.jl/Project.toml
+++ b/examples/MyExample.jl/Project.toml
@@ -8,7 +8,7 @@ RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
 
 [compat]
 julia = "1.12"
-RustCall = "0.1"
+RustCall = "0.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
## Summary

Release preparation for **v0.2.0**: `Project.toml` goes from `0.1.0` to `0.2.0`, and the CHANGELOG's `[Unreleased]` section becomes `[0.2.0] - <date>` with a fresh empty `[Unreleased]` above it and the compare links updated. Nothing else changes.

0.2.0 is a **breaking** release under 0.x semver: the unreleased section carries two `### Breaking` groups (#278 artifact identity, #277 load path, the `#[julia]` symbol scheme of #279, …), the `#[julia_pyo3]` deprecation (#275 Phase 3) and the Scratch.jl cache move (#252). Removal of the deprecated items (#312, #265 Phase 2, #300) is **not** in this release; it is batched for the next breaking one so users get a deprecation window.

## Merge order

This PR must merge **last**, after every PR whose CHANGELOG entry belongs to 0.2.0 (currently #313, #316, #317, and the #288 / #261 PRs). Each of those adds lines under `## [Unreleased]`, so before merging:

1. rebase this branch onto `origin/main`,
2. move any entry that landed under the new empty `[Unreleased]` heading into `[0.2.0]`,
3. set the `[0.2.0]` date to the merge day,
4. re-request review, merge on green.

## After the merge

- Comment `@JuliaRegistrator register` on the squash commit on `main`. The registry PR merges after the usual 3-day / auto-merge checks; TagBot (gated on the `JuliaTagBot` actor) then creates the `v0.2.0` tag and the GitHub release from the CHANGELOG section.
- There is no `v0.1.0` tag on the remote even though 0.1.0 is in General, so this is the first release TagBot tags here; if it does not fire, run the TagBot workflow by hand (`workflow_dispatch`, `lookback` covering the registry merge).
- The CHANGELOG's `[0.1.0]` and `[0.2.0]` links therefore use the commit General registered as 0.1.0 — `6e98d5c` ("consolidate documentation after README cleanup (#238)", whose tree is General's `git-tree-sha1` for 0.1.0) — rather than a `v0.1.0` tag. Optionally create that historical tag on the same commit (`git tag v0.1.0 6e98d5c && git push origin v0.1.0`); the links stay valid either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
