### PR TITLE
Split docs/src/api.md into per-module reference pages (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RustCall._result_payload`, which older RustCall versions do not define.
   Regenerate after upgrading.
 
+- **The API reference is one page per group of source files**
+  ([#288](https://github.com/AtelierArith/RustCall.jl/issues/288)).
+  `docs/src/api.md` rendered every docstring in the package on one page, which
+  hit Documenter's `size_threshold` twice and left 58 docstrings out of the
+  manual altogether. It is now an index over `docs/src/reference/` — artifact
+  identity and caching, the FFI type contract, compilation and codegen, the FFI
+  manifest, Cargo projects and dependencies, external crates and hot reload,
+  PyO3 crates, types/memory/ownership, generics and `#[julia]` functions,
+  errors and load policy, and the deprecated LLVM path — each an
+  `@autodocs` block per source file with an explicit `Pages` filter, so every
+  `src/*.jl` is rendered on exactly one page and no docstring is left out.
+  `size_threshold` is back near Documenter's default. Deep links into `api.md`
+  itself still resolve; links to individual docstrings now point at the
+  reference page of the defining file.
+
 ### Fixed
 - **`test_cargo.jl`'s Cargo-cache assertions no longer race the parallel runner**
   ([#306](https://github.com/AtelierArith/RustCall.jl/issues/306)). The Cargo

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For crate-side bindings, use the companion `juliacall_macros` crate and mark exp
 - Documentation: <https://atelierarith.github.io/RustCall.jl>
 - Examples: [`examples/`](examples)
 - Tutorial source: [`docs/src/tutorial.md`](docs/src/tutorial.md)
-- API reference source: [`docs/src/api.md`](docs/src/api.md)
+- API reference source: [`docs/src/api.md`](docs/src/api.md) (index) and [`docs/src/reference/`](docs/src/reference) (one page per group of source files)
 - Troubleshooting source: [`docs/src/troubleshooting.md`](docs/src/troubleshooting.md)
 
 ## Development

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,19 +15,16 @@ makedocs(
         canonical = "https://atelierarith.github.io/RustCall.jl",
         assets = String[],
         edit_link = :commit,
-        # `api.md` is a single generated page that renders every docstring in
-        # the package, so its size is a function of how well documented
-        # RustCall is — and Documenter's limit has already been hit twice by
-        # ordinary docstring additions (the previous bump to 500 KiB, then
-        # #287 at 501.2 KiB). A limit that turns "wrote a docstring" into a red
-        # Documentation job pushes in exactly the wrong direction, so give it
-        # real margin instead of tracking the page upwards a kilobyte at a time.
-        #
-        # This is a stopgap. The proper fix is to split the reference into
-        # per-module pages with their own `@autodocs` `Pages` filters, after
-        # which the threshold can go back near Documenter's default: #288.
-        size_threshold = 1_000 * 2^10,       # 1000 KiB — hard failure
-        size_threshold_warn = 750 * 2^10,    # 750 KiB — warn, act before it fails
+        # The API reference is one page per group of source files
+        # (`docs/src/reference/`, #288), each with its own `@autodocs`
+        # `Pages` filter, so no single page renders every docstring in the
+        # package and the hard limit is Documenter's default again (the
+        # largest page renders at about 125 KiB). If a reference page grows
+        # past the warning, split it further rather than raising the limit:
+        # the single-page reference hit the limit twice (500 KiB, then #287
+        # at 501.2 KiB).
+        size_threshold = 200 * 2^10,         # 200 KiB — hard failure (Documenter's default)
+        size_threshold_warn = 150 * 2^10,    # 150 KiB — warn, split before it fails
     ),
     warnonly = [:missing_docs],
     pages = [
@@ -48,7 +45,20 @@ makedocs(
         ],
         "Reference" => [
             "Project Guide" => "project_guide.md",
-            "API Reference" => "api.md",
+            "API Reference" => [
+                "Overview" => "api.md",
+                "Artifact identity and caching" => "reference/artifacts.md",
+                "The FFI type contract" => "reference/ffi_contract.md",
+                "Compilation and codegen" => "reference/compilation.md",
+                "The FFI manifest" => "reference/manifest.md",
+                "Cargo projects and dependencies" => "reference/cargo.md",
+                "External crates and hot reload" => "reference/crates.md",
+                "PyO3 crates" => "reference/pyo3.md",
+                "Types, memory and ownership" => "reference/ownership.md",
+                "Generics and #[julia] functions" => "reference/generics.md",
+                "Errors and load policy" => "reference/loading.md",
+                "LLVM integration (deprecated)" => "reference/llvm.md",
+            ],
             "Project Status" => "status.md",
             "Developer Pitfalls" => "developer_pitfalls.md",
         ],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,478 +1,59 @@
 # API Reference
 
-This page provides the API documentation for RustCall.jl.
+The reference is split into one page per group of source files (#288); every
+docstring in the package is rendered on exactly one of them. This page is the
+index. Only the macros are exported; everything else is reached as
+`RustCall.name`.
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "RustCall.jl")]
+```
 
 ## Macros
 
-```@docs
-@rust
-@rust_str
-@irust
-@irust_str
-@rust_llvm
-```
-
-`@rust_llvm` is deprecated and will be removed in a future release; use `@rust`
-instead (see [#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
-
-## Types
-
-### Result and Option Types
-
-```@docs
-RustCall.RustResult
-RustCall.RustOption
-```
-
-### Ownership Types
-
-```@docs
-RustCall.RustBox
-RustCall.RustRc
-RustCall.RustArc
-RustCall.RustVec
-RustCall.RustSlice
-```
-
-### Pointer Types
-
-```@docs
-RustCall.RustPtr
-RustCall.RustRef
-```
-
-### String Types
-
-```@docs
-RustCall.RustString
-RustCall.RustStr
-```
-
-### Error Types
-
-```@docs
-RustCall.RustError
-RustCall.CompilationError
-RustCall.RuntimeError
-RustCall.CargoBuildError
-RustCall.DependencyResolutionError
-```
-
-## Type Conversion Functions
-
-```@docs
-RustCall.rusttype_to_julia
-RustCall.juliatype_to_rust
-```
-
-## Result/Option Operations
-
-```@docs
-RustCall.unwrap
-RustCall.unwrap_or
-RustCall.is_ok
-RustCall.is_err
-RustCall.is_some
-RustCall.is_none
-RustCall.result_to_exception
-RustCall.unwrap_or_throw
-```
-
-## String Conversion Functions
-
-```@docs
-RustCall.rust_string_to_julia
-RustCall.rust_str_to_julia
-RustCall.julia_string_to_rust
-RustCall.julia_string_to_cstring
-RustCall.cstring_to_julia_string
-```
-
-## Error Handling
-
-```@docs
-RustCall.format_rustc_error
-RustCall.suggest_fix_for_error
-```
-
-### Strings in `#[julia]` functions
-
-`#[julia]` free functions may take `String` / `&str` arguments and return
-`String` / `&str` (#242). The generated `extern "C"` wrapper — `rustcall_<fn>`,
-emitted next to the function, which is itself left untouched (#279) —
-receives every
-string as a `(ptr, len)` UTF-8 byte pair (no NUL terminator, embedded NULs
-allowed), returns `String` as an owned buffer that the Julia wrapper copies
-and releases through `<fn>_free_rust_string`, and returns `&str` as a
-borrowed view that is copied immediately. The Julia wrapper accepts any
-`AbstractString` and returns a `String`; this works for inline `rust\"\"\"`
-blocks and for `@rust_crate` alike. `String` inside `Result` / `Option` is
-not supported yet.
-
-```julia
-rust\"\"\"
-#[julia]
-pub fn shout(input: String) -> String { input.to_uppercase() }
-\"\"\"
-shout("hello")  # "HELLO"
-```
-
-## Compiler Functions
-
-```@docs
-RustCall.RustCompiler
-RustCall.compile_with_recovery
-RustCall.check_rustc_available
-RustCall.get_rustc_version
-RustCall.get_default_compiler
-RustCall.set_default_compiler
-RustCall.compile_rust_to_shared_lib
-RustCall.compile_rust_to_llvm_ir
-RustCall.load_llvm_ir
-RustCall.wrap_rust_code
-```
-
-## Ownership Type Operations
-
-```@docs
-RustCall.drop!
-RustCall.is_dropped
-RustCall.is_valid
-RustCall.clone
-RustCall.is_rust_helpers_available
-RustCall.get_rust_helpers_lib
-RustCall.get_rust_helpers_lib_path
-```
-
-## RustVec Operations
-
-```@docs
-RustCall.create_rust_vec
-RustCall.rust_vec_get
-RustCall.rust_vec_set!
-RustCall.copy_to_julia!
-RustCall.to_julia_vector
-```
-
-## Cache Management
-
-```@docs
-RustCall.clear_cache
-RustCall.get_cache_size
-RustCall.list_cached_libraries
-RustCall.cleanup_old_cache
-```
-
-## LLVM Optimization (deprecated)
-
-The LLVM IR integration path is deprecated ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)). Every function in
-this section and the next, together with `compile_rust_to_llvm_ir` and
-`load_llvm_ir` above, emits a deprecation warning and will be removed in a future
-release.
-
-```@docs
-RustCall.OptimizationConfig
-RustCall.optimize_module!
-RustCall.optimize_for_speed!
-RustCall.optimize_for_size!
-```
-
-## LLVM Function Registration (deprecated)
-
-```@docs
-RustCall.RustFunctionInfo
-RustCall.compile_and_register_rust_function
-RustCall.julia_type_to_llvm_ir_string
-```
-
-## Generics Support
-
-```@docs
-RustCall.register_generic_function
-RustCall.call_generic_function
-RustCall.is_generic_function
-RustCall.monomorphize_function
-RustCall.infer_type_parameters
-RustCall.julia_type_to_rust_string
-```
-
-## FFI Manifest
-
-Julia never parses Rust source. Signatures, struct layouts and generic
-parameters come from the FFI manifest produced by the `rustcall-extract` CLI
-(`deps/rustcall_extract`), which shares its `syn`-based core
-(`deps/rustcall_core`) with the `juliacall_macros` proc-macro.
-
-Items disabled by `#[cfg(...)]` are dropped from manifests and expanded
-sources: the extractor evaluates the predicates against `rustc --print cfg`
-(passed as `--cfg-file`). Direct `rustc` builds query it with the real
-compilation flags (`cfg = :strict`); Cargo projects RustCall generates itself
-(`// cargo-deps:` blocks) evaluate the same way against Cargo's effective
-configuration, obtained from a probe crate (`cfg = :cargo`). Only an external
-crate (`@rust_crate`), whose features and build script RustCall does not
-control, decides target predicates alone (`cfg = :lenient`, `--cfg-lenient`).
-The predicate of every reported item is recorded in its `cfg` field.
-
-```@docs
-RustCall.extract_manifest
-RustCall.expand_inline
-RustCall.manifest_function_signatures
-RustCall.manifest_struct_infos
-RustCall.specialize_generic
-RustCall.extractor_path
-RustCall.toolchain_fingerprint
-RustCall.ExtractorError
-RustCall.MANIFEST_SCHEMA_VERSION
-```
-
-## Generic Constraints
-
-```@docs
-RustCall.TraitBound
-RustCall.TypeConstraints
-RustCall.GenericFunctionInfo
-```
-
-## External Library Integration
-
-### Dependency Management
-
-```@docs
-RustCall.DependencySpec
-RustCall.parse_dependencies_from_code
-RustCall.has_dependencies
-```
-
-### Cargo Project Management
-
-```@docs
-RustCall.CargoProject
-RustCall.create_cargo_project
-RustCall.build_cargo_project
-RustCall.clear_cargo_cache
-RustCall.get_cargo_cache_size
-```
-
-## Crate Bindings
-
-The explicit-binding runtime contract is:
-
-- `@rust_crate` and `RustCall.load_crate_bindings` return a `RustCall.CrateBindings` value.
-- Property access preserves non-function bindings such as types and constants.
-- Callable exported functions remain proxy-backed so calls stay world-age-safe.
-
-```@docs
-RustCall.CrateBindings
-RustCall.CrateInfo
-RustCall.CrateBindingOptions
-RustCall.load_crate_bindings
-RustCall.scan_crate
-RustCall.generate_bindings
-RustCall.write_bindings_to_file
-@rust_crate
-```
-
-## PyO3 Crates
-
-```@docs
-RustCall.scan_report
-RustCall.PyO3LinkPlan
-RustCall.pyo3_link_plan
-RustCall.pyo3_feature_candidates
-RustCall.pyo3_link_rustflags
-RustCall.pyo3_dependency_toml
-RustCall.python_library_dir
-RustCall.pyo3_skip_explanation
-RustCall.PYO3_SKIP_REASONS
-```
-
-## Hot Reload
-
-```@docs
-RustCall.HotReloadState
-RustCall.enable_hot_reload
-RustCall.disable_hot_reload
-RustCall.disable_all_hot_reload
-RustCall.is_hot_reload_enabled
-RustCall.list_hot_reload_crates
-RustCall.trigger_reload
-RustCall.set_hot_reload_global
-RustCall.enable_hot_reload_for_crate
-```
-
-## Type System
-
-### The FFI type contract
-
-Rust-to-Julia type mapping lives in one place, `src/ffi_contract.jl`, and is
-documented — with the generated supported-type matrix — under
-[The FFI Type Contract](type_contract.md).
-
-```@docs
-RustCall.FFI_ABI_KINDS
-RustCall.FFI_OWNERSHIP_KINDS
-RustCall.FFIType
-RustCall.FFIContract
-RustCall.FFI_TYPE_TABLE
-RustCall.FFI_STRICT
-RustCall.ffi_lookup
-RustCall.ffi_argument_contract
-RustCall.ffi_return_contract
-RustCall.ffi_return_symbol_or_throw
-RustCall.ffi_describe
-```
-
-`rusttype_to_julia` is a thin shim over that table. Two spellings changed
-meaning when it stopped having a table of its own (#276): `"str"` is `RustStr`
-rather than `Cstring`, and `"*const u8"` is `Ptr{UInt8}` rather than `Cstring`.
-A Rust `str` is an unsized UTF-8 slice reached through a `(ptr, len)` fat
-pointer and a `*const u8` is a plain byte pointer; neither is a NUL-terminated C
-string.
-
-The reverse direction still has a table of its own, since a Julia type does not
-determine a Rust spelling:
-
-```julia
-# Julia to Rust type mapping
-const JULIA_TO_RUST_TYPE_MAP = Dict{Type, String}(
-    Int8 => "i8",
-    Int16 => "i16",
-    Int32 => "i32",
-    Int64 => "i64",
-    UInt8 => "u8",
-    UInt16 => "u16",
-    UInt32 => "u32",
-    UInt64 => "u64",
-    Float32 => "f32",
-    Float64 => "f64",
-    Bool => "bool",
-    Cvoid => "()",
-)
-```
-
-### Internal Registries
-
-The following registries are used internally by RustCall.jl:
-
-```@docs
-RustCall.GENERIC_FUNCTION_REGISTRY
-RustCall.MONOMORPHIZED_FUNCTIONS
-```
-
-The following registries and constants are not exported but are available for advanced usage.
-
-Note: These constants are internal implementation details. They are documented here for completeness but should not be accessed directly by users.
-
-```@autodocs
-Modules = [RustCall]
-Private = true
-Filter = t -> begin
-    name = try
-        nameof(t)
-    catch
-        return false
-    end
-    target_names = [
-        :RUST_LIBRARIES, :RUST_MODULE_REGISTRY, :FUNCTION_REGISTRY, :IRUST_FUNCTIONS,
-        :CURRENT_LIB, :JULIA_TO_RUST_TYPE_MAP
-    ]
-    return name in target_names
-end
-```
-
-## Utility Functions
-
-### Testing and Debugging
-
-These functions are exported for testing purposes but are considered internal.
-They are wrappers around internal implementation functions.
-
-## Internal Functions and Types
-
-The following functions and types are internal implementation details and are not part of the public API.
-They are documented here for completeness but should not be used directly by users.
-
-```@autodocs
-Modules = [RustCall]
-Filter = t -> begin
-    # Exclude items already documented in @docs blocks above
-    excluded_names = [
-        # Types (documented in @docs blocks)
-        :RustResult, :RustOption, :RustBox, :RustRc, :RustArc, :RustVec, :RustSlice,
-        :RustPtr, :RustRef, :RustString, :RustStr,
-        :FFIType, :FFIContract,
-        :RustError, :CompilationError, :RuntimeError, :CargoBuildError, :DependencyResolutionError,
-        :RustCompiler, :OptimizationConfig, :RustFunctionInfo,
-        :DependencySpec, :CargoProject,
-        # Constants/Registries (documented in @docs blocks)
-        :GENERIC_FUNCTION_REGISTRY, :MONOMORPHIZED_FUNCTIONS,
-        :RUST_LIBRARIES, :RUST_MODULE_REGISTRY, :FUNCTION_REGISTRY, :IRUST_FUNCTIONS,
-        # Public functions already documented
-        :unwrap, :unwrap_or, :is_ok, :is_err, :is_some, :is_none,
-        :result_to_exception, :unwrap_or_throw,
-        :rusttype_to_julia, :juliatype_to_rust,
-        :rust_string_to_julia, :rust_str_to_julia,
-        :julia_string_to_rust, :julia_string_to_cstring, :cstring_to_julia_string,
-        :format_rustc_error, :suggest_fix_for_error,
-        :compile_with_recovery, :check_rustc_available, :get_rustc_version,
-        :get_default_compiler, :set_default_compiler, :compile_rust_to_shared_lib,
-        :compile_rust_to_llvm_ir, :load_llvm_ir, :wrap_rust_code,
-        :drop!, :is_dropped, :is_valid, :clone, :is_rust_helpers_available,
-        :get_rust_helpers_lib, :get_rust_helpers_lib_path,
-        :create_rust_vec, :rust_vec_get, :rust_vec_set!, :copy_to_julia!, :to_julia_vector,
-        :clear_cache, :get_cache_size, :list_cached_libraries, :cleanup_old_cache,
-        :optimize_module!, :optimize_for_speed!, :optimize_for_size!,
-        :compile_and_register_rust_function,
-        :register_generic_function, :call_generic_function, :is_generic_function,
-        :monomorphize_function, :specialize_generic, :infer_type_parameters, :julia_type_to_rust_string,
-        :extract_manifest, :expand_inline, :manifest_function_signatures, :manifest_struct_infos,
-        :extractor_path, :toolchain_fingerprint, :ExtractorError,
-        :parse_dependencies_from_code, :has_dependencies,
-        :create_cargo_project, :build_cargo_project,
-        :clear_cargo_cache, :get_cargo_cache_size,
-        :julia_type_to_llvm_ir_string,
-        :TraitBound, :TypeConstraints, :GenericFunctionInfo,
-        :CrateBindings, :CrateInfo, :CrateBindingOptions,
-        :load_crate_bindings, :scan_crate, :generate_bindings, :write_bindings_to_file,
-        :scan_report, :PyO3LinkPlan, :pyo3_link_plan, :pyo3_feature_candidates,
-        :pyo3_link_rustflags, :pyo3_dependency_toml,
-        :python_library_dir, :pyo3_skip_explanation,
-        :HotReloadState,
-        :enable_hot_reload, :disable_hot_reload, :disable_all_hot_reload,
-        :is_hot_reload_enabled, :list_hot_reload_crates,
-        :trigger_reload, :set_hot_reload_global, :enable_hot_reload_for_crate,
-        # Macros (documented separately)
-        Symbol("@rust"), Symbol("@rust_str"), Symbol("@irust"), Symbol("@irust_str"),
-        Symbol("@rust_llvm"), Symbol("@rust_crate"),
-    ]
-    # Get the binding name
-    name = try
-        nameof(t)
-    catch
-        return false
-    end
-    # Include all documented items that are not in the excluded list
-    # This includes internal functions, types, and Base method extensions
-    return !(name in excluded_names)
-end
-```
-
-## Loading and lifetime
-
-Every compiled artifact is opened, registered and unloaded through one path
-(`src/loadpolicy.jl`). The user-facing halves of it:
-
-- `RustCall.unload_library(name; close = false)` /
-  `RustCall.unload_all_libraries(; close = false)` — drop everything the
-  registries record about a library. The image stays mapped by default, because
-  a call may still be inside it; `close = true` reclaims it, and is the caller
-  stating that none is.
-- `RustCall.retired_handles()` / `RustCall.retired_handles(name)` — the images
-  that have left the registry and are still mapped.
-- `RustCall.list_loaded_libraries()` — the registered library names, which now
-  include `@rust_crate` libraries.
-- `RustCall.RustPanicError` — a Rust `panic!` caught at the FFI boundary.
-- `RustCall.finalizer_failure_count()` — how many Rust destructors raised while
-  being called from a finalizer (non-zero means objects leaked).
-
-See [Panics, Visibility and Lifetime](panics.md) for the semantics these guarantee.
+- [`@rust_str`](@ref) — `rust"""..."""`: compile a Rust snippet and register its functions.
+- [`@rust`](@ref) — call a registered Rust function.
+- [`@irust`](@ref) / [`@irust_str`](@ref) — inline Rust with `$var` binding.
+- [`@rust_crate`](@ref) — bind an external crate.
+- [`@rust_llvm`](@ref) — deprecated; use `@rust` instead
+  ([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)).
+
+## Pages
+
+- [Artifact identity and caching](reference/artifacts.md) — `ArtifactId` and
+  `artifact_key`, the one place an artifact is named, and the Scratch.jl cache
+  that stores what it names (`artifact_id.jl`, `cache.jl`).
+- [The FFI type contract](reference/ffi_contract.md) — the Rust ↔ Julia type
+  table every code path consults, and the type translation shims over it
+  (`ffi_contract.jl`, `typetranslation.jl`).
+- [Compilation and codegen](reference/compilation.md) — `rust"""..."""`,
+  `@rust` and `@irust`, the `rustc` invocation and the generated `ccall`s
+  (`ruststr.jl`, `rustmacro.jl`, `compiler.jl`, `codegen.jl`).
+- [The FFI manifest](reference/manifest.md) — the `rustcall-extract` interface:
+  manifests, inline expansion, specialization and the toolchain fingerprint
+  (`manifest.jl`).
+- [Cargo projects and dependencies](reference/cargo.md) — `// cargo-deps:`,
+  dependency resolution, and the generated Cargo projects and their build cache
+  (`dependencies.jl`, `dependency_resolution.jl`, `cargoproject.jl`,
+  `cargobuild.jl`).
+- [External crates and hot reload](reference/crates.md) — `@rust_crate`
+  bindings and hot reload (`crate_bindings.jl`, `hot_reload.jl`).
+- [PyO3 crates](reference/pyo3.md) — the wrapper crate built around a PyO3
+  extension module, its link plan and skip reasons (`pyo3.jl`).
+- [Types, memory and ownership](reference/ownership.md) — `RustResult`,
+  `RustOption`, the ownership wrappers, the Rust helpers library and the Julia
+  types generated for `#[julia]` structs (`types.jl`, `memory.jl`, `structs.jl`).
+- [Generics and `#[julia]` functions](reference/generics.md) — the generic
+  function registry, monomorphization, and the wrappers for `#[julia]` free
+  functions (`generics.jl`, `julia_functions.jl`).
+- [Errors and load policy](reference/loading.md) — the exception types and the
+  one load/unload path (`exceptions.jl`, `loadpolicy.jl`).
+- [LLVM integration (deprecated)](reference/llvm.md) — the LLVM IR path, kept
+  until #265 removes it (`llvmintegration.jl`, `llvmoptimization.jl`,
+  `llvmcodegen.jl`).
+
+Internal registries and constants (`RustCall.RUST_LIBRARIES`,
+`RustCall.CURRENT_LIB`, `RustCall.GENERIC_FUNCTION_REGISTRY`, …) are rendered on
+the page of the file that defines them. They are implementation details,
+documented for completeness, and should not be accessed directly by users.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -351,6 +351,17 @@ Pages = [
     "troubleshooting.md",
     "project_guide.md",
     "api.md",
+    "reference/artifacts.md",
+    "reference/ffi_contract.md",
+    "reference/compilation.md",
+    "reference/manifest.md",
+    "reference/cargo.md",
+    "reference/crates.md",
+    "reference/pyo3.md",
+    "reference/ownership.md",
+    "reference/generics.md",
+    "reference/loading.md",
+    "reference/llvm.md",
     "status.md",
 ]
 Depth = 2

--- a/docs/src/reference/artifacts.md
+++ b/docs/src/reference/artifacts.md
@@ -1,0 +1,22 @@
+# Artifact identity and caching
+
+Every compiled artifact — a direct `rustc` build, a generated Cargo project, a
+monomorphized generic, a `@rust_crate` library — is named by an
+[`RustCall.ArtifactId`](@ref) and looked up by its [`RustCall.artifact_key`](@ref).
+Identity is computed in exactly one place, `src/artifact_id.jl`; the cache in
+`src/cache.jl` stores what that identity names, in a Scratch.jl space (#252,
+#278).
+
+## Artifact identity (`src/artifact_id.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "artifact_id.jl")]
+```
+
+## Cache (`src/cache.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "cache.jl")]
+```

--- a/docs/src/reference/cargo.md
+++ b/docs/src/reference/cargo.md
@@ -1,0 +1,35 @@
+# Cargo projects and dependencies
+
+Everything an inline block with a `// cargo-deps:` comment (or a
+`` //! ```cargo `` block) goes through instead of a bare `rustc`: the
+dependency DSL and its resolution, and the temporary Cargo projects RustCall
+generates, builds and caches. External crates are on
+[External crates and hot reload](crates.md).
+
+## Dependencies (`src/dependencies.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "dependencies.jl")]
+```
+
+## Dependency resolution (`src/dependency_resolution.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "dependency_resolution.jl")]
+```
+
+## Cargo projects (`src/cargoproject.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "cargoproject.jl")]
+```
+
+## Cargo builds (`src/cargobuild.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "cargobuild.jl")]
+```

--- a/docs/src/reference/compilation.md
+++ b/docs/src/reference/compilation.md
@@ -1,0 +1,33 @@
+# Compilation and codegen
+
+The front doors — `rust"""..."""`, `@rust`, `@irust` — and the pipeline behind
+them: the `rustc` invocation and the `ccall` expressions generated from the
+[FFI manifest](manifest.md).
+
+## `rust"""..."""` and `@irust` (`src/ruststr.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "ruststr.jl")]
+```
+
+## `@rust` (`src/rustmacro.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "rustmacro.jl")]
+```
+
+## Compiler (`src/compiler.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "compiler.jl")]
+```
+
+## Code generation (`src/codegen.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "codegen.jl")]
+```

--- a/docs/src/reference/crates.md
+++ b/docs/src/reference/crates.md
@@ -1,0 +1,25 @@
+# External crates and hot reload
+
+`@rust_crate` bindings to an existing crate, and hot reload of a crate's
+library while it is in use. See [External Crate Bindings](../crate_bindings.md)
+for the user-facing guide; PyO3 extension modules are on [PyO3 crates](pyo3.md).
+
+## Crate bindings (`src/crate_bindings.jl`)
+
+The explicit-binding runtime contract is:
+
+- `@rust_crate` and `RustCall.load_crate_bindings` return a `RustCall.CrateBindings` value.
+- Property access preserves non-function bindings such as types and constants.
+- Callable exported functions remain proxy-backed so calls stay world-age-safe.
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "crate_bindings.jl")]
+```
+
+## Hot reload (`src/hot_reload.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "hot_reload.jl")]
+```

--- a/docs/src/reference/ffi_contract.md
+++ b/docs/src/reference/ffi_contract.md
@@ -1,0 +1,47 @@
+# The FFI type contract
+
+Rust-to-Julia type mapping lives in one place, `src/ffi_contract.jl`, and is
+documented — with the generated supported-type matrix — under
+[The FFI Type Contract](../type_contract.md).
+
+`rusttype_to_julia` is a thin shim over that table. Two spellings changed
+meaning when it stopped having a table of its own (#276): `"str"` is `RustStr`
+rather than `Cstring`, and `"*const u8"` is `Ptr{UInt8}` rather than `Cstring`.
+A Rust `str` is an unsized UTF-8 slice reached through a `(ptr, len)` fat
+pointer and a `*const u8` is a plain byte pointer; neither is a NUL-terminated C
+string.
+
+The reverse direction still has a table of its own, since a Julia type does not
+determine a Rust spelling:
+
+```julia
+# Julia to Rust type mapping
+const JULIA_TO_RUST_TYPE_MAP = Dict{Type, String}(
+    Int8 => "i8",
+    Int16 => "i16",
+    Int32 => "i32",
+    Int64 => "i64",
+    UInt8 => "u8",
+    UInt16 => "u16",
+    UInt32 => "u32",
+    UInt64 => "u64",
+    Float32 => "f32",
+    Float64 => "f64",
+    Bool => "bool",
+    Cvoid => "()",
+)
+```
+
+## Contract table and lookups (`src/ffi_contract.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "ffi_contract.jl")]
+```
+
+## Type translation (`src/typetranslation.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "typetranslation.jl")]
+```

--- a/docs/src/reference/generics.md
+++ b/docs/src/reference/generics.md
@@ -1,0 +1,42 @@
+# Generics and `#[julia]` functions
+
+The generic function registry and monomorphization through
+`rustcall-extract specialize`, and the Julia wrappers generated for `#[julia]`
+free functions (Result/Option aware). See [Generics](../generics.md) for the
+user-facing guide.
+
+## Generics (`src/generics.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "generics.jl")]
+```
+
+## `#[julia]` functions (`src/julia_functions.jl`)
+
+### Strings in `#[julia]` functions
+
+`#[julia]` free functions may take `String` / `&str` arguments and return
+`String` / `&str` (#242). The generated `extern "C"` wrapper — `rustcall_<fn>`,
+emitted next to the function, which is itself left untouched (#279) —
+receives every
+string as a `(ptr, len)` UTF-8 byte pair (no NUL terminator, embedded NULs
+allowed), returns `String` as an owned buffer that the Julia wrapper copies
+and releases through `<fn>_free_rust_string`, and returns `&str` as a
+borrowed view that is copied immediately. The Julia wrapper accepts any
+`AbstractString` and returns a `String`; this works for inline `rust\"\"\"`
+blocks and for `@rust_crate` alike. `String` inside `Result` / `Option` is
+not supported yet.
+
+```julia
+rust\"\"\"
+#[julia]
+pub fn shout(input: String) -> String { input.to_uppercase() }
+\"\"\"
+shout("hello")  # "HELLO"
+```
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "julia_functions.jl")]
+```

--- a/docs/src/reference/llvm.md
+++ b/docs/src/reference/llvm.md
@@ -1,0 +1,28 @@
+# LLVM integration (deprecated)
+
+The LLVM IR integration path is deprecated
+([#265](https://github.com/AtelierArith/RustCall.jl/issues/265)). Every
+function on this page, together with `compile_rust_to_llvm_ir` and
+`load_llvm_ir`, emits a deprecation warning and will be removed in a future
+release. `@rust_llvm` is deprecated as well; use `@rust` instead.
+
+## LLVM modules (`src/llvmintegration.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "llvmintegration.jl")]
+```
+
+## LLVM optimization (`src/llvmoptimization.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "llvmoptimization.jl")]
+```
+
+## LLVM function registration (`src/llvmcodegen.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "llvmcodegen.jl")]
+```

--- a/docs/src/reference/loading.md
+++ b/docs/src/reference/loading.md
@@ -1,0 +1,38 @@
+# Errors and load policy
+
+The exception types RustCall raises, and the one path through which every
+compiled artifact is opened, registered, retired and unloaded
+(`src/loadpolicy.jl`, #277).
+
+## Loading and lifetime
+
+The user-facing halves of the load path:
+
+- `RustCall.unload_library(name; close = false)` /
+  `RustCall.unload_all_libraries(; close = false)` — drop everything the
+  registries record about a library. The image stays mapped by default, because
+  a call may still be inside it; `close = true` reclaims it, and is the caller
+  stating that none is.
+- `RustCall.retired_handles()` / `RustCall.retired_handles(name)` — the images
+  that have left the registry and are still mapped.
+- `RustCall.list_loaded_libraries()` — the registered library names, which now
+  include `@rust_crate` libraries.
+- `RustCall.RustPanicError` — a Rust `panic!` caught at the FFI boundary.
+- `RustCall.finalizer_failure_count()` — how many Rust destructors raised while
+  being called from a finalizer (non-zero means objects leaked).
+
+See [Panics, Visibility and Lifetime](../panics.md) for the semantics these guarantee.
+
+## Errors (`src/exceptions.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "exceptions.jl")]
+```
+
+## Load policy (`src/loadpolicy.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "loadpolicy.jl")]
+```

--- a/docs/src/reference/manifest.md
+++ b/docs/src/reference/manifest.md
@@ -1,0 +1,23 @@
+# The FFI manifest
+
+Julia never parses Rust source. Signatures, struct layouts and generic
+parameters come from the FFI manifest produced by the `rustcall-extract` CLI
+(`deps/rustcall_extract`), which shares its `syn`-based core
+(`deps/rustcall_core`) with the `juliacall_macros` proc-macro.
+
+Items disabled by `#[cfg(...)]` are dropped from manifests and expanded
+sources: the extractor evaluates the predicates against `rustc --print cfg`
+(passed as `--cfg-file`). Direct `rustc` builds query it with the real
+compilation flags (`cfg = :strict`); Cargo projects RustCall generates itself
+(`// cargo-deps:` blocks) evaluate the same way against Cargo's effective
+configuration, obtained from a probe crate (`cfg = :cargo`). Only an external
+crate (`@rust_crate`), whose features and build script RustCall does not
+control, decides target predicates alone (`cfg = :lenient`, `--cfg-lenient`).
+The predicate of every reported item is recorded in its `cfg` field.
+
+## Extractor interface (`src/manifest.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "manifest.jl")]
+```

--- a/docs/src/reference/ownership.md
+++ b/docs/src/reference/ownership.md
@@ -1,0 +1,29 @@
+# Types, memory and ownership
+
+The Julia-side wrapper types (`RustResult`, `RustOption`, `RustBox`, `RustRc`,
+`RustArc`, `RustVec`, `RustSlice`, `RustPtr`, `RustRef`, `RustString`,
+`RustStr`) and their operations, the ownership operations backed by the Rust
+helpers library (`deps/rust_helpers/`), and the Julia types generated for
+`#[julia]` structs. See [Struct Mapping](../struct_mapping.md) for the
+user-facing guide.
+
+## Wrapper types (`src/types.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "types.jl")]
+```
+
+## Memory and ownership (`src/memory.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "memory.jl")]
+```
+
+## `#[julia]` structs (`src/structs.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "structs.jl")]
+```

--- a/docs/src/reference/pyo3.md
+++ b/docs/src/reference/pyo3.md
@@ -1,0 +1,13 @@
+# PyO3 crates
+
+The wrapper crate RustCall builds around a PyO3 extension module so that its
+`#[pyfunction]`s and `#[pymethods]` can be called from Julia, the link plan
+that finds the Python runtime, and the skip reasons a scan reports. See
+[PyO3 Crates](../pyo3.md) for the user-facing guide.
+
+## PyO3 wrapper crates (`src/pyo3.jl`)
+
+```@autodocs
+Modules = [RustCall]
+Pages = [joinpath("src", "pyo3.jl")]
+```


