### PR TITLE
test_regressions: the #276 fake crate lives in a temp dir, not the test directory

### DIFF
--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -1841,7 +1841,13 @@ end
 @testset "#276: strict is threaded, not stashed in a global" begin
     unsupported = RustCall.RustFunctionSignature(
         "rc276_histogram", ["n"], ["u32"], "Vec<f64>", false, String[])
-    info = RustCall.CrateInfo("rc276_crate", ".", "0.1.0", RustCall.DependencySpec[],
+    # The fake crate lives in its own empty directory: the emitter walks the
+    # crate path, and `"."` (the test directory) holds `fixtures/*/target/`,
+    # whose rustc temp directories other workers of the parallel run create and
+    # remove under our feet — `readdir` then raised ENOENT instead of the
+    # `RustError` under test (flaky macOS CI on #334).
+    rc276_dir = mktempdir()
+    info = RustCall.CrateInfo("rc276_crate", rc276_dir, "0.1.0", RustCall.DependencySpec[],
                               [unsupported], RustCall.RustStructInfo[], String[])
 
     previous = RustCall.FFI_STRICT[]
@@ -1878,6 +1884,7 @@ end
         @test RustCall.FFI_STRICT[] === :none
     finally
         RustCall.FFI_STRICT[] = previous
+        rm(rc276_dir; recursive = true, force = true)
     end
 end
 


### PR DESCRIPTION
## Summary

`test_regressions.jl`'s "#276: strict is threaded, not stashed in a global" testset built a fake `CrateInfo` with path `"."`. `emit_crate_module_code` walks the crate path, and since #332 moved the fixtures under `test/`, `"."` (the test directory) contains `fixtures/*/target/`, whose rustc temp directories other workers of the parallel run create and delete concurrently — `readdir` raised `IOError: ENOENT` instead of the expected `RustError` (macOS job on #334, run 34141195428).

The fake crate now lives in a `mktempdir()` (removed in the testset's `finally`), so the walk sees an empty directory.

Full `Pkg.test()` green locally; `test_regressions.jl` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw