### PR TITLE
examples/SampleCratePyO3Only.jl: a PyO3-only crate bound through the generated wrapper

### DIFF
--- a/.github/workflows/Examples.yml
+++ b/.github/workflows/Examples.yml
@@ -37,8 +37,20 @@ jobs:
           - MyExample.jl
           - SampleCrate.jl
           - SampleCratePyO3.jl
+          - SampleCratePyO3Only.jl
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v5
+        # SampleCratePyO3Only.jl binds a PyO3-only crate through RustCall's
+        # generated wrapper crate, and pyo3 is a mandatory dependency of that
+        # crate, so the wrapper links libpython (link plan `:link_libpython`):
+        # its build needs an interpreter whose library directory RustCall can
+        # find. Install one before Julia runs and pin it with PYO3_PYTHON
+        # below, rather than trusting whatever `python3` the runner image has.
+        # Harmless for the other packages: their crates never link Python.
+        id: python
+        with:
+          python-version: '3.x'
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
@@ -52,6 +64,11 @@ jobs:
         # checkout (its compat allows it) and builds RustCall's helper library;
         # `Pkg.build()` runs the example's own deps/build.jl when it has one
         # (the written-bindings workflow); `Pkg.test()` is the check.
+        env:
+          # The interpreter pyo3 configures itself for and whose library
+          # directory the wrapper links against (docs/src/pyo3.md, "Which
+          # Python"). Only SampleCratePyO3Only.jl reads it.
+          PYO3_PYTHON: ${{ steps.python.outputs.python-path }}
         run: >
           julia --color=yes --project=examples/${{ matrix.package }} -e '
             using Pkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`examples/SampleCratePyO3Only.jl`**, a third example package: a Julia