### PR DESCRIPTION
## Summary

`docs/src/api.md` rendered every docstring in the package on one page (732 KiB locally on `main`), hit Documenter's `size_threshold` twice, and — because its catch-all `@autodocs` filter had to enumerate exclusions by hand — silently left **58 docstrings out of the manual** (`RUST_LIBRARIES`, `CACHE_LOCK`, `ARTIFACT_GENERATIONS`, `FFI_SYMBOL_PREFIX`, …; the build on `main` warns about them).

This PR splits the reference into `docs/src/reference/`, one page per group of source files along the include order in `src/RustCall.jl`. Each source file is rendered by exactly one `@autodocs` block with an explicit `Pages` filter (27 files, 27 entries, checked by listing `src/*.jl` against every `Pages` list), so every docstring lands on exactly one page and the missing-docs warning is gone. `api.md` stays at its URL as the index (module docstring, macro list, one paragraph per page), so existing links to `api.md` keep resolving.

`Pages` entries are spelled `joinpath("src", "codegen.jl")` rather than `"codegen.jl"` because Documenter's filter is an `endswith` on the path: a bare `"codegen.jl"` would also match `llvmcodegen.jl` and raise a duplicate-docs error.

The prose that lived on `api.md` moved with its subject: the FFI manifest / `#[cfg]` explanation to the manifest page, "Strings in `#[julia]` functions" to the generics page, the crate-bindings runtime contract to the crates page, "Loading and lifetime" to the errors/load-policy page, the type-contract shim note to the FFI contract page.

