### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-07
+
 ### Added
 - **The Pluto notebook `examples/pluto/hello.jl` runs in CI.** The `Examples`
   workflow gains a `Pluto - hello.jl` job that opens the notebook headlessly in
@@ -1030,6 +1032,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for Rust helpers library
 - Documentation examples tests
 
-[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/atelierarith/RustCall.jl/compare/6e98d5cb62c0a0ca8b2f894c6fe53af209d9d3ea...v0.2.0
 [0.1.0]: https://github.com/atelierarith/RustCall.jl/commit/6e98d5cb62c0a0ca8b2f894c6fe53af209d9d3ea

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustCall"
 uuid = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

Release preparation for **v0.2.1**, a patch release on top of 0.2.0: `Project.toml` goes to `0.2.1`, the CHANGELOG's `[Unreleased]` section becomes `[0.2.1] - <date>` with a fresh empty `[Unreleased]` above it, and the compare links are updated. Nothing else changes.

No breaking changes. Contents of 0.2.1:

- static `#[julia]` methods dispatch on the type and no longer overwrite a free function of the same name (#323, PR #325) — additive for every non-colliding call;
- Julia packages beside the sample crates, `examples/SampleCrate.jl` and `examples/SampleCratePyO3.jl` (PR #328), plus the `Examples` CI workflow (#324) and, if merged in time, the Pluto notebook CI job (#326).

## Merge order

Merges **last**, after every PR whose entry belongs to 0.2.1 (currently #328; #326 if it lands first). Before merging: rebase onto `origin/main`, move any entry that landed under the new empty `[Unreleased]` into `[0.2.1]`, set the date to the merge day, re-request review, merge on green.

## After the merge

Comment on issue #229:

```
@JuliaRegistrator register

Release notes:

No breaking changes; see the changelog, section 0.2.1.
…
```

(The General AutoMerge bot requires the words "breaking" or "changelog" in the notes.) TagBot then creates `v0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