+  package with a crate **written for PyO3 only** embedded under
+  `deps/sample_crate_pyo3_only` — no RustCall attribute anywhere, no
+  `juliacall_macros` dependency — bound through the wrapper crate RustCall
+  generates (`write_bindings_to_file`, [#275](https://github.com/AtelierArith/RustCall.jl/issues/275)
+  Phase 2). It shows `#[pyfunction]` / `#[pyclass(get_all, set_all)]` /
+  `#[new]` / `#[staticmethod]` bindings without `#[julia]`, `PyResult<T>`
+  arriving as `RustResult{T, String}` with the opaque
+  `RustCall.PYO3_OPAQUE_ERROR` and a Julia layer over it, and the
+  `:link_libpython` link plan: the wrapper links libpython, so the package
+  needs a Python interpreter to build (`PYO3_PYTHON` pins one). The
+  `Examples` workflow tests it with a `actions/setup-python` interpreter.
+
 ### Removed
 - **`#[julia_pyo3]`** ([#312](https://github.com/AtelierArith/RustCall.jl/issues/312)),
   deprecated in 0.2.0 (#275 Phase 3). The proc-macro is gone from

--- a/docs/src/project_guide.md
+++ b/docs/src/project_guide.md
@@ -20,6 +20,12 @@ This page collects repository-oriented information that no longer lives in the t
 - `examples/SampleCratePyO3.jl`: a Julia package with the dual Julia/Python
   crate `deps/sample_crate_pyo3` embedded in it; `deps/sample_crate_pyo3/main.py`
   is its Python consumer.
+- `examples/SampleCratePyO3Only.jl`: a Julia package with the **PyO3-only**
+  crate `deps/sample_crate_pyo3_only` embedded in it — no RustCall attribute
+  anywhere — bound through the wrapper crate RustCall generates
+  (`write_bindings_to_file`, #275 Phase 2; see [PyO3 Crates](pyo3.md)). pyo3 is
+  a mandatory dependency of that crate, so the wrapper links libpython and
+  building the package needs a Python interpreter (`PYO3_PYTHON` pins one).
 - `examples/pluto/hello.jl`: Pluto-oriented walkthrough. CI runs it headlessly with
   Pluto (`examples/pluto/run_notebook.jl`, the `Pluto - hello.jl` job of the
   `Examples` workflow) and fails when any cell errors.
@@ -28,13 +34,15 @@ Every `examples/*.jl` directory is a Julia package, and each is self-contained:
 the crate it binds lives under its own `deps/<crate>/`, in the layout the
 [Precompilation Support](precompilation.md) guide prescribes, and the only
 reference it makes outside its directory is the `juliacall_macros` path
-dependency (the proc-macro crate is not on crates.io yet). Run its tests against
-the RustCall of this checkout from the repository root:
+dependency (the proc-macro crate is not on crates.io yet; the PyO3-only crate
+has none, its generated wrapper being what depends on `juliacall_macros`). Run
+its tests against the RustCall of this checkout from the repository root:
 
 ```bash
 julia --project=examples/MyExample.jl -e 'using Pkg; Pkg.develop(path="."); Pkg.test()'
 julia --project=examples/SampleCrate.jl -e 'using Pkg; Pkg.develop(path="."); Pkg.test()'
 julia --project=examples/SampleCratePyO3.jl -e 'using Pkg; Pkg.develop(path="."); Pkg.test()'
+julia --project=examples/SampleCratePyO3Only.jl -e 'using Pkg; Pkg.develop(path="."); Pkg.test()'
 ```
 
 The Pluto notebook activates the repository root itself, so instantiate and build

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ Before running the examples, ensure you have:
 | [MyExample.jl](./MyExample.jl/) | Julia package using `rust""` string literal | Beginner | Inline Rust code, basic FFI |
 | [SampleCrate.jl](./SampleCrate.jl/) | Julia package with a Rust crate using `#[julia]` embedded under `deps/sample_crate/` | Intermediate | `#[julia]`, `@rust_crate`, `write_bindings_to_file`, Rust and Julia in separate files |
 | [SampleCratePyO3.jl](./SampleCratePyO3.jl/) | Julia package with a dual Julia/Python crate embedded under `deps/sample_crate_pyo3/` | Advanced | PyO3 integration, feature flags |
+| [SampleCratePyO3Only.jl](./SampleCratePyO3Only.jl/) | Julia package with a **PyO3-only** crate (no RustCall attribute) embedded under `deps/sample_crate_pyo3_only/`, bound through RustCall's generated wrapper crate | Advanced | `#[pyfunction]` / `#[pyclass]` without `#[julia]`, `PyResult` → `RustResult`, `:link_libpython` (needs a Python interpreter to build) |
 | [pluto/hello.jl](./pluto/hello.jl) | Pluto notebook with a `// cargo-deps:` block | Beginner | Inline Rust in Pluto, run headlessly in CI |
 
 Every `*.jl` directory is a Julia package: `Pkg.test()` runs its tests, and the
@@ -31,11 +32,13 @@ Every `*.jl` directory is a Julia package: `Pkg.test()` runs its tests, and the
 guide prescribes), and no Julia file contains Rust source. The only reference an
 example makes outside its own directory is the `juliacall_macros` path
 dependency in its `Cargo.toml`, because the proc-macro crate is not on crates.io
-yet. (RustCall's own test suite uses separate fixture crates under
-`test/fixtures/`, not the examples.)
+yet — and `SampleCratePyO3Only.jl` makes none at all: its crate depends on pyo3
+alone, and the wrapper crate RustCall generates for it is what depends on
+`juliacall_macros`. (RustCall's own test suite uses separate fixture crates
+under `test/fixtures/`, not the examples.)
 
 ```bash
-# any of MyExample.jl, SampleCrate.jl, SampleCratePyO3.jl
+# any of MyExample.jl, SampleCrate.jl, SampleCratePyO3.jl, SampleCratePyO3Only.jl
 cd examples/SampleCrate.jl
 julia --project=. -e 'using Pkg; Pkg.develop(path="../.."); Pkg.test()'
 ```
@@ -187,6 +190,47 @@ import sample_crate_pyo3 as m
 m.add(2, 3)  # => 5
 ```
 
+### SampleCratePyO3Only.jl
+
+A Julia package with a Rust crate embedded under `deps/sample_crate_pyo3_only/`
+that was **written for PyO3 only**: no `#[julia]`, no `juliacall_macros`
+dependency, just `#[pyfunction]`, `#[pyclass]`, `#[pymethods]` and a
+`#[pymodule]`. RustCall binds it without changing it ([#275](https://github.com/AtelierArith/RustCall.jl/issues/275)
+Phase 2): `write_bindings_to_file` scans the `pub` items PyO3 exposes,
+generates a wrapper crate that depends on the crate, builds it and writes the
+bindings of that wrapper. This is the shape you have when the crate is not
+yours to annotate.
+
+**Features demonstrated:**
+- Binding a PyO3 crate with no RustCall attribute anywhere, through the generated wrapper crate
+- `PyResult<T>` → `RustResult{T, String}` with the opaque error `RustCall.PYO3_OPAQUE_ERROR`, and a Julia layer (`parse_int`) that turns it into a value or an `ArgumentError`
+- `#[new]` as the constructor, `#[staticmethod]` as a module-level function (`origin()` / `origin(Point)`), `#[pyclass(get_all, set_all)]` fields as properties, `&self` / `&mut self` / `String` / `PyResult` methods
+- The link plan: pyo3 is a mandatory dependency, so the wrapper links libpython (`:link_libpython`)
+
+**The Python requirement:** building this package needs a Python interpreter
+whose library directory RustCall can find (`PYO3_PYTHON=/path/to/python3` pins
+one; `RUSTCALL_PYTHON_LIBDIR` overrides the directory; on Windows the
+interpreter's `python3xy.dll` is preloaded by full path). No Python code runs:
+the wrapper only links the library pyo3 refers to. The `Examples` workflow
+installs one with `actions/setup-python` before Julia runs.
+
+**How to use from Julia:**
+```bash
+cd examples/SampleCratePyO3Only.jl
+julia --project=. -e 'using Pkg; Pkg.develop(path="../.."); Pkg.test()'
+```
+```julia
+using SampleCratePyO3Only
+add(Int32(2), Int32(3))                      # 5
+p = Point(3.0, 4.0); norm(p)                 # 5.0
+parse_int("42")                              # 42; parse_int("x") throws ArgumentError
+SampleCratePyO3Only.Bindings.parse("x").value == RustCall.PYO3_OPAQUE_ERROR   # true
+```
+
+`RustCall.scan_report("examples/SampleCratePyO3Only.jl/deps/sample_crate_pyo3_only")`
+prints what the wrapper exports and what it skips (only the `#[pymodule]`
+initializer), and the link plan.
+
 ### pluto/hello.jl
 
 A [Pluto](https://plutojl.org/) notebook that compiles a `rust"""..."""` block with a
@@ -235,7 +279,12 @@ We recommend learning RustCall.jl in this order:
    - Understand feature flags for conditional compilation
    - See how to share core logic between languages
 
-4. **Read the documentation**
+4. **Explore SampleCratePyO3Only.jl** (optional)
+   - Bind a PyO3 crate you cannot annotate: RustCall's generated wrapper crate
+   - See what `PyResult<T>` becomes, and why its error is opaque
+   - Understand the link plan and the Python requirement of `:link_libpython`
+
+5. **Read the documentation**
    - [Tutorial](../docs/src/tutorial.md)
    - [Crate Bindings (Phase 6)](../docs/src/crate_bindings.md)
    - [Troubleshooting](../docs/src/troubleshooting.md)

--- a/examples/SampleCratePyO3Only.jl/.gitignore
+++ b/examples/SampleCratePyO3Only.jl/.gitignore
@@ -1,0 +1,10 @@
+# Written by deps/build.jl (Pkg.build("SampleCratePyO3Only")): the generated
+# bindings module and the compiled wrapper library it loads.
+/src/generated/
+/deps/lib/
+# Cargo's output for the embedded crate (the generated wrapper crate is built
+# under it too).
+/deps/sample_crate_pyo3_only/target/
+/deps/sample_crate_pyo3_only/Cargo.lock
+/deps/build.log
+/Manifest.toml

--- a/examples/SampleCratePyO3Only.jl/Project.toml
+++ b/examples/SampleCratePyO3Only.jl/Project.toml
@@ -1,0 +1,18 @@
+name = "SampleCratePyO3Only"
+uuid = "954b05db-f9a7-4d81-a54e-6e67bd52548d"
+version = "0.1.0"
+authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
+
+[deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
+
+[compat]
+julia = "1.12"
+RustCall = "0.2"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/examples/SampleCratePyO3Only.jl/README.md
+++ b/examples/SampleCratePyO3Only.jl/README.md
@@ -1,0 +1,149 @@
+# SampleCratePyO3Only.jl
+
+A Julia **package** with the Rust crate [`deps/sample_crate_pyo3_only`](./deps/sample_crate_pyo3_only/)
+embedded in it: a crate **written for PyO3 only**. There is no RustCall
+attribute anywhere in it — no `#[julia]`, no `juliacall_macros` dependency —
+just `#[pyfunction]`, `#[pyclass]` and `#[pymethods]`, the way its author
+wrote it for Python. RustCall binds it as is
+([#275](https://github.com/AtelierArith/RustCall.jl/issues/275) Phase 2): the
+build step scans the `pub` items PyO3 exposes, generates a **wrapper crate**
+that depends on the crate and exports one `extern "C"` entry point per item,
+builds that wrapper, and writes its bindings. This package is that binding.
+
+The two other example packages show the other shapes: `../SampleCrate.jl` is a
+crate with `#[julia]`, `../SampleCratePyO3.jl` a crate with `#[julia]` *and*
+PyO3 attributes on one definition. This one is what you have when the crate is
+not yours to annotate.
+
+The example is **self-contained**: everything it builds and tests is inside
+this directory. The crate itself refers to nothing outside it; the wrapper
+crate RustCall generates depends on `juliacall_macros` from this checkout, and
+is written under the crate's own `target/`.
+
+## Layout: Rust and Julia in separate files
+
+```
+SampleCratePyO3Only.jl/
+├── Project.toml
+├── deps/
+│   ├── build.jl                      # Pkg.build: generate + build the wrapper crate, write the bindings
+│   ├── sample_crate_pyo3_only/       # Rust: a PyO3 crate, untouched
+│   │   ├── Cargo.toml                #   pyo3 mandatory, `crate-type = ["rlib"]`, no RustCall dependency
+│   │   └── src/lib.rs                #   #[pyfunction], #[pyclass], #[pymethods], #[pymodule] — no #[julia]
+│   └── lib/                          # the compiled wrapper library (git-ignored)
+├── src/
+│   ├── SampleCratePyO3Only.jl        # hand-written Julia
+│   └── generated/Bindings.jl         # written by deps/build.jl (git-ignored)
+└── test/runtests.jl                  # Pkg.test
+```
+
+## The Python requirement
+
+pyo3 is a plain **mandatory** dependency of the crate
+(`default-features = false, features = ["macros"]`), which is what most PyO3
+crates look like: pyo3's inner attributes (`#[new]`, `#[staticmethod]`,
+`#[pyo3(get, set)]`, ...) cannot be put behind `#[cfg_attr(feature = ...)]`, so
+a class always needs pyo3 in the graph. Any build whose graph contains pyo3
+links libpython, so RustCall's link plan for this crate is **`:link_libpython`**
+(`RustCall.pyo3_link_plan("deps/sample_crate_pyo3_only").mode`), and building
+this package needs a **Python interpreter** whose library directory RustCall
+can find:
+
+- by default the `python3` (or `python`) on `PATH` is asked for its library
+  directory, which becomes the linker search path and, on Unix, an rpath
+  recorded in the wrapper library;
+- `PYO3_PYTHON=/path/to/python3` pins a specific interpreter (a virtual
+  environment, a Conda one); `RUSTCALL_PYTHON_LIBDIR` overrides the directory
+  outright;
+- on **Windows** there is no rpath: the generated module records the
+  interpreter's `python3xy.dll` by full path and preloads it before the wrapper,
+  so the DLL need not be on `PATH`.
+
+The interpreter — its path and what it reports about itself — is part of the
+wrapper's artifact identity, so switching Pythons rebuilds the wrapper rather
+than reusing one configured for the other. The details, and the two other link
+plan modes (`:python_free`, `:unlinkable`), are in RustCall's `docs/src/pyo3.md`.
+
+No Python is *called*: the wrapper never initializes an interpreter, it only
+links the library pyo3 refers to. The `Examples` workflow installs one with
+`actions/setup-python` before Julia runs.
+
+## Run the tests
+
+```bash
+cd examples/SampleCratePyO3Only.jl
+julia --project=. -e 'using Pkg; Pkg.develop(path="../.."); Pkg.test()'
+```
+
+`Pkg.develop(path="../..")` uses the RustCall of this checkout; with a
+registered RustCall, `Pkg.instantiate()` is enough. A fresh checkout needs no
+manual build step: loading the package generates `src/generated/Bindings.jl`
+once. After editing the crate, `Pkg.build("SampleCratePyO3Only")` regenerates
+it.
+
+The same tests run in CI (the `Examples` workflow, job
+`Example - SampleCratePyO3Only.jl`).
+
+## Usage
+
+```julia
+using SampleCratePyO3Only
+
+add(Int32(2), Int32(3))      # 5           — a #[pyfunction]
+shout("hello")               # "HELLO!"    — String in, String out
+
+p = Point(3.0, 4.0)          # #[new]
+p.x, p.y                     # 3.0, 4.0    — #[pyclass(get_all, set_all)]
+norm(p)                      # 5.0         — a &self method
+translate(p, 1.0, 2.0)       # mutates p → (4.0, 6.0); a &mut self method
+label(p)                     # "(4, 6)"    — a String-returning method
+origin()                     # Point(0, 0) — a #[staticmethod]; also origin(Point)
+distance(p, origin())        # a Julia-side convenience
+```
+
+### What `PyResult<T>` becomes
+
+`parse(s) -> PyResult<i32>` in Rust is `RustResult{Int32, String}` in Julia,
+and the `Err` payload is always the same fixed sentence:
+
+```julia
+r = SampleCratePyO3Only.Bindings.parse("42")          # RustResult{Int32, String}(true, 42)
+bad = SampleCratePyO3Only.Bindings.parse("forty-two")
+RustCall.is_err(bad)                                  # true
+bad.value == RustCall.PYO3_OPAQUE_ERROR               # true
+# "PyErr (Python-side error; message unavailable without an interpreter)"
+```
+
+That is deliberate: creating and dropping a `PyErr` needs no interpreter, but
+*rendering* one does, so the generated code never looks at it. The Julia layer
+in `src/SampleCratePyO3Only.jl` turns it into something idiomatic:
+
+```julia
+parse_int("42")              # 42::Int32
+parse_int("forty-two")       # throws ArgumentError
+```
+
+(`parse` itself is not re-exported, because that would shadow `Base.parse`;
+reach it as `SampleCratePyO3Only.Bindings.parse`.) The same lowering applies to
+a `PyResult` *method*: `scaled(p, 2.0)` is `RustResult{Float64, String}`.
+
+## Notes
+
+- **`juliacall_macros` is not needed by the crate.** `deps/sample_crate_pyo3_only/Cargo.toml`
+  depends on pyo3 and nothing else. The wrapper crate RustCall generates does
+  depend on `juliacall_macros`, from this checkout — that is where the
+  `extern "C"` entry points, the string ABI and the panic channel come from —
+  but that is RustCall's business, not the crate's.
+- **What a PyO3 crate needs to be wrappable**: every item Julia should see must
+  be `pub` (pyo3 does not need that; a wrapper crate compiled outside the crate
+  does), the `[lib]` must offer an `rlib` target (`["cdylib", "rlib"]` for a
+  real extension module), and pyo3's `extension-module` feature must not be on
+  unconditionally (that build cannot be loaded outside Python: link plan
+  `:unlinkable`). `RustCall.scan_report("deps/sample_crate_pyo3_only")` lists
+  what the wrapper exports and, for what it skips, why — here only the
+  `#[pymodule]` initializer.
+- `deps/build.jl` is `RustCall.write_bindings_to_file(crate, "src/generated/Bindings.jl"; relative_lib_path = "../../deps/lib")`,
+  the same call as in `../SampleCrate.jl`; the wrapper path is chosen by the
+  crate's contents, not by an option.
+- RustCall's test suite uses its own, larger copy of this crate,
+  `test/fixtures/sample_crate_pyo3_only`; this example does not depend on it.

--- a/examples/SampleCratePyO3Only.jl/deps/build.jl
+++ b/examples/SampleCratePyO3Only.jl/deps/build.jl
@@ -1,0 +1,37 @@
+# Build step of SampleCratePyO3Only.jl: bind a PyO3-only crate for Julia and
+# write the bindings that `src/SampleCratePyO3Only.jl` includes.
+#
+# `Pkg.build("SampleCratePyO3Only")` runs this file (RustCall's "Precompilation
+# Support" workflow, docs/src/precompilation.md). The crate in
+# deps/sample_crate_pyo3_only carries no RustCall attribute, so
+# `write_bindings_to_file` takes the PyO3 wrapper path (#275 Phase 2,
+# docs/src/pyo3.md):
+#
+#   1. the crate is scanned for the `pub` items PyO3 exposes, and a wrapper
+#      crate that depends on it is generated under the crate's own `target/`;
+#   2. `cargo build --release` of that wrapper. pyo3 is a mandatory dependency
+#      of the crate, so the wrapper links libpython (link plan
+#      `:link_libpython`): the build needs a Python interpreter whose library
+#      directory RustCall can find — `PYO3_PYTHON` pins one;
+#   3. the built library is copied to deps/lib/;
+#   4. src/generated/Bindings.jl is written with a path relative to itself.
+#
+# Nothing in deps/sample_crate_pyo3_only is touched.
+
+using RustCall
+
+const CRATE_DIR = joinpath(@__DIR__, "sample_crate_pyo3_only")
+const BINDINGS_PATH = joinpath(@__DIR__, "..", "src", "generated", "Bindings.jl")
+
+isdir(CRATE_DIR) || error("Rust crate not found at $(CRATE_DIR)")
+
+mkpath(dirname(BINDINGS_PATH))
+RustCall.write_bindings_to_file(
+    CRATE_DIR,
+    BINDINGS_PATH;
+    output_module_name = "Bindings",
+    build_release = true,
+    relative_lib_path = joinpath("..", "..", "deps", "lib"),
+)
+
+@info "SampleCratePyO3Only: bindings written" BINDINGS_PATH

--- a/examples/SampleCratePyO3Only.jl/deps/sample_crate_pyo3_only/Cargo.toml
+++ b/examples/SampleCratePyO3Only.jl/deps/sample_crate_pyo3_only/Cargo.toml
@@ -1,0 +1,32 @@
+# A crate written for PyO3 only: it knows nothing about RustCall and carries no
+# RustCall attribute anywhere, and it does not depend on `juliacall_macros`.
+# RustCall binds it anyway (#275 Phase 2): `write_bindings_to_file` in
+# ../build.jl generates a *second* crate that depends on this one, builds that,
+# and binds the result. Nothing in this directory is changed for Julia's sake.
+#
+# pyo3 is a plain mandatory dependency with `default-features = false,
+# features = ["macros"]`, which is what most real PyO3 crates look like: making
+# pyo3 optional would need `#[cfg_attr(feature = "python", ...)]`, and that
+# does not work for pyo3's inner attributes (`new`, `staticmethod`, `getter`,
+# `setter`, `pyo3(get, set)`) because the outer macro runs before `cfg_attr`
+# expands. The price is that the generated wrapper links libpython (link plan
+# `:link_libpython`), so building this package needs a Python interpreter.
+#
+# Two things a PyO3 crate needs for RustCall to be able to wrap it:
+#
+#   * an `rlib` target, so the wrapper crate can depend on it as a Rust
+#     library — a crate that is `crate-type = ["cdylib"]` alone provides no
+#     linkable target (write `["cdylib", "rlib"]` for a real extension module);
+#   * `extension-module` NOT enabled unconditionally: a build whose pyo3 has
+#     that feature cannot be loaded outside a Python interpreter (link plan
+#     `:unlinkable`). Put it behind a feature maturin enables.
+[package]
+name = "sample_crate_pyo3_only"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+pyo3 = { version = "0.29", default-features = false, features = ["macros"] }

--- a/examples/SampleCratePyO3Only.jl/deps/sample_crate_pyo3_only/src/lib.rs
+++ b/examples/SampleCratePyO3Only.jl/deps/sample_crate_pyo3_only/src/lib.rs
@@ -1,0 +1,102 @@
+//! A small crate written for PyO3, and for PyO3 only.
+//!
+//! There is no RustCall attribute in this file and no RustCall dependency in
+//! `Cargo.toml`: this is what a PyO3 extension crate looks like before anyone
+//! thinks of Julia. RustCall binds it as is (#275 Phase 2): it scans the
+//! `pub` items PyO3 exposes, generates a wrapper crate that depends on this
+//! one and exports one `extern "C"` entry point per item
+//! (`rustcall_<name>`, `rustcall_Point_<method>`, `Point_free`, ...), builds
+//! it, and binds the result. The Julia package around this crate
+//! (`SampleCratePyO3Only.jl`) is that binding.
+//!
+//! Two rules to keep a crate wrappable: every item Julia should see must be
+//! `pub` (pyo3 does not need that, a wrapper crate compiled outside does), and
+//! a class has **one** `#[pymethods]` block unless the crate enables pyo3's
+//! `multiple-pymethods` feature.
+
+use pyo3::prelude::*;
+
+/// A free function: `rustcall_add` in the wrapper, `add(a, b)` in Julia.
+#[pyfunction]
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+/// Strings cross as `(ptr, len)` pairs; the returned `String` is released
+/// through a generated `..._free_rust_string`.
+#[pyfunction]
+pub fn shout(s: String) -> String {
+    format!("{}!", s.to_uppercase())
+}
+
+/// `PyResult<T>` becomes `RustResult{T, String}` in Julia, with an *opaque*
+/// error: creating and dropping a `PyErr` needs no interpreter, but rendering
+/// one does, so the generated code never looks at it and Julia reports
+/// `RustCall.PYO3_OPAQUE_ERROR` instead of this message.
+#[pyfunction]
+pub fn parse(s: &str) -> PyResult<i32> {
+    s.trim()
+        .parse::<i32>()
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}
+
+/// A class: an opaque handle in Julia, freed by the generated `Point_free`,
+/// which runs this type's destructor. `get_all, set_all` exposes every `pub`
+/// field, so `p.x` and `p.x = 1.0` work in Julia as they do in Python.
+#[pyclass(get_all, set_all)]
+pub struct Point {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[pymethods]
+impl Point {
+    /// `#[new]` is the Julia constructor: `Point(3.0, 4.0)`.
+    #[new]
+    pub fn new(x: f64, y: f64) -> Self {
+        Point { x, y }
+    }
+
+    /// `#[staticmethod]`: a module-level Julia function, `origin()`.
+    #[staticmethod]
+    pub fn origin() -> Self {
+        Point { x: 0.0, y: 0.0 }
+    }
+
+    /// `&self` method: `norm(p)`.
+    pub fn norm(&self) -> f64 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+
+    /// `&mut self` method: `translate(p, dx, dy)` mutates `p` in place.
+    pub fn translate(&mut self, dx: f64, dy: f64) {
+        self.x += dx;
+        self.y += dy;
+    }
+
+    /// A `String`-returning method: an owned buffer, released by the wrapper.
+    pub fn label(&self) -> String {
+        format!("({}, {})", self.x, self.y)
+    }
+
+    /// A `PyResult` method: `RustResult{Float64, String}` on the Julia side,
+    /// with the same opaque error as `parse`.
+    pub fn scaled(&self, factor: f64) -> PyResult<f64> {
+        if factor.is_finite() {
+            Ok(self.norm() * factor)
+        } else {
+            Err(pyo3::exceptions::PyValueError::new_err("factor must be finite"))
+        }
+    }
+}
+
+/// The module initializer Python's importer calls. RustCall skips it: it means
+/// nothing outside an interpreter, and the scan says so.
+#[pymodule]
+fn sample_crate_pyo3_only(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(add, m)?)?;
+    m.add_function(wrap_pyfunction!(shout, m)?)?;
+    m.add_function(wrap_pyfunction!(parse, m)?)?;
+    m.add_class::<Point>()?;
+    Ok(())
+}

--- a/examples/SampleCratePyO3Only.jl/src/SampleCratePyO3Only.jl
+++ b/examples/SampleCratePyO3Only.jl/src/SampleCratePyO3Only.jl
@@ -1,0 +1,85 @@
+"""
+    SampleCratePyO3Only
+
+A Julia package with the Rust crate `deps/sample_crate_pyo3_only` embedded in
+it: a crate **written for PyO3 only**. It carries no RustCall attribute — no
+`#[julia]` anywhere — and does not depend on `juliacall_macros`; it is a PyO3
+extension crate as its author wrote it for Python. RustCall binds it anyway
+(#275 Phase 2): `deps/build.jl` runs `RustCall.write_bindings_to_file`, which
+scans the `pub` items PyO3 exposes, generates a **wrapper crate** that depends
+on the crate, builds it, and writes the bindings of that wrapper.
+
+The two halves live in separate files:
+
+- **Rust**: `deps/sample_crate_pyo3_only/src/lib.rs` — `#[pyfunction]`,
+  `#[pyclass]`, `#[pymethods]` and nothing else. No Julia file contains Rust
+  source, and no Rust file mentions Julia.
+- **Julia**: this file and `src/generated/Bindings.jl`, the generated wrapper's
+  binding, written by `deps/build.jl` (run `Pkg.build("SampleCratePyO3Only")`).
+
+The wrapper links libpython (pyo3 is a mandatory dependency of the crate, link
+plan `:link_libpython`), so building this package needs a Python interpreter;
+see `README.md`.
+
+Every exported name here is the Julia binding of the same-named PyO3 item,
+except `parse_int` and `distance`, which are Julia-side conveniences.
+"""
+module SampleCratePyO3Only
+
+using RustCall
+using RustCall: RustResult, is_ok, unwrap
+
+const _BINDINGS_FILE = joinpath(@__DIR__, "generated", "Bindings.jl")
+if !isfile(_BINDINGS_FILE)
+    # First use from a fresh checkout, before any
+    # `Pkg.build("SampleCratePyO3Only")`: run the build step now so that
+    # `using SampleCratePyO3Only` and `Pkg.test()` work without a manual step.
+    # `Pkg.build("SampleCratePyO3Only")` is still the way to regenerate after
+    # editing the Rust crate.
+    @info "SampleCratePyO3Only: no generated bindings yet; running deps/build.jl"
+    include(joinpath(@__DIR__, "..", "deps", "build.jl"))
+end
+include(_BINDINGS_FILE)
+# Explicit list: exactly the names this module re-exports unchanged. The
+# crate's `parse` is *not* among them — re-exporting it would shadow
+# `Base.parse` for every user of this package — so it is reached as
+# `Bindings.parse` by the `parse_int` wrapper below.
+using .Bindings: add, shout,
+                 Point, origin, norm, translate, label, scaled
+
+# Names the PyO3 crate exposes, re-exported unchanged: `#[pyfunction]`s ...
+export add, shout
+# ... and the `#[pyclass]` with its `#[new]`, `#[staticmethod]` and methods.
+export Point, origin, norm, translate, label, scaled
+
+# Julia-side conveniences defined below.
+export parse_int, distance
+
+"""
+    parse_int(s::AbstractString) -> Int32
+
+Parse an integer in Rust through the crate's `parse`, a `#[pyfunction]`
+returning `PyResult<i32>`. The wrapper cannot render a `PyErr` without a Python
+interpreter, so the generated binding returns `RustResult{Int32, String}` whose
+`Err` payload is always the fixed sentence `RustCall.PYO3_OPAQUE_ERROR`; this
+wrapper turns that into an `ArgumentError` naming the input instead.
+"""
+function parse_int(s::AbstractString)::Int32
+    r = Bindings.parse(String(s))
+    is_ok(r) || throw(ArgumentError("parse_int: not an integer: $(repr(s))"))
+    return unwrap(r)
+end
+
+"""
+    distance(p::Point, q::Point) -> Float64
+
+Euclidean distance between two points, computed from the fields
+`#[pyclass(get_all, set_all)]` exposes (`p.x`, `p.y` go through the generated
+getters) and the crate's `Point::norm`.
+"""
+function distance(p::Point, q::Point)::Float64
+    d = Point(p.x - q.x, p.y - q.y)
+    return norm(d)
+end
+
+end # module SampleCratePyO3Only

--- a/examples/SampleCratePyO3Only.jl/test/runtests.jl
+++ b/examples/SampleCratePyO3Only.jl/test/runtests.jl
@@ -1,0 +1,89 @@
+using SampleCratePyO3Only
+using RustCall: RustResult, RustError, is_ok, is_err, unwrap, PYO3_OPAQUE_ERROR
+using Test
+
+# Every binding below reaches a crate that has no RustCall attribute anywhere:
+# the module under test is the generated wrapper's binding (#275 Phase 2).
+@testset "SampleCratePyO3Only.jl" begin
+    @testset "#[pyfunction]" begin
+        @test add(Int32(2), Int32(3)) == 5
+        @test add(Int32(-1), Int32(1)) == 0
+        @test shout("hello") == "HELLO!"
+        @test shout("") == "!"
+    end
+
+    @testset "PyResult<i32> -> RustResult{Int32, String}, opaque error" begin
+        ok = SampleCratePyO3Only.Bindings.parse("42")
+        @test ok isa RustResult{Int32, String}
+        @test is_ok(ok)
+        @test unwrap(ok) == 42
+        @test SampleCratePyO3Only.Bindings.parse(" -7 ").value == -7
+
+        bad = SampleCratePyO3Only.Bindings.parse("not a number")
+        @test is_err(bad)
+        # The `PyErr` is never rendered (that needs an interpreter): the error
+        # payload is RustCall's fixed sentence, not pyo3's message.
+        @test bad.value == PYO3_OPAQUE_ERROR
+        @test !occursin("invalid digit", bad.value)
+
+        # The Julia layer: a value, or an ArgumentError naming the input.
+        @test parse_int("42") == 42
+        @test parse_int("42") isa Int32
+        @test_throws ArgumentError parse_int("not a number")
+        @test_throws ArgumentError parse_int("")
+    end
+
+    @testset "#[pyclass(get_all, set_all)] Point" begin
+        # `#[new]` is the constructor.
+        p = Point(3.0, 4.0)
+        @test p isa Point
+
+        # `#[staticmethod] origin` is a module-level function, in both forms
+        # the generator emits: typed and bare.
+        o = origin(Point)
+        @test o isa Point
+        @test (o.x, o.y) == (0.0, 0.0)
+        @test norm(origin()) == 0.0
+
+        # Fields, through the generated `rustcall_Point_get_x` / `_set_x`.
+        @test (p.x, p.y) == (3.0, 4.0)
+        @test propertynames(p) == (:x, :y)
+        p.x = 6.0
+        @test p.x == 6.0
+        p.y = 8                        # converted to the field's f64
+        @test p.y == 8.0
+        @test_throws ErrorException p.z
+        p.x, p.y = 3.0, 4.0
+
+        # `&self` and `&mut self` methods.
+        @test norm(p) == 5.0
+        translate(p, 1.0, 2.0)          # mutates in place
+        @test (p.x, p.y) == (4.0, 6.0)
+        translate(p, -1.0, -2.0)
+
+        # A `String`-returning method: the owned buffer comes back as a
+        # Julia String.
+        @test label(p) == "(3, 4)"
+
+        # A `PyResult` method, both ways.
+        good = scaled(p, 2.0)
+        @test good isa RustResult{Float64, String}
+        @test is_ok(good) && unwrap(good) == 10.0
+        bad = scaled(p, Inf)
+        @test is_err(bad)
+        @test bad.value == PYO3_OPAQUE_ERROR
+
+        # The Julia-side convenience.
+        @test distance(p, origin()) == 5.0
+        @test distance(Point(1.0, 1.0), Point(4.0, 5.0)) == 5.0
+    end
+
+    @testset "Point_free runs the Rust destructor" begin
+        p = Point(1.0, 2.0)
+        finalize(p)
+        # After `finalize`, the handle is gone and a call is refused rather
+        # than handed to Rust.
+        @test_throws RustError norm(p)
+        @test_throws RustError p.x
+    end
+end


### PR DESCRIPTION
## Summary

A third example package, `examples/SampleCratePyO3Only.jl`, in the exact shape of `SampleCrate.jl` and `SampleCratePyO3.jl`: a Julia package with a Rust crate embedded under `deps/`, `deps/build.jl` writing `src/generated/Bindings.jl` with `RustCall.write_bindings_to_file`, a "generate on first use" fallback in the module, `Pkg.test()` as the check.

The story of this one: **a crate written for PyO3 only** — no RustCall attribute anywhere, no `juliacall_macros` dependency, just `#[pyfunction]` / `#[pyclass]` / `#[pymethods]` / `#[pymodule]` — bound from Julia through the wrapper crate RustCall generates (#275 Phase 2). `write_bindings_to_file` takes the same path `@rust_crate` does: scan, generate the wrapper, build it under the link plan, bind the result. The other two examples show a crate you annotate; this is the shape you have when the crate is not yours to annotate.

The embedded crate is a trimmed copy of `test/fixtures/sample_crate_pyo3_only`: `add`, `shout`, `parse -> PyResult<i32>`, and a `Point` class (`#[pyclass(get_all, set_all)]`, `#[new]`, `#[staticmethod] origin`, `norm`, `translate(&mut self)`, a `String` method `label`, a `PyResult<f64>` method `scaled`), plus the `#[pymodule]` initializer a real crate has (skipped by the scan, and the README says why). The test-only items (`boom`, `dropped_points`, `describe(py)`, `private_add`, the set-only `scale` field, the `Drop` counter) are gone. pyo3 stays a **mandatory** dependency with `default-features = false, features = ["macros"]` and `crate-type = ["rlib"]` — that is the point of the example — so the link plan is `:link_libpython`.

```
SampleCratePyO3Only.jl/
├── Project.toml
├── deps/
│   ├── build.jl                      # Pkg.build: generate + build the wrapper crate, write the bindings
│   ├── sample_crate_pyo3_only/       # Rust: a PyO3 crate, untouched
│   │   ├── Cargo.toml                #   pyo3 mandatory, crate-type = ["rlib"], no RustCall dependency
│   │   └── src/lib.rs                #   #[pyfunction], #[pyclass], #[pymethods], #[pymodule] — no #[julia]
│   └── lib/                          # the compiled wrapper library (git-ignored)
├── src/
│   ├── SampleCratePyO3Only.jl        # hand-written Julia: re-exports, parse_int, distance
│   └── generated/Bindings.jl         # written by deps/build.jl (git-ignored)
└── test/runtests.jl                  # Pkg.test
```

The Julia layer re-exports the bound names (`parse` excepted — it would shadow `Base.parse`; it is reached as `Bindings.parse`), turns `parse`'s `RustResult{Int32, String}` into a value or an `ArgumentError` (`parse_int`), and adds `distance(p, q)` over the generated field getters and `norm`. The tests cover the free functions, `PyResult` ok/err (`is_err(r)` and `r.value == RustCall.PYO3_OPAQUE_ERROR`, and that pyo3's own message never leaks), the constructor, `origin(Point)` and bare `origin()` (both are generated), fields through `get_all, set_all` including the `Int -> f64` conversion on set, the methods, and that a finalized handle is refused with `RustError`.

## The Python requirement

pyo3 in the graph means the wrapper cdylib links libpython, so building this package needs a Python interpreter whose library directory RustCall can find: the `python3` on `PATH` by default, `PYO3_PYTHON` to pin one, `RUSTCALL_PYTHON_LIBDIR` to override the directory; on Windows the interpreter's `python3xy.dll` is preloaded by full path. No Python code runs. The package README has a section on this; `.github/workflows/Examples.yml` adds `actions/setup-python@v5` (`3.x`) before the Julia step for the whole matrix and pins `PYO3_PYTHON` to it — harmless for the other three packages, whose crates never link Python. The other jobs are unchanged.

Also: `examples/README.md` (table row, section, learning progression), `docs/src/project_guide.md` (Bundled Examples), CHANGELOG `### Added` under `## [Unreleased]`.

Link plan observed locally (macOS, Xcode's Python 3.9 framework): `mode = :link_libpython`, `resolved = true`, rpath `/Applications/Xcode.app/Contents/Developer/Library/Frameworks`. The scan wraps all 10 items and skips only the `#[pymodule]` initializer.

## Verification

| check | result |
| --- | --- |
| `cargo check` in `deps/sample_crate_pyo3_only` | ok |
| `RustCall.pyo3_link_plan(crate).mode` | `:link_libpython` (resolved) |
| `SampleCratePyO3Only.jl`: `rm -rf src/generated deps/lib; Pkg.develop; Pkg.build; Pkg.test` | 35/35 pass |
| `SampleCrate.jl`: same, fresh | pass |
| `SampleCratePyO3.jl`: same, fresh | pass |
| `scripts/lint_*.sh src` (all five) | OK |
| `julia --project=docs docs/make.jl` | exit 0 |

No file under `src/`, `deps/`, or `test/` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