## Pages (rendered size, `CI=true` build)

| page | files | size |
| --- | --- | --- |
| `api.md` (index) | `RustCall.jl` | 16 KiB |
| `reference/artifacts.md` — Artifact identity and caching | `artifact_id.jl`, `cache.jl` | 92 KiB |
| `reference/ffi_contract.md` — The FFI type contract | `ffi_contract.jl`, `typetranslation.jl` | 96 KiB |
| `reference/compilation.md` — Compilation and codegen | `ruststr.jl`, `rustmacro.jl`, `compiler.jl`, `codegen.jl` | 116 KiB |
| `reference/manifest.md` — The FFI manifest | `manifest.jl` | 52 KiB |
| `reference/cargo.md` — Cargo projects and dependencies | `dependencies.jl`, `dependency_resolution.jl`, `cargoproject.jl`, `cargobuild.jl` | 56 KiB |
| `reference/crates.md` — External crates and hot reload | `crate_bindings.jl`, `hot_reload.jl` | 104 KiB |
| `reference/pyo3.md` — PyO3 crates | `pyo3.jl` | 72 KiB |
| `reference/ownership.md` — Types, memory and ownership | `types.jl`, `memory.jl`, `structs.jl` | 100 KiB |
| `reference/generics.md` — Generics and `#[julia]` functions | `generics.jl`, `julia_functions.jl` | 52 KiB |
| `reference/loading.md` — Errors and load policy | `exceptions.jl`, `loadpolicy.jl` | **124 KiB (largest)** |
| `reference/llvm.md` — LLVM integration (deprecated) | `llvmintegration.jl`, `llvmoptimization.jl`, `llvmcodegen.jl` | 48 KiB |

The issue's seven groups grew to eleven pages because three of them rendered too large to sit comfortably under the default: "Cargo and external crates" was 208 KiB as one page (split into Cargo projects / external crates / PyO3), and the manifest section took "Compilation and codegen" to 156 KiB.

## `size_threshold`

Back to Documenter's default: `size_threshold = 200 KiB` (hard failure), `size_threshold_warn = 150 KiB`. The largest page is 124 KiB, ~60% headroom; the `make.jl` comment says to split a page that reaches the warning rather than raise the limit again.

`julia --project=docs docs/make.jl` exits 0 with no `@autodocs`, missing-docstring, duplicate or cross-reference warnings. The two remaining warnings (`@example` PNG fallback on `examples.md`, and the 686 KiB search index) exist on `main` too; the search index grew by the 58 docstrings that are now rendered.

Also: `docs/src/index.md`'s `@contents` lists the new pages, `README.md` points at `docs/src/reference/`, and CHANGELOG has a `### Changed` entry.

Docs-only change: nothing under `src/` or `test/` is touched, and nothing there reads `api.md`.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
