### PR TITLE
Static #[julia] methods dispatch on the type; bare form only without a name collision (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A static `#[julia]` method no longer overwrites a free function of the same
+  name** ([#323](https://github.com/AtelierArith/RustCall.jl/issues/323)). A
+  method without `self` was bound as a bare Julia function named after the
+  method, so `Labeler::shout` and the crate's free `fn shout` defined
+  `shout(::Any)` twice: the second silently replaced the first under
+  `@rust_crate`, and a module written by `write_bindings_to_file` failed to
+  precompile ("Method overwriting is not permitted"). A static method now
+  dispatches on the type — `shout(Labeler, s)` — and keeps the bare
+  `shout(s)` form only when no free function or other static method of the
+  crate has that name, so every existing non-colliding call still works and the
+  free function always keeps its name. The inline `rust"""` path applies the
+  same rule to a `#[julia] impl` block's static methods (`add(MathUtils, a, b)`).
+  `examples/sample_crate` is unchanged and now binds both `shout`s.
+
 ## [0.2.0] - 2026-09-07
 
 ### Deprecated

--- a/docs/src/crate_bindings.md
+++ b/docs/src/crate_bindings.md
@@ -161,6 +161,23 @@ The generated Julia bindings keep the Rust names (`Counter(1)`, `get(c)`);
 they resolve the exported symbol through the manifest, so nothing in the Julia
 API changes.
 
+### Static methods
+
+A method without `self` (other than a constructor) is called with the type as
+its first argument, the Julia spelling of `Labeler::shout(s)`:
+
+```julia
+shout(Labeler, "hi")     # Labeler::shout
+parse_scale(Divider, "7") # Divider::parse_scale
+```
+
+The bare `shout("hi")` form is generated as well, **unless** the crate also
+has a free `#[julia] fn shout` or another struct with a static `shout`: two
+bare definitions would overwrite each other — silently under `@rust_crate`,
+and as a hard error when a module written by `write_bindings_to_file` is
+precompiled — so in that case only the typed form exists and the free function
+keeps the bare name (#323).
+
 ## Property Access Syntax
 
 Generated struct wrappers support Julia's property access syntax for natural field access:

--- a/docs/src/struct_mapping.md
+++ b/docs/src/struct_mapping.md
@@ -298,11 +298,23 @@ impl MathUtils {
 }
 """
 
-# Create an instance and call static methods
-utils = MathUtils()
-result1 = add(3.0, 4.0)      # => 7.0
-result2 = multiply(3.0, 4.0) # => 12.0
+# Call static methods with the type first — the Julia spelling of
+# `MathUtils::add(3.0, 4.0)`:
+result1 = add(MathUtils, 3.0, 4.0)      # => 7.0
+result2 = multiply(MathUtils, 3.0, 4.0) # => 12.0
+
+# The bare form exists too, as long as nothing else in the block is called
+# `add` or `multiply`:
+result1 = add(3.0, 4.0)                 # => 7.0
 ```
+
+A static method dispatches on the type so that it never shares a method table
+with a free `#[julia] fn` of the same name: `MathUtils::add` and a free
+`fn add` in one block used to define `add(::Any, ::Any)` twice and overwrite
+each other — silently, or as a hard error when the module is precompiled. When
+such a name exists in the block, only the typed form is generated for the
+static method and the free function keeps the bare name (#323). The same rule
+applies to `@rust_crate` bindings.
 
 !!! note
     Unit struct support is still planned for a future release, so the example

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -948,9 +948,10 @@ Generate Julia struct definitions and wrappers for all #[julia] structs in the c
 """
 function generate_crate_struct_wrappers(info::CrateInfo, lib_path::String)
     exprs = Expr[]
+    colliding = _static_method_collisions(info)
 
     for s in info.julia_structs
-        wrapper = _generate_crate_struct_wrapper(s)
+        wrapper = _generate_crate_struct_wrapper(s; colliding = colliding)
         push!(exprs, wrapper)
     end
 
@@ -961,7 +962,24 @@ function generate_crate_struct_wrappers(info::CrateInfo, lib_path::String)
     Expr(:block, exprs...)
 end
 
-function _generate_crate_struct_wrapper(info::RustStructInfo)
+"""
+    _static_method_collisions(info::CrateInfo) -> Set{String}
+
+The names a static (non-constructor) `#[julia]` method shares with a free
+function or with another struct's static method in the same crate.
+
+A static method is bound as `name(::Type{Struct}, args...)` (#323); it also gets
+the bare `name(args...)` form for convenience, but only when nothing else in the
+generated module would define `name(args...)` too — two such definitions
+overwrite each other (silently under `@rust_crate`, a hard error when a written
+module is precompiled). Free functions always keep their bare name; the static
+method yields.
+"""
+_static_method_collisions(info::CrateInfo) =
+    _static_method_collisions(info.julia_functions, info.julia_structs)
+
+function _generate_crate_struct_wrapper(info::RustStructInfo;
+                                        colliding::Set{String} = Set{String}())
     struct_name = Symbol(info.name)
     struct_name_str = info.name
 
@@ -1008,7 +1026,7 @@ function _generate_crate_struct_wrapper(info::RustStructInfo)
 
     # Generate constructor and method wrappers
     for m in info.methods
-        method_wrapper = _generate_crate_method_wrapper(info, m)
+        method_wrapper = _generate_crate_method_wrapper(info, m; bare = !(m.name in colliding))
         push!(exprs, method_wrapper)
     end
 
@@ -1230,7 +1248,8 @@ one message, both flavours (#249, #277 Phase B4).
 """
 _check_not_freed(obj, type_name::String) = check_not_freed(obj, type_name)
 
-function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod)
+function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod;
+                                        bare::Bool = true)
     struct_name = Symbol(info.name)
     struct_name_str = info.name
     method_name = Symbol(method.name)
@@ -1265,7 +1284,7 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
     # is built whole rather than as one `call` expression (#275 Phase 2).
     if method.return_kind === :py_result
         return _generate_py_result_method_wrapper(info, method, arg_syms, bindings, preserved,
-                                                  converted_args, wrapper_name)
+                                                  converted_args, wrapper_name; bare = bare)
     end
     # Definitions the wrapper needs next to it: the `#[repr(C)]` mirror of a
     # `CResult_<Struct>_<method>` / `COption_<Struct>_<method>` aggregate (#268).
@@ -1333,10 +1352,18 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
             end
         end
     elseif method.is_static
+        # A static method dispatches on the type — `shout(Labeler, s)` for
+        # `Labeler::shout` — so it can never share a method table with a free
+        # function or another struct's static method of the same name (#323).
+        # The bare `shout(s)` form is kept only while no such name exists.
+        bare_def = bare ?
+            :($method_name($(arg_syms...)) = $method_name($struct_name, $(arg_syms...))) :
+            nothing
         quote
-            function $method_name($(arg_syms...))
+            function $method_name(::Type{$struct_name}, $(arg_syms...))
                 $body
             end
+            $bare_def
             export $method_name
         end
     else
@@ -1459,7 +1486,7 @@ generator gives it.
 function _generate_py_result_method_wrapper(info::RustStructInfo, method::RustMethod,
                                             arg_syms::Vector{Symbol}, bindings::Vector,
                                             preserved::Vector, converted_args::Vector,
-                                            wrapper_name::String)
+                                            wrapper_name::String; bare::Bool = true)
     struct_name = Symbol(info.name)
     struct_name_str = info.name
     method_name = Symbol(method.name)
@@ -1502,11 +1529,17 @@ function _generate_py_result_method_wrapper(info::RustStructInfo, method::RustMe
     end
 
     if method.is_static
+        # Type-dispatched, bare form only without a name collision (#323); see
+        # `_generate_crate_method_wrapper`.
+        bare_def = bare ?
+            :($method_name($(arg_syms...)) = $method_name($struct_name, $(arg_syms...))) :
+            nothing
         quote
             $declaration
-            function $method_name($(arg_syms...))
+            function $method_name(::Type{$struct_name}, $(arg_syms...))
                 $body
             end
+            $bare_def
             export $method_name
         end
     else
@@ -2575,8 +2608,9 @@ function emit_crate_module_code(info::CrateInfo, lib_path::String;
     end
 
     # Generate struct wrappers
+    colliding = _static_method_collisions(info)
     for s in info.julia_structs
-        code = _emit_struct_code(s; strict = strict)
+        code = _emit_struct_code(s; strict = strict, colliding = colliding)
         push!(lines, code)
         push!(lines, "")
     end
@@ -2790,7 +2824,8 @@ end
 
 Generate Julia code for a struct wrapper as a string.
 """
-function _emit_struct_code(info::RustStructInfo; strict::Symbol = FFI_STRICT[])
+function _emit_struct_code(info::RustStructInfo; strict::Symbol = FFI_STRICT[],
+                           colliding::Set{String} = Set{String}())
     struct_name = info.name
 
     lines = String[]
@@ -2828,7 +2863,7 @@ function _emit_struct_code(info::RustStructInfo; strict::Symbol = FFI_STRICT[])
 
     # Method wrappers
     for m in info.methods
-        code = _emit_method_code(info, m; strict = strict)
+        code = _emit_method_code(info, m; strict = strict, bare = !(m.name in colliding))
         push!(lines, code)
         push!(lines, "")
     end
@@ -2924,7 +2959,7 @@ end
 Generate Julia code for a method wrapper as a string.
 """
 function _emit_method_code(struct_info::RustStructInfo, method::RustMethod;
-                           strict::Symbol = FFI_STRICT[])
+                           strict::Symbol = FFI_STRICT[], bare::Bool = true)
     struct_name = struct_info.name
     method_name = method.name
     # Exported symbol (`rustcall_<Struct>_<method>`, #279); the per-method
@@ -2956,7 +2991,7 @@ function _emit_method_code(struct_info::RustStructInfo, method::RustMethod;
     alive_var = _generated_local("alive", method.arg_names)
     if method.return_kind === :py_result
         return _emit_py_result_method_code(struct_info, method, arg_syms, converted_args_str,
-                                           wrapper_name; prologue, preserve_str, strict)
+                                           wrapper_name; prologue, preserve_str, strict, bare)
     end
     method_label = "$(struct_name)::$(method_name)"
     # `Result` / `Option` returns are lowered like a free function's (#268):
@@ -2975,7 +3010,7 @@ $(prologue)    $payload_target
     _guard_panic(nothing, $channel_var, "$method_label")
 $(_emit_payload_decode(plan, c_var, free_expr))"""
         return _emit_method_definition(struct_name, method, arg_syms, payload_body;
-                                       predef = plan.source)
+                                       predef = plan.source, bare = bare)
     end
     call = if method.returns_boxed_struct
         target = "$ptr_var, $channel_var, $free_var, $alive_var = " *
@@ -2996,15 +3031,16 @@ $(_emit_payload_decode(plan, c_var, free_expr))"""
 $(prologue)    $target
     _guard_panic($(_emit_preserved(preserve_str, call)), $channel_var, "$method_label")"""
 
-    return _emit_method_definition(struct_name, method, arg_syms, body)
+    return _emit_method_definition(struct_name, method, arg_syms, body; bare = bare)
 end
 
 # The `function ... end` (and `export`) wrapper shared by every method-emitting
 # branch, so a new return shape cannot forget the freed-object check or the
-# receiver argument. `predef` is emitted above the definition.
+# receiver argument. `predef` is emitted above the definition. `bare` says
+# whether a static method also gets its bare `name(args)` form (#323).
 function _emit_method_definition(struct_name::AbstractString, method::RustMethod,
                                  arg_syms::AbstractString, body::AbstractString;
-                                 predef::AbstractString = "")
+                                 predef::AbstractString = "", bare::Bool = true)
     method_name = method.name
     definition = if method.is_static && method.is_constructor
         """
@@ -3012,10 +3048,15 @@ function $struct_name($arg_syms)
 $body
 end"""
     elseif method.is_static
+        # Type-dispatched — `shout(Labeler, s)` for `Labeler::shout` — so it
+        # never shares a method table with a free function of the same name;
+        # the bare form only while nothing else defines it (#323).
+        comma_args = isempty(arg_syms) ? "" : ", $arg_syms"
+        bare_def = bare ? "\n$method_name($arg_syms) = $method_name($struct_name$comma_args)" : ""
         """
-function $method_name($arg_syms)
+function $method_name(::Type{$struct_name}$comma_args)
 $body
-end
+end$bare_def
 export $method_name"""
     else
         self_args = isempty(arg_syms) ? "" : ", $arg_syms"
@@ -3059,7 +3100,7 @@ function _emit_py_result_method_code(info::RustStructInfo, method::RustMethod,
                                      wrapper_name::String;
                                      prologue::AbstractString = "",
                                      preserve_str::AbstractString = "",
-                                     strict::Symbol = FFI_STRICT[])
+                                     strict::Symbol = FFI_STRICT[], bare::Bool = true)
     struct_name = info.name
     method_name = method.name
     ok_type_str, ok_slot_str, is_unit =
@@ -3096,10 +3137,14 @@ end
 """
 
     if method.is_static
+        # Type-dispatched, bare form only without a name collision (#323); see
+        # `_emit_method_definition`.
+        comma_args = isempty(arg_syms) ? "" : ", $arg_syms"
+        bare_def = bare ? "\n$method_name($arg_syms) = $method_name($struct_name$comma_args)" : ""
         return """$declaration
-function $method_name($arg_syms)
+function $method_name(::Type{$struct_name}$comma_args)
 $body
-end
+end$bare_def
 export $method_name"""
     end
     self_args = isempty(arg_syms) ? "" : ", $arg_syms"

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1356,8 +1356,12 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
         # `Labeler::shout` — so it can never share a method table with a free
         # function or another struct's static method of the same name (#323).
         # The bare `shout(s)` form is kept only while no such name exists.
+        # The delegator names its own arguments: an argument called like the
+        # method (`fn scale(scale)`) or like the struct would otherwise shadow
+        # the function or the type inside the forwarding body.
+        dargs = [Symbol("__rustcall_arg", i) for i in eachindex(arg_syms)]
         bare_def = bare ?
-            :($method_name($(arg_syms...)) = $method_name($struct_name, $(arg_syms...))) :
+            :($method_name($(dargs...)) = $method_name($struct_name, $(dargs...))) :
             nothing
         quote
             function $method_name(::Type{$struct_name}, $(arg_syms...))
@@ -1531,8 +1535,12 @@ function _generate_py_result_method_wrapper(info::RustStructInfo, method::RustMe
     if method.is_static
         # Type-dispatched, bare form only without a name collision (#323); see
         # `_generate_crate_method_wrapper`.
+        # The delegator names its own arguments: an argument called like the
+        # method (`fn scale(scale)`) or like the struct would otherwise shadow
+        # the function or the type inside the forwarding body.
+        dargs = [Symbol("__rustcall_arg", i) for i in eachindex(arg_syms)]
         bare_def = bare ?
-            :($method_name($(arg_syms...)) = $method_name($struct_name, $(arg_syms...))) :
+            :($method_name($(dargs...)) = $method_name($struct_name, $(dargs...))) :
             nothing
         quote
             $declaration
@@ -3052,7 +3060,11 @@ end"""
         # never shares a method table with a free function of the same name;
         # the bare form only while nothing else defines it (#323).
         comma_args = isempty(arg_syms) ? "" : ", $arg_syms"
-        bare_def = bare ? "\n$method_name($arg_syms) = $method_name($struct_name$comma_args)" : ""
+        # Own argument names in the delegator, so an argument called like the
+        # method or the struct cannot shadow them in the forwarding body.
+        dargs = join(("__rustcall_arg$i" for i in eachindex(method.arg_names)), ", ")
+        dcomma = isempty(dargs) ? "" : ", $dargs"
+        bare_def = bare ? "\n$method_name($dargs) = $method_name($struct_name$dcomma)" : ""
         """
 function $method_name(::Type{$struct_name}$comma_args)
 $body
@@ -3140,7 +3152,11 @@ end
         # Type-dispatched, bare form only without a name collision (#323); see
         # `_emit_method_definition`.
         comma_args = isempty(arg_syms) ? "" : ", $arg_syms"
-        bare_def = bare ? "\n$method_name($arg_syms) = $method_name($struct_name$comma_args)" : ""
+        # Own argument names in the delegator, so an argument called like the
+        # method or the struct cannot shadow them in the forwarding body.
+        dargs = join(("__rustcall_arg$i" for i in eachindex(method.arg_names)), ", ")
+        dcomma = isempty(dargs) ? "" : ", $dargs"
+        bare_def = bare ? "\n$method_name($dargs) = $method_name($struct_name$dcomma)" : ""
         return """$declaration
 function $method_name(::Type{$struct_name}$comma_args)
 $body

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -236,9 +236,12 @@ macro rust_str(code)
     cargo_env = cfg_mode === :cargo ? _cargo_cfg_env_key() : nothing
     expanded = expand_inline(code_str; cfg = cfg_mode, cfg_text = cfg_text)
     struct_infos = manifest_struct_infos(expanded.manifest)
-    julia_defs = [emit_julia_definitions(info) for info in struct_infos]
-
     julia_func_signatures = manifest_function_signatures(expanded.manifest)
+    # A static method whose name a free function of this block (or another
+    # struct's static method) also has gets no bare form (#323).
+    colliding = _static_method_collisions(julia_func_signatures, struct_infos)
+    julia_defs = [emit_julia_definitions(info; colliding = colliding) for info in struct_infos]
+
     julia_func_wrappers = emit_julia_function_wrappers(julia_func_signatures)
     # The symbols this block exports, known at macro-expansion time. They are
     # recorded per *module* so that a wrapper resolves through the library its

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -256,12 +256,37 @@ function register_generic_struct_wrappers(info::RustStructInfo, expanded_source:
 end
 
 """
-    emit_julia_definitions(info::RustStructInfo)
+    _static_method_collisions(functions, structs) -> Set{String}
+
+The names a static (non-constructor) method shares with a free function or with
+another struct's static method, among the items one generated module (a
+`rust\"\"\"` block, or a crate) defines. Such a name gets no bare
+`name(args...)` form — only the type-dispatched `name(Struct, args...)` — so
+two definitions never overwrite each other (#323). Free functions always keep
+their bare name.
+"""
+function _static_method_collisions(functions, structs)
+    counts = Dict{String, Int}()
+    for func in functions
+        func.is_generic && continue
+        counts[func.name] = get(counts, func.name, 0) + 1
+    end
+    for s in structs, m in s.methods
+        (m.is_static && !m.is_constructor && isempty(m.skip_reason)) || continue
+        counts[m.name] = get(counts, m.name, 0) + 1
+    end
+    return Set{String}(name for (name, n) in counts if n > 1)
+end
+
+"""
+    emit_julia_definitions(info::RustStructInfo; colliding = Set{String}())
 
 Generate Julia code to define a corresponding mutable struct and its methods.
 Only generates definitions for structs marked with #[derive(JuliaStruct)] or #[julia].
+`colliding` is `_static_method_collisions` of the whole block: a static method
+whose name is in it gets no bare `name(args...)` form (#323).
 """
-function emit_julia_definitions(info::RustStructInfo)
+function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = Set{String}())
     # Only generate Julia definitions for structs with #[derive(JuliaStruct)]
     # This is set when #[julia] attribute is used (transformed to #[derive(JuliaStruct)])
     if !info.has_derive_julia_struct
@@ -513,14 +538,14 @@ function emit_julia_definitions(info::RustStructInfo)
             elseif m.return_kind === :result || m.return_kind === :option
                 push!(exprs, _inline_method_payload_wrapper(
                     info, m, fname, wrapper_name, esc_args, bindings, preserved,
-                    expanded_call_args; self = nothing))
+                    expanded_call_args; self = nothing, static_type = esc_struct))
             else
                 mc = ffi_return_contract(m.return_type; abi = m.return_abi,
                                          owner = struct_name_str)
                 if ffi_owned_string_return(mc)
                     free_fn = mc.free_symbol
                     push!(exprs, quote
-                        function $fname($(esc_args...))
+                        function $fname(::Type{$esc_struct}, $(esc_args...))
                             $(bindings...)
                             lib = get_current_library()
                             return GC.@preserve $(preserved...) _call_rust_owned_string(lib, $wrapper_name, $free_fn, $(expanded_call_args...))
@@ -528,7 +553,7 @@ function emit_julia_definitions(info::RustStructInfo)
                     end)
                 elseif ffi_borrowed_string_return(mc)
                     push!(exprs, quote
-                        function $fname($(esc_args...))
+                        function $fname(::Type{$esc_struct}, $(esc_args...))
                             $(bindings...)
                             lib = get_current_library()
                             return GC.@preserve $(preserved...) _call_rust_borrowed_string(lib, $wrapper_name, $(expanded_call_args...))
@@ -541,13 +566,21 @@ function emit_julia_definitions(info::RustStructInfo)
                     jl_ret_type = ffi_return_type_or_throw(m.return_type, m.return_abi,
                                                            _ffi_context(m, struct_name_str))
                     push!(exprs, quote
-                        function $fname($(esc_args...))
+                        function $fname(::Type{$esc_struct}, $(esc_args...))
                             $(bindings...)
                             lib = get_current_library()
                             return GC.@preserve $(preserved...) _call_rust_method(lib, $wrapper_name, C_NULL, $jl_ret_type, $(expanded_call_args...))
                         end
                     end)
                 end
+            end
+            # A static method dispatches on the type — `shout(Labeler, s)` —
+            # so it cannot share a method table with a free `#[julia] fn` of
+            # the block or another struct's static method; the bare `shout(s)`
+            # form is a delegator, emitted only while no such name exists
+            # (#323). Constructors are `Labeler(...)` and never collide.
+            if !is_ctor && !(m.name in colliding)
+                push!(exprs, :($fname($(esc_args...)) = $fname($esc_struct, $(esc_args...))))
             end
         elseif m.return_kind === :result || m.return_kind === :option
             push!(exprs, _inline_method_payload_wrapper(
@@ -730,7 +763,8 @@ that is the owner the release symbol comes from.
 """
 function _inline_method_payload_wrapper(info::RustStructInfo, m::RustMethod, fname,
                                         wrapper_name::AbstractString, esc_args, bindings,
-                                        preserved, call_args; self = nothing)
+                                        preserved, call_args; self = nothing,
+                                        static_type = nothing)
     ctx = _ffi_context(m, info.name)
     if m.return_kind === :result
         ok_t, ok_slot = ffi_payload_symbols(m.ok_type, m.ok_abi, ctx)
@@ -760,9 +794,12 @@ function _inline_method_payload_wrapper(info::RustStructInfo, m::RustMethod, fna
         $(decode(c, tgt))
     end
     if self === nothing
+        # A static method dispatches on the type (#323); the bare form, when
+        # there is one, is a delegator emitted by `emit_julia_definitions`.
+        static_type === nothing && throw(ArgumentError("a static method needs `static_type`"))
         inner = body(:(get_current_library()), (), preserved)
         return quote
-            function $fname($(esc_args...))
+            function $fname(::Type{$static_type}, $(esc_args...))
                 $inner
             end
         end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -580,7 +580,10 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
             # form is a delegator, emitted only while no such name exists
             # (#323). Constructors are `Labeler(...)` and never collide.
             if !is_ctor && !(m.name in colliding)
-                push!(exprs, :($fname($(esc_args...)) = $fname($esc_struct, $(esc_args...))))
+                # Hygienic (unescaped) argument names: an argument called like
+                # the method or the struct must not shadow them in the body.
+                dargs = [Symbol("__rustcall_arg", i) for i in eachindex(esc_args)]
+                push!(exprs, :($fname($(dargs...)) = $fname($esc_struct, $(dargs...))))
             end
         elseif m.return_kind === :result || m.return_kind === :option
             push!(exprs, _inline_method_payload_wrapper(

--- a/test/test_static_methods.jl
+++ b/test/test_static_methods.jl
@@ -1,0 +1,143 @@
+# Static `#[julia]` methods dispatch on the type (#323).
+#
+# A static method (no `self`) used to be bound as a bare Julia function named
+# after the method, so `Labeler::shout` and the crate's free `fn shout` defined
+# the same `shout(::Any)` twice: the second silently overwrote the first under
+# `@rust_crate`, and a module written by `write_bindings_to_file` could not be
+# precompiled at all ("Method overwriting is not permitted during Module
+# precompilation"). A static method is now `shout(Labeler, s)`, and it keeps the
+# bare `shout(s)` form only when no free function or other static method of the
+# crate has that name.
+
+using Test
+using RustCall
+using RustToolChain: cargo
+
+const SM_SAMPLE_CRATE = joinpath(dirname(@__DIR__), "examples", "sample_crate")
+
+const _SM_HAVE_CARGO = try
+    success(run(pipeline(`$(cargo()) --version`, devnull, devnull); wait = true))
+catch
+    false
+end
+
+@testset "Static methods dispatch on the type (#323)" begin
+    info = RustCall.scan_crate(SM_SAMPLE_CRATE)
+    colliding = RustCall._static_method_collisions(info)
+    # `fn shout(String)` and `Labeler::shout(&str)` share a name; `Divider::parse_scale`
+    # is the only `parse_scale`; constructors (`new`) never count.
+    @test "shout" in colliding
+    @test !("parse_scale" in colliding)
+    @test !("new" in colliding)
+
+    @testset "written module: one bare `shout`, a typed `Labeler` one" begin
+        code = RustCall.emit_crate_module_code(info, "/tmp/libsample.so")
+        # The free function keeps its bare name; the static method is typed and
+        # gets no bare form, so `shout(::Any)` is defined exactly once.
+        @test occursin("function shout(input)", code)
+        @test occursin("function shout(::Type{Labeler}, s)", code)
+        @test !occursin("shout(s) = shout(Labeler, s)", code)
+        @test count("\nfunction shout(", code) == 2   # `shout(input)` and `shout(::Type{Labeler}, s)`
+        # A static method that collides with nothing keeps both forms.
+        @test occursin("function parse_scale(::Type{Divider}, text)", code)
+        @test occursin("parse_scale(text) = parse_scale(Divider, text)", code)
+        # Constructors are untouched: `Labeler(count)`, not `new(...)`.
+        @test occursin("function Labeler(count)", code)
+        @test !occursin("function new(", code)
+    end
+
+    @testset "in-memory Expr template agrees" begin
+        labeler = only(filter(s -> s.name == "Labeler", info.julia_structs))
+        shout_m = only(filter(m -> m.name == "shout", labeler.methods))
+        # `string(::Expr)` prints the delegator as `shout(s) = begin … shout(Labeler, s) end`.
+        typed = string(RustCall._generate_crate_method_wrapper(labeler, shout_m; bare = false))
+        @test occursin("function shout(::Type{Labeler}, s)", typed)
+        @test !occursin("shout(s) = begin", typed)
+        with_bare = string(RustCall._generate_crate_method_wrapper(labeler, shout_m))
+        @test occursin("function shout(::Type{Labeler}, s)", with_bare)
+        @test occursin("shout(s) = begin", with_bare)
+        @test occursin("shout(Labeler, s)", with_bare)
+        # Constructors never dispatch on the type.
+        ctor = only(filter(m -> m.is_constructor, labeler.methods))
+        @test occursin("function Labeler(count)", string(RustCall._generate_crate_method_wrapper(labeler, ctor)))
+    end
+
+    @testset "inline rust\"\"\" path agrees" begin
+        if !RustCall.check_rustc_available()
+            @warn "rustc not available, skipping the inline #323 test"
+        else
+            # A free `twice` and a static `Yeller::twice` in one block, plus a
+            # static `thrice` that collides with nothing.
+            rust"""
+            #[julia]
+            fn twice(x: i32) -> i32 { x * 2 }
+
+            #[julia]
+            pub struct Yeller { pub level: i32 }
+
+            #[julia]
+            impl Yeller {
+                #[julia]
+                pub fn new(level: i32) -> Self { Yeller { level } }
+                #[julia]
+                pub fn twice(x: i32) -> i32 { x * 2 + 1 }
+                #[julia]
+                pub fn thrice(x: i32) -> i32 { x * 3 }
+            }
+            """
+            @test twice(Int32(5)) == 10                  # the free function, not overwritten
+            @test twice(Yeller, Int32(5)) == 11          # Yeller::twice
+            @test thrice(Yeller, Int32(5)) == 15         # typed form always
+            @test thrice(Int32(5)) == 15                 # bare form: no collision
+            # `twice`: the free function's bare method plus the typed static
+            # one, nothing overwritten; `thrice`: typed plus its bare delegator.
+            @test length(methods(twice)) == 2
+            @test length(methods(thrice)) == 2
+            y = Yeller(Int32(1))
+            @test y.level == 1
+        end
+    end
+
+    if !_SM_HAVE_CARGO || !RustCall.check_rustc_available()
+        @warn "cargo/rustc not available, skipping the behavioural #323 tests"
+    else
+        @testset "both `shout`s are callable, in memory" begin
+            bindings = @rust_crate SM_SAMPLE_CRATE name="StaticMethodBindings"
+            @test bindings.shout("hello") == "HELLO"                       # free fn (String)
+            @test bindings.shout(bindings.Labeler, "hi") == "HI"           # Labeler::shout (&str)
+            @test RustCall.unwrap(bindings.parse_scale(" 7 ")) == Int32(7)                 # bare form kept
+            @test RustCall.unwrap(bindings.parse_scale(bindings.Divider, " 7 ")) == Int32(7)
+            @test RustCall.is_err(bindings.parse_scale(bindings.Divider, "seven"))
+        end
+
+        @testset "a written module with both `shout`s loads without overwriting" begin
+            output_dir = mktempdir()
+            output_path = joinpath(output_dir, "StaticBindings.jl")
+            try
+                RustCall.write_bindings_to_file(SM_SAMPLE_CRATE, output_path;
+                                                output_module_name = "StaticBindings")
+                content = read(output_path, String)
+                @test occursin("function shout(::Type{Labeler}, s)", content)
+                @test count("\nfunction shout(", content) == 2
+                # Loading the file defines every method once: with `--warn-overwrite`
+                # semantics this is what precompilation checks, and here it is
+                # asserted directly on the method tables.
+                sandbox = Module(:StaticSandbox)
+                Base.include(sandbox, output_path)
+                mod = Base.invokelatest(getfield, sandbox, :StaticBindings)
+                shout_f = Base.invokelatest(getfield, mod, :shout)
+                sigs = [m.sig for m in methods(shout_f)]
+                @test length(sigs) == 2
+                @test any(s -> s.parameters[2] === Type{Base.invokelatest(getfield, mod, :Labeler)}, sigs)
+                @test Base.invokelatest(shout_f, "hey") == "HEY"
+                @test Base.invokelatest(shout_f, Base.invokelatest(getfield, mod, :Labeler), "hey") == "HEY"
+                try
+                    RustCall.unload_library(Base.invokelatest(getfield, mod, :_LIB_NAME); close = true)
+                catch
+                end
+            finally
+                rm(output_dir; recursive = true, force = true)
+            end
+        end
+    end
+end

--- a/test/test_static_methods.jl
+++ b/test/test_static_methods.jl
@@ -38,9 +38,11 @@ end
         @test occursin("function shout(::Type{Labeler}, s)", code)
         @test !occursin("shout(s) = shout(Labeler, s)", code)
         @test count("\nfunction shout(", code) == 2   # `shout(input)` and `shout(::Type{Labeler}, s)`
-        # A static method that collides with nothing keeps both forms.
+        # A static method that collides with nothing keeps both forms; the
+        # delegator names its own arguments so that an argument called like
+        # the method or the struct cannot shadow them (#325 review).
         @test occursin("function parse_scale(::Type{Divider}, text)", code)
-        @test occursin("parse_scale(text) = parse_scale(Divider, text)", code)
+        @test occursin("parse_scale(__rustcall_arg1) = parse_scale(Divider, __rustcall_arg1)", code)
         # Constructors are untouched: `Labeler(count)`, not `new(...)`.
         @test occursin("function Labeler(count)", code)
         @test !occursin("function new(", code)
@@ -49,14 +51,15 @@ end
     @testset "in-memory Expr template agrees" begin
         labeler = only(filter(s -> s.name == "Labeler", info.julia_structs))
         shout_m = only(filter(m -> m.name == "shout", labeler.methods))
-        # `string(::Expr)` prints the delegator as `shout(s) = begin … shout(Labeler, s) end`.
+        # `string(::Expr)` prints the delegator as
+        # `shout(__rustcall_arg1) = begin … shout(Labeler, __rustcall_arg1) end`.
         typed = string(RustCall._generate_crate_method_wrapper(labeler, shout_m; bare = false))
         @test occursin("function shout(::Type{Labeler}, s)", typed)
-        @test !occursin("shout(s) = begin", typed)
+        @test !occursin("shout(__rustcall_arg1) = begin", typed)
         with_bare = string(RustCall._generate_crate_method_wrapper(labeler, shout_m))
         @test occursin("function shout(::Type{Labeler}, s)", with_bare)
-        @test occursin("shout(s) = begin", with_bare)
-        @test occursin("shout(Labeler, s)", with_bare)
+        @test occursin("shout(__rustcall_arg1) = begin", with_bare)
+        @test occursin("shout(Labeler, __rustcall_arg1)", with_bare)
         # Constructors never dispatch on the type.
         ctor = only(filter(m -> m.is_constructor, labeler.methods))
         @test occursin("function Labeler(count)", string(RustCall._generate_crate_method_wrapper(labeler, ctor)))
@@ -67,7 +70,10 @@ end
             @warn "rustc not available, skipping the inline #323 test"
         else
             # A free `twice` and a static `Yeller::twice` in one block, plus a
-            # static `thrice` that collides with nothing.
+            # static `thrice` that collides with nothing — whose argument is
+            # named like the method, and a `Yeller`-named argument on `level`:
+            # neither may shadow the function or the type in the bare
+            # delegator (#325 review).
             rust"""
             #[julia]
             fn twice(x: i32) -> i32 { x * 2 }
@@ -82,13 +88,17 @@ end
                 #[julia]
                 pub fn twice(x: i32) -> i32 { x * 2 + 1 }
                 #[julia]
-                pub fn thrice(x: i32) -> i32 { x * 3 }
+                pub fn thrice(thrice: i32) -> i32 { thrice * 3 }
+                #[julia]
+                pub fn level_of(Yeller: i32) -> i32 { Yeller }
             }
             """
             @test twice(Int32(5)) == 10                  # the free function, not overwritten
             @test twice(Yeller, Int32(5)) == 11          # Yeller::twice
             @test thrice(Yeller, Int32(5)) == 15         # typed form always
-            @test thrice(Int32(5)) == 15                 # bare form: no collision
+            @test thrice(Int32(5)) == 15                 # bare form: no collision, no shadowing
+            @test level_of(Yeller, Int32(7)) == 7
+            @test level_of(Int32(7)) == 7
             # `twice`: the free function's bare method plus the typed static
             # one, nothing overwritten; `thrice`: typed plus its bare delegator.
             @test length(methods(twice)) == 2


### PR DESCRIPTION
## Summary

A static `#[julia]` method (no `self`, not a constructor) was bound as a **bare** Julia function named after the method, so `Labeler::shout` and the crate's free `fn shout` in `examples/sample_crate` both defined `shout(::Any)`: under `@rust_crate` the second silently overwrote the first, and a module written by `write_bindings_to_file` could not be precompiled at all (`Method overwriting is not permitted during Module precompilation`) — which is how it surfaced, when giving the sample crate a Julia package.

A static method now dispatches on the type, the Julia spelling of `Labeler::shout`:

```julia
shout(Labeler, "hi")        # always
shout("hi")                 # only while no free function / other static is called `shout`
```

The bare form is a one-line delegator, emitted only when the name is unique among the module's free functions and static methods (`_static_method_collisions`), so every existing non-colliding call keeps working and a free function always keeps its bare name. Constructors are untouched (`Labeler(count)`).

Both generators follow the rule:

- **crate bindings** (`src/crate_bindings.jl`): the `Expr` template and the source-text template, including their `Result`/`Option` and `PyResult` variants, take `bare`; `generate_crate_struct_wrappers` and `emit_crate_module_code` compute the collision set from the `CrateInfo`.
- **inline `rust"""`** (`src/structs.jl`, `src/ruststr.jl`): the four static branches of `emit_julia_definitions` (owned string, borrowed string, plain, `Result`/`Option` payload) emit the typed form; the block's free functions and structs give the collision set.

The fixture crate is unchanged: `examples/sample_crate` now binds both `shout`s.

## Tests

`test/test_static_methods.jl` (new, auto-discovered):

| criterion (#323) | test |
| --- | --- |
| a crate with a free `fn shout` and a `Struct::shout` static method binds both, in memory | `bindings.shout("hello") == "HELLO"` (free) and `bindings.shout(bindings.Labeler, "hi") == "HI"`; a non-colliding static (`Divider::parse_scale`) keeps both forms |
| … and in a written module that precompiles | `write_bindings_to_file` output defines `shout` exactly twice (`shout(input)`, `shout(::Type{Labeler}, s)`), no bare delegator; the file is `include`d and both methods are called — the method table has exactly two entries, i.e. nothing was overwritten |
| the inline path agrees | a `rust"""` block with a free `twice`, `Yeller::twice` and `Yeller::thrice`: `twice(5) == 10` (free, not overwritten), `twice(Yeller, 5) == 11`, `thrice(Yeller, 5)` and bare `thrice(5)`; `methods(twice)` and `methods(thrice)` have two entries each |
| source-level | `emit_crate_module_code` and `_generate_crate_method_wrapper(…; bare)` emit the typed form and the delegator only when asked; `_static_method_collisions(sample_crate)` is `{"shout"}` |
| docs | `docs/src/crate_bindings.md` "Static methods", `docs/src/struct_mapping.md` "Static Methods" |

Existing suites touched by the change (`test_crate_bindings`, `test_method_result_option`, `test_pyo3_wrapper`, `test_regressions`, `test_struct_examples`, `test_julia_attribute`, `test_docs_examples`) pass unchanged: their static-method calls are non-colliding and keep the bare form.

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
