### PR TITLE
Crate scan attaches #[julia] impl blocks across modules (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Documentation that pointed `@rust_crate` at `examples/sample_crate*` now
   names the embedded crate or the fixture.
 
+### Fixed
+- **A `#[julia] impl` block in another module than its struct binds its methods**
+  ([#315](https://github.com/AtelierArith/RustCall.jl/issues/315)). The crate
+  scan matched an impl block only to a struct at the same file / module level,
+  so for `struct Gauge` in `lib.rs` and `impl crate::Gauge` in `ops.rs` the
+  proc-macro emitted `rustcall_Gauge_read` while the manifest listed `Gauge`
+  with no methods and the Julia module had no `read`. `rustcall-extract` now
+  scans the crate's module tree once for both `#[julia]` and PyO3 items
+  (`--crate-root`, which no longer takes FILE arguments), collects structs and
+  `#[julia] impl` blocks crate-wide and marries them through the resolver the
+  PyO3 scan already had (`crate::`, `super::`, `self::`, a `use`, a bare name);
+  the inline expander does the same within a `rust"""` block. The method
+  symbols follow the struct the header names, so the proc-macro now reads the
+  header (`impl super::Gauge` inside `#[julia] mod ops` is `rustcall_Gauge_read`,
+  not `rustcall_ops__Gauge_read`) and spells the struct in the wrapper the way
+  the header does, so nothing needs to be in scope next to the block. A block
+  whose header names no `#[julia]` struct, an ambiguous one, or one the
+  proc-macro would qualify differently from the struct fails the scan with the
+  header to write instead of being dropped; the crate-wide duplicate-symbol
+  check of #300 now runs inside the scan, within one file as much as across
+  files. The `#[julia_pyo3]` half of the issue is moot: that macro was removed
+  in v0.3.0 (#330).
+
 ## [0.2.1] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,8 +179,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proc-macro would qualify differently from the struct fails the scan with the
   header to write instead of being dropped; the crate-wide duplicate-symbol
   check of #300 now runs inside the scan, within one file as much as across
-  files. The `#[julia_pyo3]` half of the issue is moot: that macro was removed
-  in v0.3.0 (#330).
+  files. A header that resolves to a struct **without** `#[julia]` — the plain
+  `struct C` beside the block, which is what Rust resolves to — is refused with
+  the fix to make, never attached to a same-named annotated struct elsewhere.
+  A file reached only by a literal `include!("api.rs")` is scanned as part of
+  the including module, so items the proc-macro wraps there are in the manifest
+  too. The `#[julia_pyo3]` half of the issue is moot: that macro was removed
+  in v0.3.0 (#330). Known limitation: in a `rust"""` block a cross-module
+  method's signature must be in scope at the struct
+  ([#342](https://github.com/AtelierArith/RustCall.jl/issues/342)).
 
 ## [0.2.1] - 2026-09-07
 

--- a/deps/juliacall_macros/tests/cross_module_impl.rs
+++ b/deps/juliacall_macros/tests/cross_module_impl.rs
@@ -1,0 +1,145 @@
+//! A `#[julia] impl` block in another module than its struct (RustCall.jl
+//! #315): the method symbols follow the struct the header names —
+//! `rustcall_Gauge_read` for `impl super::Gauge` inside `#[julia] mod ops` —
+//! and the wrapper spells the struct the way the header does, so nothing needs
+//! to be in scope next to the block.
+
+#![allow(dead_code)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![allow(non_snake_case)]
+
+use juliacall_macros::julia;
+
+#[julia]
+pub struct Gauge {
+    pub value: i32,
+}
+
+#[julia]
+impl Gauge {
+    #[julia]
+    pub fn new(value: i32) -> Self {
+        Self { value }
+    }
+}
+
+// A marked child module: `super::Gauge` is the root struct.
+#[julia]
+pub mod ops {
+    #[julia]
+    impl super::Gauge {
+        #[julia]
+        pub fn read(&self) -> i32 {
+            self.value
+        }
+
+        #[julia]
+        pub fn bump(&mut self) {
+            self.value += 1;
+        }
+    }
+}
+
+// Through `crate::`, with a static constructor and a `String` return whose
+// buffer hangs off the struct's FFI name.
+#[julia]
+pub mod more {
+    #[julia]
+    impl crate::Gauge {
+        #[julia]
+        pub fn scaled(value: i32, factor: i32) -> Self {
+            Self {
+                value: value * factor,
+            }
+        }
+
+        #[julia]
+        pub fn label(&self) -> String {
+            format!("Gauge({})", self.value)
+        }
+    }
+}
+
+// An unmarked module: item-level expansion, a bare name brought in by `use`.
+pub mod plain {
+    use super::Gauge;
+    use juliacall_macros::julia;
+
+    #[julia]
+    impl Gauge {
+        #[julia]
+        pub fn halved(&self) -> Result<i32, String> {
+            if self.value % 2 == 0 {
+                Ok(self.value / 2)
+            } else {
+                Err(format!("{} is odd", self.value))
+            }
+        }
+    }
+}
+
+// A struct in a marked module, its block in a sibling marked module.
+#[julia]
+pub mod a {
+    #[julia]
+    pub struct C {
+        pub v: i32,
+    }
+
+    #[julia]
+    impl C {
+        #[julia]
+        pub fn new(v: i32) -> Self {
+            Self { v }
+        }
+    }
+}
+
+#[julia]
+pub mod b {
+    #[julia]
+    impl crate::a::C {
+        #[julia]
+        pub fn get(&self) -> i32 {
+            self.v
+        }
+    }
+}
+
+#[test]
+fn the_rust_items_are_untouched() {
+    let mut g = Gauge::new(4);
+    assert_eq!(g.read(), 4);
+    g.bump();
+    assert_eq!(g.label(), "Gauge(5)");
+    assert_eq!(Gauge::scaled(2, 3).read(), 6);
+    assert_eq!(a::C::new(7).get(), 7);
+}
+
+#[test]
+fn method_symbols_follow_the_struct_not_the_block() {
+    let p = rustcall_Gauge_new(4);
+    assert_eq!(ops::rustcall_Gauge_read(p), 4);
+    ops::rustcall_Gauge_bump(p);
+    assert_eq!(ops::rustcall_Gauge_read(p), 5);
+
+    let out = more::rustcall_Gauge_label(p);
+    let bytes = unsafe { std::slice::from_raw_parts(out.ptr, out.len) };
+    assert_eq!(std::str::from_utf8(bytes).unwrap(), "Gauge(5)");
+    more::Gauge_label_free_rust_string(out.ptr, out.len, out.cap);
+
+    let q = more::rustcall_Gauge_scaled(2, 3);
+    assert_eq!(ops::rustcall_Gauge_read(q), 6);
+    assert_eq!(Gauge_get_value(q), 6);
+
+    // The `Result` lowering is the free-function one (#268); its aggregate is
+    // read by Julia, so only that the wrapper exists and runs is checked here.
+    let _lowered = plain::rustcall_Gauge_halved(q);
+
+    Gauge_free(p);
+    Gauge_free(q);
+
+    let c = a::rustcall_a__C_new(7);
+    assert_eq!(b::rustcall_a__C_get(c), 7);
+    a::a__C_free(c);
+}

--- a/deps/rustcall_core/src/codegen.rs
+++ b/deps/rustcall_core/src/codegen.rs
@@ -84,7 +84,7 @@ use crate::model::{MethodModel, StructModel};
 use crate::types::{
     extract_option_type, extract_result_type, is_ffi_compatible_type,
     is_inline_accessible_field_type, is_non_ffi_type, is_self_type, is_str_ref_type,
-    is_string_type, is_vec_type, needs_clone_for_getter, unparen,
+    is_string_type, is_vec_type, last_ident, needs_clone_for_getter, unparen,
 };
 
 // ============================================================================
@@ -1416,17 +1416,33 @@ pub fn transform_struct_crate(mut item_struct: ItemStruct, module_path: &[String
     }
 }
 
+/// The module path the proc-macro takes the struct of `#[julia] impl <self_ty>`
+/// to live at, given the `#[julia]` modules `module_path` around the block:
+/// the header read literally (`crate::a::C` is `a::C`, `super::C` one level up,
+/// a bare `C` the block's own path), see
+/// `PathQualifier::macro_target_path` (#315). Every symbol of the block's
+/// methods hangs off this path, and crate extraction refuses a block whose
+/// header names a struct that lives somewhere else.
+pub fn impl_target_module_path(module_path: &[String], self_ty: &Type) -> Vec<String> {
+    crate::paths::type_path_qualifier(self_ty).macro_target_path(module_path)
+}
+
 /// Transform a `#[julia]` impl block (crate flavour): wrap `#[julia]` methods.
+///
+/// The block may sit in another module than its struct (`impl crate::Gauge`
+/// from `ops.rs`, `impl super::Gauge` from a child module, #315); the method
+/// symbols follow the struct the header names, [`impl_target_module_path`].
 pub fn transform_impl_crate(mut item_impl: ItemImpl, module_path: &[String]) -> TokenStream2 {
-    let struct_name = match item_impl.self_ty.as_ref() {
-        Type::Path(type_path) => type_path.path.segments.last().map(|s| s.ident.clone()),
-        _ => None,
-    };
-    let Some(struct_name) = struct_name else {
+    if last_ident(&item_impl.self_ty).is_none() {
         return quote! {
             compile_error!("#[julia] on impl block requires a simple type path");
         };
-    };
+    }
+    let struct_path = impl_target_module_path(module_path, &item_impl.self_ty);
+    // The wrappers are emitted next to the block, in *its* module, so they
+    // name the struct the way the header does (`super::Gauge`): a bare
+    // `Gauge` need not be in scope there.
+    let self_ty = (*item_impl.self_ty).clone();
 
     // The block's own `#[cfg]` gates every wrapper it produces: inside a
     // `#[julia] mod` the module macro expands a gated impl before rustc
@@ -1447,8 +1463,8 @@ pub fn transform_impl_crate(mut item_impl: ItemImpl, module_path: &[String]) -> 
                 let mut gated = method.clone();
                 gated.attrs.splice(0..0, block_cfgs.iter().cloned());
                 ffi_wrappers.extend(generate_method_wrapper_crate(
-                    &struct_name,
-                    module_path,
+                    &self_ty,
+                    &struct_path,
                     &gated,
                 ));
             }
@@ -1567,10 +1583,15 @@ pub fn returns_boxed_struct(struct_name: &Ident, method: &syn::ImplItemFn) -> bo
 /// `<Struct>_<method>_RustCallBorrowedString`. The method itself is left in the
 /// impl block untouched; the wrapper calls it (#279).
 pub fn generate_method_wrapper_crate(
-    struct_name: &Ident,
+    self_ty: &Type,
     module_path: &[String],
     method: &syn::ImplItemFn,
 ) -> TokenStream2 {
+    let (Type::Path(self_path), Some(struct_name)) = (unparen(self_ty), last_ident(self_ty)) else {
+        return quote! {
+            compile_error!("#[julia] on impl block requires a simple type path");
+        };
+    };
     // The origin is a manifest column; the wrapper's shape does not depend
     // on it.
     let model = MethodModel::from_fn(method, crate::manifest::Attribute::Julia);
@@ -1580,6 +1601,7 @@ pub fn generate_method_wrapper_crate(
     let owned_free = format_ident!("{}_free_rust_string", owner);
     let borrowed_helper = format_ident!("{}_RustCallBorrowedString", owner);
     generate_wrapper(method_spec(
+        &self_path.path,
         struct_name,
         &stem,
         &model,
@@ -1795,8 +1817,14 @@ pub fn inline_struct_wrappers(
 /// The [`WrapperSpec`] of a struct method, shared by the inline and the crate
 /// flavour: `declare` says whether the string buffer helpers are emitted by
 /// this wrapper (crate flavour, per method) or already exist next to the struct
-/// (inline flavour, per struct).
+/// (inline flavour, per struct). `self_path` is how the wrapper spells the
+/// struct where it is emitted — the bare name next to the struct (inline), the
+/// impl header's own path (`super::Gauge`) next to the block (crate, #315) —
+/// and `struct_name` the struct's identifier, which a `-> Self` / `-> Gauge`
+/// constructor return is recognised by.
+#[allow(clippy::too_many_arguments)]
 fn method_spec(
+    self_path: &syn::Path,
     struct_name: &Ident,
     stem: &Ident,
     m: &MethodModel,
@@ -1809,12 +1837,12 @@ fn method_spec(
     let method_name_str = method_name.to_string();
     let symbol = format_ident!("{}", method_symbol_of(&stem.to_string(), &method_name_str));
     let receiver = (!m.is_static).then(|| WrapperReceiver {
-        ty: struct_name.clone().into(),
+        ty: self_path.clone(),
         mutable: m.is_mutable,
     });
     let target = if m.is_static {
         CallTarget::Assoc {
-            ty: struct_name.clone().into(),
+            ty: self_path.clone(),
             method: method_name,
         }
     } else {
@@ -1823,7 +1851,7 @@ fn method_spec(
     let ret = if inline_method_is_ctor(struct_name, m) {
         // `new`, or any method returning `Self` / the struct type, hands Julia
         // an owning pointer. The string helpers are not involved.
-        WrapperReturn::Boxed(struct_name.clone().into())
+        WrapperReturn::Boxed(self_path.clone())
     } else if let Some(r) = method_result_return(m) {
         // A `Result` method is lowered exactly like a free function (#268):
         // `CResult_<Struct>_<method>`, with a `String` payload composed onto
@@ -1877,6 +1905,7 @@ fn inline_method_wrapper(
     borrowed_helper: &Ident,
 ) -> TokenStream2 {
     generate_wrapper(method_spec(
+        &syn::Path::from(struct_name.clone()),
         struct_name,
         stem,
         m,

--- a/deps/rustcall_core/src/expand.rs
+++ b/deps/rustcall_core/src/expand.rs
@@ -20,7 +20,7 @@ use crate::cfg::{predicate_string, CfgSet};
 use crate::codegen::{inline_generic_wrappers, inline_struct_wrappers, transform_function};
 use crate::extract::{fn_args, function_entry};
 use crate::manifest::{Attribute, Field, Manifest, Method, Mode, Struct};
-use crate::model::{collect_struct_models_in, StructModel};
+use crate::model::{ModelTree, StructModel};
 use crate::types::{
     const_param_names, generics_to_type_params, has_impl_trait, has_type_params,
     is_inline_accessible_field_type, return_type_to_string, type_to_string,
@@ -65,7 +65,11 @@ pub fn expand_with_cfg(source: &str, cfg: Option<&CfgSet>) -> Result<Expanded, s
         crate::cfg::prune_file_or_error(set, &mut file)?;
     }
     let mut manifest = Manifest::new(Mode::Inline);
-    let out = expand_items(&file.items, &mut manifest, &[], &[])?;
+    // Structs and their impl blocks are matched across the whole block first
+    // (#315), so an `impl super::Gauge` inside `mod ops` wraps `Gauge`'s
+    // methods next to the struct.
+    let tree = ModelTree::collect(&file.items, Mode::Inline);
+    let out = expand_items(&file.items, &mut manifest, &[], &[], &tree)?;
 
     Ok(Expanded {
         // Crate-level inner attributes (`#![allow(...)]`, `//!` docs) are kept;
@@ -88,8 +92,8 @@ fn expand_items(
     manifest: &mut Manifest,
     module_path: &[String],
     enclosing_cfg: &[syn::Attribute],
+    tree: &ModelTree,
 ) -> Result<Vec<Item>, syn::Error> {
-    let models = collect_struct_models_in(items, Mode::Inline);
     let mut out: Vec<Item> = Vec::new();
     let push_fn = |manifest: &mut Manifest, entry: crate::manifest::Function| {
         manifest.functions.push(entry);
@@ -151,7 +155,7 @@ fn expand_items(
                 }
             }
             Item::Struct(s) => {
-                let Some(model) = models.iter().find(|m| s.ident == m.name()) else {
+                let Some(model) = tree.find(module_path, &s.ident.to_string()) else {
                     out.push(item.clone());
                     continue;
                 };
@@ -197,7 +201,7 @@ fn expand_items(
                     let mut path = module_path.to_vec();
                     path.push(m.ident.to_string());
                     let cfg = crate::cfg::effective_cfg_attrs(enclosing_cfg, &m.attrs);
-                    m.content = Some((*brace, expand_items(inner, manifest, &path, &cfg)?));
+                    m.content = Some((*brace, expand_items(inner, manifest, &path, &cfg, tree)?));
                     out.push(Item::Mod(m));
                 }
                 None => out.push(item.clone()),
@@ -314,7 +318,12 @@ fn methods_of(model: &StructModel, symbols: bool, stem: &str) -> Vec<Method> {
                 return_type: return_type_to_string(&m.func.sig.output),
                 return_abi: crate::codegen::return_abi(&m.func.sig).to_string(),
                 generic_wrapper: String::new(),
-                cfg: crate::cfg::predicate_string(&m.func.attrs),
+                // The block's and its modules' predicates gate the method as
+                // much as its own do (#300 review, #315).
+                cfg: crate::cfg::predicate_string(&crate::cfg::effective_cfg_attrs(
+                    &m.enclosing_cfg,
+                    &m.func.attrs,
+                )),
             }
         })
         .collect()

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -7,16 +7,17 @@
 //!   disagree.
 
 use syn::spanned::Spanned;
-use syn::{FnArg, Item, ItemFn, Pat, ReturnType};
+use syn::{FnArg, Item, ItemFn, ItemImpl, Pat, ReturnType};
 
 use crate::attrs::{has_no_mangle, rustcall_attribute};
 use crate::cfg::{body_has_cfg, predicate_string, CfgSet};
-use crate::codegen::returns_boxed_struct;
+use crate::codegen::{returns_boxed_struct, symbol_stem};
 
 use crate::manifest::{
     Arg, Attribute, Field, Function, Manifest, Method, Mode, ReturnKind, Struct,
 };
-use crate::model::{collect_struct_models_in, StructModel};
+use crate::model::{impl_has_julia, wrapped_methods, StructModel};
+use crate::paths::{imports_of_use, locate, ImplHeader, Located, ScannedImport, Unresolved};
 use crate::types::{
     extract_option_type, extract_result_type, generics_to_type_params, has_impl_trait,
     has_type_params, is_ffi_compatible_type, is_str_ref_type, is_string_type,
@@ -316,11 +317,10 @@ pub fn extract_crate_with_cfg(
 /// Like [`extract_crate_with_cfg`], with the PyO3 scan (#275) switchable.
 ///
 /// The scan is on by default: one file, treated as its own root. A caller that
-/// can read files instead walks the crate's module tree with
-/// [`extract_pyo3_file`] — which records the real `module_path` and the
-/// reachability of every enclosing `mod` — and then passes `false` here so the
-/// per-file pass does not report the same items a second time under the wrong
-/// path.
+/// can read files instead walks the crate's module tree with [`TreeScan`] —
+/// which records the real `module_path` and the reachability of every
+/// enclosing `mod` — and then passes `false` here so the per-file pass does
+/// not report the same items a second time under the wrong path.
 pub fn extract_crate_with_cfg_scan(
     source: &str,
     cfg: Option<&CfgSet>,
@@ -331,45 +331,79 @@ pub fn extract_crate_with_cfg_scan(
         crate::cfg::prune_file_or_error(set, &mut file)?;
     }
     let mut manifest = Manifest::new(Mode::Crate);
-    extract_crate_items(&file.items, &mut manifest, &[], &[], &[], true)?;
+    let mut scan = CrateScan::new();
+    scan.file(&file.items, &[], &[], &mut manifest, "")?;
+    scan.finish(&mut manifest)?;
     // Items that carry only PyO3 attributes (#275). Reported with a PyO3
     // origin, `exported = false` and the symbol a Phase-2 wrapper crate will
     // emit; an item that also carries `#[julia]` is owned by `#[julia]` and is
-    // skipped by the scan (see `crate::pyo3`). The scan walks inline modules
-    // itself, because unlike the `#[julia]` path it records `module_path`: a
-    // wrapper crate has to name the item as `user_crate::module::item`.
+    // skipped by the scan (see `crate::pyo3`).
     if pyo3_scan {
         crate::pyo3::extract_pyo3_items(&file.items, &mut manifest);
     }
     Ok(manifest)
 }
 
-/// The PyO3 items of one file of a crate's module tree, plus the out-of-line
-/// `mod` declarations it makes (#275).
+/// Both crate-wide scans of one crate — `#[julia]` items (#315) and PyO3 items
+/// (#275) — fed one file of the module tree at a time.
 ///
-/// `module_path` is where this file sits in the tree (empty for the crate
-/// root) and `reachable` says whether every `mod` on the way to it is `pub`.
-/// The caller resolves each returned [`crate::pyo3::PendingModule`] to a file
-/// and calls this again; only it can touch the filesystem.
-///
-/// `scan` carries the crate-wide state: `#[pyclass]` structs and their
-/// `#[pymethods]` blocks may live in different files, so the structs are only
-/// written to a manifest by [`crate::pyo3::Pyo3Scan::finish`], once every file
-/// has been seen.
-pub fn extract_pyo3_file(
-    source: &str,
-    cfg: Option<&CfgSet>,
-    module_path: &[String],
-    reachable: bool,
-    enclosing_cfg: &[syn::Attribute],
-    scan: &mut crate::pyo3::Pyo3Scan,
-    manifest: &mut Manifest,
-) -> Result<Vec<crate::pyo3::PendingModule>, syn::Error> {
-    let mut file = syn::parse_file(source)?;
-    if let Some(set) = cfg {
-        crate::cfg::prune_file_or_error(set, &mut file)?;
+/// A struct and its impl blocks may live in different files, so the structs
+/// are only written to the manifest by [`TreeScan::finish`], once every file
+/// has been seen. The caller — `rustcall-extract` — owns the walk: it resolves
+/// each returned [`crate::pyo3::PendingModule`] to a file and calls
+/// [`TreeScan::file`] again; only it can touch the filesystem. Without a crate
+/// root every file is fed as its own root (an empty `module_path`).
+#[derive(Debug, Default)]
+pub struct TreeScan {
+    julia: CrateScan,
+    pyo3: crate::pyo3::Pyo3Scan,
+}
+
+impl TreeScan {
+    pub fn new() -> Self {
+        TreeScan::default()
     }
-    Ok(scan.file(&file.items, module_path, reachable, enclosing_cfg, manifest))
+
+    /// Scan one file. `module_path` is where it sits in the tree (empty for
+    /// the crate root), `reachable` whether every `mod` on the way to it is
+    /// `pub`, `enclosing_cfg` the `#[cfg]` of every `mod` declaration on the
+    /// way (which every item in the file inherits, #300 review), and `file`
+    /// labels it in diagnostics. `#[julia]` and PyO3 functions go straight
+    /// into `manifest`; the out-of-line `mod` declarations found are returned
+    /// for the caller to follow.
+    #[allow(clippy::too_many_arguments)]
+    pub fn file(
+        &mut self,
+        source: &str,
+        cfg: Option<&CfgSet>,
+        module_path: &[String],
+        reachable: bool,
+        enclosing_cfg: &[syn::Attribute],
+        manifest: &mut Manifest,
+        file: &str,
+    ) -> Result<Vec<crate::pyo3::PendingModule>, ExtractError> {
+        let mut parsed = syn::parse_file(source)?;
+        if let Some(set) = cfg {
+            crate::cfg::prune_file_or_error(set, &mut parsed)?;
+        }
+        self.julia
+            .file(&parsed.items, module_path, enclosing_cfg, manifest, file)?;
+        Ok(self.pyo3.file(
+            &parsed.items,
+            module_path,
+            reachable,
+            enclosing_cfg,
+            manifest,
+        ))
+    }
+
+    /// Attach every impl block to its struct and write the structs of both
+    /// scans to `manifest`.
+    pub fn finish(self, manifest: &mut Manifest) -> Result<(), ExtractError> {
+        self.julia.finish(manifest)?;
+        self.pyo3.finish(manifest);
+        Ok(())
+    }
 }
 
 /// The error for a `#[julia]` item inside an inline module that is not itself
@@ -386,104 +420,410 @@ fn unmarked_module_error(kind: &str, name: &str, full_path: &[String]) -> Extrac
     ))
 }
 
-/// One level of items; inline modules are visited recursively.
+/// `crate::a::b` for a module path, `crate` for the root.
+fn crate_path(path: &[String]) -> String {
+    if path.is_empty() {
+        "crate".to_string()
+    } else {
+        format!("crate::{}", path.join("::"))
+    }
+}
+
+/// Where an item is, for a diagnostic: `(line 3 in src/ops.rs)`, or just the
+/// line for an in-memory source.
+fn location(line: usize, file: &str) -> String {
+    if file.is_empty() {
+        format!("(line {line})")
+    } else {
+        format!("(line {line} in {file})")
+    }
+}
+
+/// Crate-wide state of the `#[julia]` scan (#315).
 ///
-/// `module_path` is the chain of `#[julia]`-marked inline modules leading here
-/// — the path the proc-macro folds into the symbols — `full_path` every
-/// inline module, for diagnostics, and `enclosing_cfg` the `#[cfg]` attributes
-/// of every enclosing module, which every entry below inherits (an item in a
-/// gated module is itself gated). `marked` says whether *this* level is a
-/// marked one (the crate root counts as marked): a `#[julia]` item at an
-/// unmarked level is refused, see [`unmarked_module_error`]. An unmarked module
-/// below a marked one resets nothing — its items are simply refused — and a
-/// marked module below an unmarked one continues the path from the last marked
-/// ancestor, exactly as `codegen::transform_module` does when the proc-macro
-/// expands it.
-fn extract_crate_items(
-    items: &[Item],
-    manifest: &mut Manifest,
-    module_path: &[String],
-    full_path: &[String],
-    enclosing_cfg: &[syn::Attribute],
-    marked: bool,
-) -> Result<(), ExtractError> {
-    for item in items {
-        match item {
-            Item::Fn(f) => {
-                let attribute = rustcall_attribute(&f.attrs);
-                if attribute != Attribute::None && !marked {
-                    return Err(unmarked_module_error(
-                        "function",
-                        &f.sig.ident.to_string(),
-                        full_path,
-                    ));
-                }
-                if attribute == Attribute::Julia {
-                    manifest.functions.push(function_entry(
-                        f,
-                        attribute,
-                        true,
-                        module_path,
-                        enclosing_cfg,
-                    ));
-                }
-            }
-            Item::Mod(m) => {
-                if let Some((_, inner)) = &m.content {
-                    let mut full = full_path.to_vec();
-                    full.push(m.ident.to_string());
-                    let cfg = crate::cfg::effective_cfg_attrs(enclosing_cfg, &m.attrs);
-                    if crate::codegen::is_marked_module(m) {
-                        let mut path = module_path.to_vec();
-                        path.push(m.ident.to_string());
-                        extract_crate_items(inner, manifest, &path, &full, &cfg, true)?;
-                    } else {
-                        extract_crate_items(inner, manifest, module_path, &full, &cfg, false)?;
-                    }
-                }
-            }
-            _ => {}
-        }
+/// A `#[julia] struct` and its `#[julia] impl` blocks need not live together:
+/// `impl C` is legal in any module that has `C` in scope, and in a multi-file
+/// crate the two are routinely in different files (`struct Gauge` in `lib.rs`,
+/// `impl crate::Gauge` in `ops.rs`). Matching them per file, or per module
+/// level, silently dropped the methods of every such struct — the proc-macro
+/// had emitted the wrappers, the manifest did not list them, and the Julia
+/// module had no method. So the structs and the impl blocks of the whole tree
+/// are collected first and married in [`CrateScan::finish`], the block's
+/// header resolved through the same resolver the PyO3 scan uses
+/// (`crate::paths`): `impl crate::Gauge`, `impl super::Gauge`, `impl Gauge`
+/// next to a `use crate::Gauge;`, or a bare `impl Gauge` when the crate has
+/// one.
+///
+/// Two paths are tracked for every item. Its **module path** is where it really
+/// is — every module on the way, file (`mod ops;`) and inline — and is what
+/// headers are resolved against. Its **symbol path** is the chain of `#[julia]`
+/// inline modules the proc-macro folds into its symbols (#300); file modules
+/// and unmarked inline modules are transparent to it, and an unmarked module
+/// cuts the chain, because whatever is inside it is expanded by the item-level
+/// macro, which sees no module at all. The manifest records the symbol path as
+/// `module_path`, since that is what the symbols and the Julia layout follow.
+///
+/// Nothing is dropped silently: a block whose header names no `#[julia]`
+/// struct, or an ambiguous one, fails the scan with the unresolved path, and so
+/// does a block the proc-macro would give symbols other than the struct's own
+/// (`impl_target_module_path` versus the struct's symbol path) — the macro
+/// cannot see where the struct is declared, so the header has to spell it.
+#[derive(Debug, Default)]
+pub struct CrateScan {
+    structs: Vec<ScannedStruct>,
+    impls: Vec<ScannedImpl>,
+    imports: Vec<ScannedImport>,
+    /// Every exported symbol seen so far and the item that claims it, so a
+    /// second claimant is reported with both locations (#300).
+    claimed: Vec<(String, String)>,
+}
+
+#[derive(Debug)]
+struct ScannedStruct {
+    model: StructModel,
+    name: String,
+    module_path: Vec<String>,
+    symbol_path: Vec<String>,
+    /// The `#[cfg]` of every module enclosing the struct (#300 review).
+    cfg: Vec<syn::Attribute>,
+    file: String,
+}
+
+impl Located for ScannedStruct {
+    fn name(&self) -> &str {
+        &self.name
     }
 
-    // A `#[julia] impl C` is only wrapped next to the `#[julia] struct C` of the
-    // same module: the proc-macro derives the method symbols from the module
-    // it runs in, so an impl written elsewhere (`use a::C; #[julia] impl C`
-    // at the crate root) would export `rustcall_C_run` for what the struct
-    // knows as `a__C`. Such an impl used to be dropped silently; it is
-    // refused with the rule instead (#300 review).
-    let models = collect_struct_models_in(items, Mode::Crate);
-    for item in items {
-        let Item::Impl(imp) = item else { continue };
-        if imp.trait_.is_some() || !imp.attrs.iter().any(crate::attrs::is_julia_attr) {
-            continue;
-        }
-        let Some(target) = crate::types::last_ident(&imp.self_ty) else {
-            continue;
-        };
-        if !models.iter().any(|m| m.item.ident == *target) {
-            return Err(ExtractError::Unsupported(format!(
-                "#[julia] impl `{target}` at {} has no `#[julia] struct {target}` in the same \
-                 module. The proc-macro derives a method's symbol from the module the impl \
-                 block is in, so an impl of a struct defined elsewhere would export a symbol \
-                 the manifest cannot describe; move the impl next to the struct (#300).",
-                if full_path.is_empty() {
-                    "the crate root".to_string()
-                } else {
-                    format!("module `{}`", full_path.join("::"))
+    fn module_path(&self) -> &[String] {
+        &self.module_path
+    }
+}
+
+#[derive(Debug)]
+struct ScannedImpl {
+    item: ItemImpl,
+    header: ImplHeader,
+    symbol_path: Vec<String>,
+    /// The `#[cfg]` of the block itself and of every module enclosing it: the
+    /// block may sit in a gated module far from its struct, and its methods
+    /// exist only under that predicate (#300 review).
+    cfg: Vec<syn::Attribute>,
+    line: usize,
+    file: String,
+}
+
+impl CrateScan {
+    pub fn new() -> Self {
+        CrateScan::default()
+    }
+
+    /// Scan one file. `module_path` is where the file sits in the module tree
+    /// (empty for the crate root, or for a file scanned as its own root),
+    /// `enclosing_cfg` the `#[cfg]` of every `mod` declaration on the way to
+    /// it, and `file` labels it in diagnostics.
+    ///
+    /// `#[julia]` functions go straight into `manifest`; structs and impl
+    /// blocks are held until [`CrateScan::finish`].
+    pub fn file(
+        &mut self,
+        items: &[Item],
+        module_path: &[String],
+        enclosing_cfg: &[syn::Attribute],
+        manifest: &mut Manifest,
+        file: &str,
+    ) -> Result<(), ExtractError> {
+        let mut path = module_path.to_vec();
+        // A file's items are expanded by the item-level macro, which sees no
+        // module: their symbol path starts empty whatever the file's position.
+        self.level(items, &mut path, &[], enclosing_cfg, true, manifest, file)
+    }
+
+    /// One level of items; inline modules are visited recursively.
+    ///
+    /// `symbol_path` is the chain of `#[julia]`-marked inline modules leading
+    /// here — the path the proc-macro folds into the symbols — and `marked`
+    /// says whether *this* level is a marked one (a file's top level counts as
+    /// marked): a `#[julia]` function or struct at an unmarked level is
+    /// refused, see [`unmarked_module_error`]. An unmarked module cuts the
+    /// chain: `codegen::transform_module` leaves it as written, so a marked
+    /// module below it is expanded by the item-level macro and starts a chain
+    /// of its own. `enclosing_cfg` is the `#[cfg]` of every enclosing module,
+    /// which every entry below inherits (#300 review).
+    #[allow(clippy::too_many_arguments)]
+    fn level(
+        &mut self,
+        items: &[Item],
+        module_path: &mut Vec<String>,
+        symbol_path: &[String],
+        enclosing_cfg: &[syn::Attribute],
+        marked: bool,
+        manifest: &mut Manifest,
+        file: &str,
+    ) -> Result<(), ExtractError> {
+        for item in items {
+            match item {
+                Item::Fn(f) => {
+                    let attribute = rustcall_attribute(&f.attrs);
+                    if attribute != Attribute::None && !marked {
+                        return Err(unmarked_module_error(
+                            "function",
+                            &f.sig.ident.to_string(),
+                            module_path,
+                        ));
+                    }
+                    if attribute == Attribute::Julia {
+                        let entry = function_entry(f, attribute, true, symbol_path, enclosing_cfg);
+                        for (symbol, owner) in entry.claimed_symbols() {
+                            self.claim(symbol, owner, file)?;
+                        }
+                        manifest.functions.push(entry);
+                    }
                 }
+                Item::Struct(s) => {
+                    let Some(model) = StructModel::of(s, Mode::Crate) else {
+                        continue;
+                    };
+                    if !marked {
+                        return Err(unmarked_module_error("struct", &model.name(), module_path));
+                    }
+                    self.structs.push(ScannedStruct {
+                        name: model.name(),
+                        model,
+                        module_path: module_path.clone(),
+                        symbol_path: symbol_path.to_vec(),
+                        cfg: enclosing_cfg.to_vec(),
+                        file: file.to_string(),
+                    });
+                }
+                Item::Impl(imp) => {
+                    // A block without `#[julia]` wraps nothing in crate mode;
+                    // one with it is attached in `finish`, wherever its struct
+                    // is. An impl sits in an unmarked module legitimately: its
+                    // symbols follow the struct, not the module.
+                    if !impl_has_julia(imp) {
+                        continue;
+                    }
+                    let Some(header) = ImplHeader::of(imp, module_path) else {
+                        continue;
+                    };
+                    self.impls.push(ScannedImpl {
+                        item: imp.clone(),
+                        header,
+                        symbol_path: symbol_path.to_vec(),
+                        cfg: crate::cfg::effective_cfg_attrs(enclosing_cfg, &imp.attrs),
+                        line: imp.span().start().line,
+                        file: file.to_string(),
+                    });
+                }
+                Item::Use(u) => {
+                    self.imports.extend(imports_of_use(u, module_path));
+                }
+                Item::Mod(m) => {
+                    let Some((_, inner)) = &m.content else {
+                        // `mod name;` lives in another file; the caller follows
+                        // it (see `TreeScan`).
+                        continue;
+                    };
+                    module_path.push(m.ident.to_string());
+                    let cfg = crate::cfg::effective_cfg_attrs(enclosing_cfg, &m.attrs);
+                    let result = if crate::codegen::is_marked_module(m) {
+                        let mut inner_symbol = symbol_path.to_vec();
+                        inner_symbol.push(m.ident.to_string());
+                        self.level(
+                            inner,
+                            module_path,
+                            &inner_symbol,
+                            &cfg,
+                            true,
+                            manifest,
+                            file,
+                        )
+                    } else {
+                        self.level(inner, module_path, &[], &cfg, false, manifest, file)
+                    };
+                    module_path.pop();
+                    result?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Record `symbol` as claimed by `owner`, failing on the second claimant
+    /// (#300).
+    ///
+    /// The symbol scheme keeps items of different modules apart, so a
+    /// duplicate here is either two file modules — transparent to the scheme
+    /// — defining the same `#[julia]` item, or a crate-root name that spells a
+    /// qualified one. The `cdylib` could not export both, and a wrong binding
+    /// is worse than no binding, so the scan fails closed and names the fix.
+    fn claim(&mut self, symbol: String, owner: String, file: &str) -> Result<(), ExtractError> {
+        let here = if file.is_empty() {
+            owner
+        } else {
+            format!("{owner} in {file}")
+        };
+        if let Some((_, first)) = self.claimed.iter().find(|(s, _)| *s == symbol) {
+            return Err(ExtractError::Unsupported(format!(
+                "duplicate exported symbol `{symbol}`: claimed by {first} and by {here}. \
+                 Two #[julia] items of one crate export the same symbol; only inline modules \
+                 marked `#[julia]` (`#[julia] pub mod name {{ ... }}`) qualify a symbol by \
+                 their name, while file modules (`mod name;`) do not. Wrap one of the items in \
+                 a `#[julia]` module block or rename it (#300)."
             )));
         }
+        self.claimed.push((symbol, here));
+        Ok(())
     }
-    for model in models {
-        if !marked {
-            return Err(unmarked_module_error("struct", &model.name(), full_path));
+
+    /// Attach every `#[julia] impl` block to its struct and write the structs
+    /// to `manifest`, in the order the structs were seen (the CLI sorts a
+    /// multi-file manifest afterwards).
+    ///
+    /// Blocks are visited by (module path, line) so the result does not
+    /// depend on the order the caller happened to visit files in.
+    pub fn finish(mut self, manifest: &mut Manifest) -> Result<(), ExtractError> {
+        let mut impls = std::mem::take(&mut self.impls);
+        impls.sort_by(|a, b| {
+            a.header
+                .module_path
+                .cmp(&b.header.module_path)
+                .then(a.line.cmp(&b.line))
+                .then(a.file.cmp(&b.file))
+        });
+
+        for imp in &impls {
+            // A block with no `#[julia]` method makes the proc-macro emit
+            // nothing, whatever it names.
+            if wrapped_methods(&imp.item, Mode::Crate, &imp.cfg).is_empty() {
+                continue;
+            }
+            let index = match locate(&self.structs, &imp.header, &self.imports) {
+                Ok(index) => index,
+                Err(why) => return Err(self.unresolved_impl(imp, why)),
+            };
+            self.check_symbol_path(imp, index)?;
+            self.structs[index]
+                .model
+                .attach_impl(&imp.item, Mode::Crate, &imp.cfg);
         }
-        manifest
-            .structs
-            .push(crate_struct_entry(&model, module_path, enclosing_cfg));
+
+        for scanned in std::mem::take(&mut self.structs) {
+            let entry = crate_struct_entry(&scanned.model, &scanned.symbol_path, &scanned.cfg);
+            for (symbol, owner) in entry.claimed_symbols() {
+                self.claim(symbol, owner, &scanned.file)?;
+            }
+            manifest.structs.push(entry);
+        }
+        Ok(())
     }
-    Ok(())
+
+    fn unresolved_impl(&self, imp: &ScannedImpl, why: Unresolved) -> ExtractError {
+        let header = imp.header.display();
+        let where_ = location(imp.line, &imp.file);
+        let name = &imp.header.target;
+        ExtractError::Unsupported(match why {
+            Unresolved::NotFound => {
+                let looked = if imp.header.qualifier.is_uninformative() {
+                    "anywhere in the crate".to_string()
+                } else {
+                    let places: Vec<String> = imp
+                        .header
+                        .qualifier
+                        .candidates(&imp.header.module_path)
+                        .iter()
+                        .map(|p| format!("`{}`", crate_path(p)))
+                        .collect();
+                    if places.is_empty() {
+                        "where the header points (it walks above the crate root)".to_string()
+                    } else {
+                        format!("at {}", places.join(" or "))
+                    }
+                };
+                format!(
+                    "#[julia] `{header}` {where_} names no #[julia] struct: no `struct {name}` \
+                     marked `#[julia]` is declared {looked}. A `#[julia] impl` block wraps the \
+                     methods of a `#[julia]` struct, so mark the struct, or point the header at \
+                     one that is (#315)."
+                )
+            }
+            Unresolved::Ambiguous(paths) => {
+                let places: Vec<String> = paths
+                    .iter()
+                    .map(|p| format!("`{}`", crate_path(p)))
+                    .collect();
+                let first = paths.first().map(|p| crate_path(p)).unwrap_or_default();
+                format!(
+                    "#[julia] `{header}` {where_} is ambiguous: `#[julia] struct {name}` is \
+                     declared in {}, and neither the header nor a `use` in `{}` picks one. Write \
+                     the struct's path in the header (`impl {first}::{name}`) (#315).",
+                    places.join(" and "),
+                    crate_path(&imp.header.module_path)
+                )
+            }
+        })
+    }
+
+    /// Refuse a block the proc-macro would give other symbols than the struct
+    /// it names has (#315).
+    ///
+    /// The macro derives a method's symbol from the header and the `#[julia]`
+    /// modules around the block ([`crate::codegen::impl_target_module_path`]);
+    /// it cannot see where the struct is declared. When that path is not the
+    /// struct's own symbol path the wrappers would be exported under one stem
+    /// and the struct's `free` / accessors under another, and Julia — which
+    /// derives every method symbol from the struct's FFI name — would look for
+    /// symbols that do not exist. The manifest cannot describe that honestly,
+    /// so the scan fails and names the header that would.
+    fn check_symbol_path(&self, imp: &ScannedImpl, index: usize) -> Result<(), ExtractError> {
+        let scanned = &self.structs[index];
+        let name = scanned.model.name();
+        let macro_path = imp.header.qualifier.macro_target_path(&imp.symbol_path);
+        let macro_stem = symbol_stem(&macro_path, &name);
+        let struct_stem = symbol_stem(&scanned.symbol_path, &name);
+        if macro_stem == struct_stem {
+            return Ok(());
+        }
+        let header = imp.header.display();
+        let where_ = location(imp.line, &imp.file);
+        let block_is = if imp.symbol_path.is_empty() {
+            "outside any `#[julia]` module".to_string()
+        } else {
+            format!(
+                "inside the `#[julia]` module `{}`",
+                imp.symbol_path.join("::")
+            )
+        };
+        let real = crate_path(&scanned.module_path);
+        let fix = if scanned.module_path == scanned.symbol_path {
+            format!("write the header as `impl {real}::{name}`")
+        } else if scanned.symbol_path.is_empty() {
+            format!(
+                "bring the struct into scope (`use {real}::{name};`) and write `impl {name}` \
+                 outside any `#[julia]` module — the modules in `{real}` are file modules or \
+                 unmarked ones, transparent to the symbol scheme (#300), so a header naming \
+                 them would qualify the symbols by them"
+            )
+        } else {
+            format!(
+                "bring the struct into scope (`use {real}::{name};`) and write `impl {name}` \
+                 inside `#[julia] mod {}` (module path `{}`), or move the block next to the \
+                 struct",
+                scanned.symbol_path.last().map(String::as_str).unwrap_or(""),
+                scanned.symbol_path.join("::")
+            )
+        };
+        Err(ExtractError::Unsupported(format!(
+            "#[julia] `{header}` {where_}, {block_is}, would export its methods as \
+             `rustcall_{macro_stem}_<method>`, but the struct it names, `{real}::{name}`, has \
+             the FFI name `{struct_stem}` (`{struct_stem}_free`, \
+             `rustcall_{struct_stem}_<method>`). The proc-macro derives a method's symbol from \
+             the impl header and the `#[julia]` modules around the block — it cannot see \
+             where the struct is declared — so the header has to spell the struct's path: \
+             {fix} (#315)."
+        )))
+    }
 }
 
 fn crate_struct_entry(
@@ -550,7 +890,12 @@ fn crate_struct_entry(
             err_abi: shapes[i].err_abi.clone(),
             inner_abi: shapes[i].inner_abi.clone(),
             returns_boxed_struct: returns_boxed_struct(struct_name, &m.func),
-            cfg: crate::cfg::predicate_string(&m.func.attrs),
+            // The block's and its modules' predicates gate the method as much
+            // as its own do (#300 review, #315).
+            cfg: crate::cfg::predicate_string(&crate::cfg::effective_cfg_attrs(
+                &m.enclosing_cfg,
+                &m.func.attrs,
+            )),
             args: fn_args(&m.func.sig),
             return_type: return_type_to_string(&m.func.sig.output),
             // Crate method wrappers (`generate_method_wrapper_crate`) use the

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -431,6 +431,32 @@ fn crate_path(path: &[String]) -> String {
 
 /// Where an item is, for a diagnostic: `(line 3 in src/ops.rs)`, or just the
 /// line for an in-memory source.
+/// The error for a `#[julia] impl` whose target resolves to a struct that
+/// carries no `#[julia]` (#315 review). The proc-macro wrapped the methods
+/// with *that* type as the receiver, so attaching them to a same-named
+/// annotated struct elsewhere would describe a wrapper that dereferences a
+/// pointer to the wrong type.
+fn plain_target_error(imp: &ScannedImpl, target: &Candidate) -> ExtractError {
+    let header = imp.header.display();
+    let where_ = location(imp.line, &imp.file);
+    let name = &target.name;
+    let module = if target.module_path.is_empty() {
+        "the crate root".to_string()
+    } else {
+        format!("module `{}`", target.module_path.join("::"))
+    };
+    let declared = if target.file.is_empty() {
+        String::new()
+    } else {
+        format!(" (in {})", target.file)
+    };
+    ExtractError::Unsupported(format!(
+        "`{header}` {where_} names `{name}` in {module}{declared}, which is not a \
+         `#[julia]` struct. Mark that struct with `#[julia]`, or point the block at the \
+         annotated one with an explicit path (`impl crate::path::to::{name}`)."
+    ))
+}
+
 fn location(line: usize, file: &str) -> String {
     if file.is_empty() {
         format!("(line {line})")
@@ -471,6 +497,13 @@ fn location(line: usize, file: &str) -> String {
 #[derive(Debug, Default)]
 pub struct CrateScan {
     structs: Vec<ScannedStruct>,
+    /// Every struct the crate declares **without** `#[julia]`, by name and
+    /// module. Rust resolves an `impl` header by scope, not by attribute, so a
+    /// plain `struct C` in the block's own module is its target even when a
+    /// `#[julia] struct C` exists elsewhere; without these the resolver would
+    /// fall back to the annotated one and the manifest would name a wrapper
+    /// whose receiver is the *other* type (#315 review).
+    plain_structs: Vec<PlainStruct>,
     impls: Vec<ScannedImpl>,
     imports: Vec<ScannedImport>,
     /// Every exported symbol seen so far and the item that claims it, so a
@@ -490,6 +523,35 @@ struct ScannedStruct {
 }
 
 impl Located for ScannedStruct {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn module_path(&self) -> &[String] {
+        &self.module_path
+    }
+}
+
+/// A struct with no `#[julia]`: a resolution candidate, never a target.
+#[derive(Debug)]
+struct PlainStruct {
+    name: String,
+    module_path: Vec<String>,
+    file: String,
+}
+
+/// A struct an `impl` header may name, annotated or not: `julia` is its index
+/// in [`CrateScan::structs`] when it carries `#[julia]`, and `None` when it is
+/// a [`PlainStruct`] (#315 review).
+#[derive(Debug)]
+struct Candidate {
+    name: String,
+    module_path: Vec<String>,
+    julia: Option<usize>,
+    file: String,
+}
+
+impl Located for Candidate {
     fn name(&self) -> &str {
         &self.name
     }
@@ -581,6 +643,13 @@ impl CrateScan {
                 }
                 Item::Struct(s) => {
                     let Some(model) = StructModel::of(s, Mode::Crate) else {
+                        // Not a `#[julia]` struct, but still a name an `impl`
+                        // header can resolve to (#315 review).
+                        self.plain_structs.push(PlainStruct {
+                            name: s.ident.to_string(),
+                            module_path: module_path.clone(),
+                            file: file.to_string(),
+                        });
                         continue;
                     };
                     if !marked {
@@ -617,6 +686,41 @@ impl CrateScan {
                 }
                 Item::Use(u) => {
                     self.imports.extend(imports_of_use(u, module_path));
+                }
+                Item::Macro(m) if m.mac.path.is_ident("include") => {
+                    // `include!("api.rs")` compiles that file's items into
+                    // *this* module — no `mod` declaration reaches it, so the
+                    // tree walk has to follow it or the items it exports
+                    // disappear from the manifest while the proc-macro still
+                    // wraps them (#315 review). Only a literal path can be
+                    // followed: `include!(concat!(env!("OUT_DIR"), …))` names a
+                    // file the build writes later, and a fragment that is not a
+                    // module (`include!("table.rs")` holding `[1, 2, 3]`) does
+                    // not parse — both are left to the compiler.
+                    let Ok(literal) = m.mac.parse_body::<syn::LitStr>() else {
+                        continue;
+                    };
+                    let base = std::path::Path::new(file)
+                        .parent()
+                        .map(std::path::Path::to_path_buf)
+                        .unwrap_or_default();
+                    let included = base.join(literal.value());
+                    let Ok(source) = std::fs::read_to_string(&included) else {
+                        continue;
+                    };
+                    let Ok(parsed) = syn::parse_file(&source) else {
+                        continue;
+                    };
+                    let label = included.display().to_string();
+                    self.level(
+                        &parsed.items,
+                        module_path,
+                        symbol_path,
+                        enclosing_cfg,
+                        marked,
+                        manifest,
+                        &label,
+                    )?;
                 }
                 Item::Mod(m) => {
                     let Some((_, inner)) = &m.content else {
@@ -684,6 +788,23 @@ impl CrateScan {
     /// Blocks are visited by (module path, line) so the result does not
     /// depend on the order the caller happened to visit files in.
     pub fn finish(mut self, manifest: &mut Manifest) -> Result<(), ExtractError> {
+        let candidates: Vec<Candidate> = self
+            .structs
+            .iter()
+            .enumerate()
+            .map(|(i, s)| Candidate {
+                name: s.name.clone(),
+                module_path: s.module_path.clone(),
+                julia: Some(i),
+                file: s.file.clone(),
+            })
+            .chain(self.plain_structs.iter().map(|p| Candidate {
+                name: p.name.clone(),
+                module_path: p.module_path.clone(),
+                julia: None,
+                file: p.file.clone(),
+            }))
+            .collect();
         let mut impls = std::mem::take(&mut self.impls);
         impls.sort_by(|a, b| {
             a.header
@@ -699,8 +820,15 @@ impl CrateScan {
             if wrapped_methods(&imp.item, Mode::Crate, &imp.cfg).is_empty() {
                 continue;
             }
-            let index = match locate(&self.structs, &imp.header, &self.imports) {
-                Ok(index) => index,
+            // Resolution follows Rust's own rules, so the plain structs are
+            // candidates too; a header that lands on one names a type the
+            // proc-macro wrapped as its receiver and RustCall cannot describe
+            // (#315 review).
+            let index = match locate(&candidates, &imp.header, &self.imports) {
+                Ok(index) => match candidates[index].julia {
+                    Some(julia) => julia,
+                    None => return Err(plain_target_error(imp, &candidates[index])),
+                },
                 Err(why) => return Err(self.unresolved_impl(imp, why)),
             };
             self.check_symbol_path(imp, index)?;

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -641,6 +641,24 @@ impl CrateScan {
                         manifest.functions.push(entry);
                     }
                 }
+                // An `enum` or a `union` is a type an `impl` header resolves to
+                // as readily as a struct, and neither can carry `#[julia]`:
+                // recording them keeps a local one from being passed over for a
+                // same-named annotated struct elsewhere (#315 review).
+                Item::Enum(e) => {
+                    self.plain_structs.push(PlainStruct {
+                        name: e.ident.to_string(),
+                        module_path: module_path.clone(),
+                        file: file.to_string(),
+                    });
+                }
+                Item::Union(u) => {
+                    self.plain_structs.push(PlainStruct {
+                        name: u.ident.to_string(),
+                        module_path: module_path.clone(),
+                        file: file.to_string(),
+                    });
+                }
                 Item::Struct(s) => {
                     let Some(model) = StructModel::of(s, Mode::Crate) else {
                         // Not a `#[julia]` struct, but still a name an `impl`
@@ -908,7 +926,12 @@ impl CrateScan {
         let scanned = &self.structs[index];
         let name = scanned.model.name();
         let macro_path = imp.header.qualifier.macro_target_path(&imp.symbol_path);
-        let macro_stem = symbol_stem(&macro_path, &name);
+        // The macro reads the header's own last identifier, which a renamed
+        // import makes something else entirely (`use crate::Gauge as Meter;
+        // impl Meter` exports `rustcall_Meter_*`), so the stem is derived from
+        // what the macro sees, not from the struct the header resolves to
+        // (#315 review).
+        let macro_stem = symbol_stem(&macro_path, &imp.header.target.to_string());
         let struct_stem = symbol_stem(&scanned.symbol_path, &name);
         if macro_stem == struct_stem {
             return Ok(());

--- a/deps/rustcall_core/src/lib.rs
+++ b/deps/rustcall_core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod expand;
 pub mod extract;
 pub mod manifest;
 pub mod model;
+pub mod paths;
 pub mod pyo3;
 pub mod specialize;
 pub mod types;

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -627,6 +627,62 @@ pub struct GenericWrapper {
     pub type_params: Vec<String>,
 }
 
+/// `` `a::C` (line 3) `` — how [`Manifest::symbol_owners`] names an item.
+fn symbol_owner(path: &[String], name: &str, line: usize) -> String {
+    let mut segments = path.to_vec();
+    segments.push(name.to_string());
+    format!("`{}` (line {line})", segments.join("::"))
+}
+
+impl Function {
+    /// The exported symbol this `#[julia]` function claims, with the owner
+    /// label of [`Manifest::symbol_owners`]; empty when it claims none (a PyO3
+    /// item, an unexported or generic one, an undecided `#[cfg]`).
+    pub fn claimed_symbols(&self) -> Vec<(String, String)> {
+        if self.attribute.is_pyo3_scan()
+            || !self.exported
+            || self.symbol.is_empty()
+            || !self.cfg.is_empty()
+        {
+            return Vec::new();
+        }
+        vec![(
+            self.symbol.clone(),
+            symbol_owner(&self.module_path, &self.name, self.line),
+        )]
+    }
+}
+
+impl Struct {
+    /// The exported symbols this `#[julia]` struct claims — `free`, the field
+    /// accessors and the method wrappers — with the owner label of
+    /// [`Manifest::symbol_owners`].
+    pub fn claimed_symbols(&self) -> Vec<(String, String)> {
+        if self.attribute.is_pyo3_scan() || !self.cfg.is_empty() || self.ffi_name.is_empty() {
+            return Vec::new();
+        }
+        let who = symbol_owner(&self.module_path, &self.name, self.line);
+        let mut out = Vec::new();
+        // A generic struct exports nothing itself.
+        if self.type_params.is_empty() {
+            out.push((format!("{}_free", self.ffi_name), who.clone()));
+        }
+        for field in &self.fields {
+            for accessor in [&field.getter, &field.setter] {
+                if !accessor.is_empty() {
+                    out.push((accessor.clone(), who.clone()));
+                }
+            }
+        }
+        for m in &self.methods {
+            if !m.symbol.is_empty() && m.cfg.is_empty() {
+                out.push((m.symbol.clone(), who.clone()));
+            }
+        }
+        out
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Manifest {
     pub schema_version: u32,
@@ -683,39 +739,11 @@ impl Manifest {
     /// their clashes with a `skip_reason` (`crate::pyo3`).
     pub fn symbol_owners(&self) -> Vec<(String, String)> {
         let mut out = Vec::new();
-        let owner = |path: &[String], name: &str, line: usize| {
-            let mut segments = path.to_vec();
-            segments.push(name.to_string());
-            format!("`{}` (line {line})", segments.join("::"))
-        };
         for f in &self.functions {
-            if f.attribute.is_pyo3_scan() || !f.exported || f.symbol.is_empty() || !f.cfg.is_empty()
-            {
-                continue;
-            }
-            out.push((f.symbol.clone(), owner(&f.module_path, &f.name, f.line)));
+            out.extend(f.claimed_symbols());
         }
         for s in &self.structs {
-            if s.attribute.is_pyo3_scan() || !s.cfg.is_empty() || s.ffi_name.is_empty() {
-                continue;
-            }
-            let who = owner(&s.module_path, &s.name, s.line);
-            // A generic struct exports nothing itself.
-            if s.type_params.is_empty() {
-                out.push((format!("{}_free", s.ffi_name), who.clone()));
-            }
-            for field in &s.fields {
-                for accessor in [&field.getter, &field.setter] {
-                    if !accessor.is_empty() {
-                        out.push((accessor.clone(), who.clone()));
-                    }
-                }
-            }
-            for m in &s.methods {
-                if !m.symbol.is_empty() && m.cfg.is_empty() {
-                    out.push((m.symbol.clone(), who.clone()));
-                }
-            }
+            out.extend(s.claimed_symbols());
         }
         out
     }

--- a/deps/rustcall_core/src/model.rs
+++ b/deps/rustcall_core/src/model.rs
@@ -17,6 +17,10 @@ pub struct MethodModel {
     /// (`Julia`, or `None` for an inline-mode impl that carries none).
     /// Recorded on the manifest entry (`Method.attribute`, #275 Phase 3).
     pub attribute: Attribute,
+    /// The `#[cfg]` of the impl block and of every module enclosing it: the
+    /// method exists only under those predicates as much as under its own
+    /// (#300 review, #315). Empty for a wrapper generated from a lone method.
+    pub enclosing_cfg: Vec<syn::Attribute>,
 }
 
 impl MethodModel {
@@ -30,6 +34,7 @@ impl MethodModel {
             is_static: receiver.is_none(),
             is_mutable: receiver.map(|r| r.mutability.is_some()).unwrap_or(false),
             attribute,
+            enclosing_cfg: Vec::new(),
         }
     }
 
@@ -68,6 +73,88 @@ impl StructModel {
             _ => Vec::new(),
         }
     }
+
+    /// The model of a struct item selected under `mode`: a `#[julia]` struct,
+    /// or in inline mode also a `#[derive(JuliaStruct)]` one. `None` when the
+    /// struct carries neither.
+    pub fn of(s: &ItemStruct, mode: Mode) -> Option<StructModel> {
+        let attribute = rustcall_attribute(&s.attrs);
+        let selected = matches!(
+            (mode, attribute),
+            (_, Attribute::Julia) | (Mode::Inline, Attribute::DeriveJuliaStruct)
+        );
+        if !selected {
+            return None;
+        }
+        Some(StructModel {
+            item: s.clone(),
+            attribute,
+            derives: derive_list(&s.attrs)
+                .into_iter()
+                .filter(|d| d != "JuliaStruct")
+                .collect(),
+            impls: Vec::new(),
+            methods: Vec::new(),
+            line: s.span().start().line,
+        })
+    }
+
+    /// Record an inherent impl block of this struct and the methods of it that
+    /// get wrapped under `mode`. The caller has decided that the block is this
+    /// struct's (by name at one level, or by resolved path across modules,
+    /// #315); a method already seen under the same name is not added twice.
+    /// `enclosing_cfg` is the `#[cfg]` of every module enclosing the block.
+    pub fn attach_impl(&mut self, imp: &ItemImpl, mode: Mode, enclosing_cfg: &[syn::Attribute]) {
+        self.impls.push(imp.clone());
+        for m in wrapped_methods(imp, mode, enclosing_cfg) {
+            if !self.methods.iter().any(|seen| seen.name() == m.name()) {
+                self.methods.push(m);
+            }
+        }
+    }
+}
+
+/// Whether the block carries `#[julia]` itself, which in crate mode is what
+/// makes its `#[julia]` methods get wrapped.
+pub fn impl_has_julia(imp: &ItemImpl) -> bool {
+    imp.attrs.iter().any(is_julia_attr)
+}
+
+/// The methods of an inherent impl block that get wrapped under `mode`, in
+/// source order. Each carries the block's `#[cfg]` on top of `enclosing_cfg`,
+/// the predicates of the modules around the block.
+pub fn wrapped_methods(
+    imp: &ItemImpl,
+    mode: Mode,
+    enclosing_cfg: &[syn::Attribute],
+) -> Vec<MethodModel> {
+    let has_julia = impl_has_julia(imp);
+    let block_cfg = crate::cfg::effective_cfg_attrs(enclosing_cfg, &imp.attrs);
+    // What the manifest records as the method's origin: the impl block's
+    // attribute, which an inline-mode impl does not have.
+    let impl_attribute = if has_julia {
+        Attribute::Julia
+    } else {
+        Attribute::None
+    };
+    imp.items
+        .iter()
+        .filter_map(|ii| match ii {
+            ImplItem::Fn(func) => Some(func),
+            _ => None,
+        })
+        .filter(|func| match mode {
+            // Historical inline rule: every `pub fn` of an inherent impl.
+            Mode::Inline => matches!(func.vis, Visibility::Public(_)),
+            // Proc-macro rule: `#[julia]` methods inside a `#[julia] impl`.
+            Mode::Crate => has_julia && func.attrs.iter().any(is_julia_attr),
+        })
+        .map(|func| {
+            let mut m = MethodModel::from_fn(func, impl_attribute);
+            m.enclosing_cfg = block_cfg.clone();
+            m
+        })
+        .collect()
 }
 
 fn impl_target_name(item: &ItemImpl) -> Option<String> {
@@ -84,67 +171,136 @@ pub fn collect_struct_models(file: &syn::File, mode: Mode) -> Vec<StructModel> {
     collect_struct_models_in(&file.items, mode)
 }
 
-/// Same as [`collect_struct_models`] for one level of items (a file or the body
-/// of an inline `mod`). Impl blocks are matched within the same level only.
-pub fn collect_struct_models_in(items: &[Item], mode: Mode) -> Vec<StructModel> {
-    let mut models: Vec<StructModel> = Vec::new();
+/// The struct models of a whole item tree, every inherent impl block attached
+/// to its struct wherever the block sits (#315).
+///
+/// This is the inline expander's view of a `rust"""` block: every inline module
+/// counts, so a struct is identified by its module path and its name, and an
+/// `impl super::Gauge` in `mod ops` or an `impl Gauge` next to a
+/// `use crate::Gauge;` reaches the struct at the root exactly as a block next
+/// to it does. Headers are resolved by the resolver the crate scans share
+/// (`crate::paths::locate`). A block that names no selected struct is left
+/// alone — an inherent impl of an ordinary struct is ordinary code.
+#[derive(Debug, Default)]
+pub struct ModelTree {
+    entries: Vec<LocatedModel>,
+}
 
-    for item in items {
-        if let Item::Struct(s) = item {
-            let attribute = rustcall_attribute(&s.attrs);
-            let selected = matches!(
-                (mode, attribute),
-                (_, Attribute::Julia) | (Mode::Inline, Attribute::DeriveJuliaStruct)
-            );
-            if !selected {
-                continue;
+#[derive(Debug)]
+struct LocatedModel {
+    module_path: Vec<String>,
+    name: String,
+    model: StructModel,
+}
+
+/// An inherent impl block seen by [`ModelTree::collect`], with the `#[cfg]` of
+/// the modules around it.
+#[derive(Debug)]
+struct ScannedBlock {
+    item: ItemImpl,
+    header: crate::paths::ImplHeader,
+    enclosing_cfg: Vec<syn::Attribute>,
+}
+
+impl crate::paths::Located for LocatedModel {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn module_path(&self) -> &[String] {
+        &self.module_path
+    }
+}
+
+impl ModelTree {
+    pub fn collect(items: &[Item], mode: Mode) -> ModelTree {
+        let mut tree = ModelTree::default();
+        let mut impls: Vec<ScannedBlock> = Vec::new();
+        let mut imports = Vec::new();
+        let mut path = Vec::new();
+        tree.walk(items, mode, &mut path, &[], &mut impls, &mut imports);
+        for block in &impls {
+            if let Ok(index) = crate::paths::locate(&tree.entries, &block.header, &imports) {
+                tree.entries[index]
+                    .model
+                    .attach_impl(&block.item, mode, &block.enclosing_cfg);
             }
-            models.push(StructModel {
-                item: s.clone(),
-                attribute,
-                derives: derive_list(&s.attrs)
-                    .into_iter()
-                    .filter(|d| d != "JuliaStruct")
-                    .collect(),
-                impls: Vec::new(),
-                methods: Vec::new(),
-                line: s.span().start().line,
-            });
+        }
+        tree
+    }
+
+    fn walk(
+        &mut self,
+        items: &[Item],
+        mode: Mode,
+        path: &mut Vec<String>,
+        enclosing_cfg: &[syn::Attribute],
+        impls: &mut Vec<ScannedBlock>,
+        imports: &mut Vec<crate::paths::ScannedImport>,
+    ) {
+        for item in items {
+            match item {
+                Item::Struct(s) => {
+                    if let Some(model) = StructModel::of(s, mode) {
+                        self.entries.push(LocatedModel {
+                            module_path: path.clone(),
+                            name: model.name(),
+                            model,
+                        });
+                    }
+                }
+                Item::Impl(imp) => {
+                    if let Some(header) = crate::paths::ImplHeader::of(imp, path) {
+                        impls.push(ScannedBlock {
+                            item: imp.clone(),
+                            header,
+                            enclosing_cfg: enclosing_cfg.to_vec(),
+                        });
+                    }
+                }
+                Item::Use(u) => imports.extend(crate::paths::imports_of_use(u, path)),
+                Item::Mod(m) => {
+                    if let Some((_, inner)) = &m.content {
+                        path.push(m.ident.to_string());
+                        let cfg = crate::cfg::effective_cfg_attrs(enclosing_cfg, &m.attrs);
+                        self.walk(inner, mode, path, &cfg, impls, imports);
+                        path.pop();
+                    }
+                }
+                _ => {}
+            }
         }
     }
+
+    /// The model of `name` declared directly in `module_path`, if selected.
+    pub fn find(&self, module_path: &[String], name: &str) -> Option<&StructModel> {
+        self.entries
+            .iter()
+            .find(|e| e.module_path == module_path && e.name == name)
+            .map(|e| &e.model)
+    }
+}
+
+/// Same as [`collect_struct_models`] for one level of items (a file or the body
+/// of an inline `mod`). Impl blocks are matched within the same level only;
+/// [`ModelTree`] and the crate scan (`crate::extract::CrateScan`) match them
+/// across the whole module tree (#315).
+pub fn collect_struct_models_in(items: &[Item], mode: Mode) -> Vec<StructModel> {
+    let mut models: Vec<StructModel> = items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Struct(s) => StructModel::of(s, mode),
+            _ => None,
+        })
+        .collect();
 
     for item in items {
         let Item::Impl(imp) = item else { continue };
         let Some(target) = impl_target_name(imp) else {
             continue;
         };
-        let Some(model) = models.iter_mut().find(|m| m.name() == target) else {
-            continue;
-        };
-        model.impls.push(imp.clone());
-
-        let impl_has_julia = imp.attrs.iter().any(is_julia_attr);
-        // What the manifest records as the method's origin: the impl block's
-        // attribute, which an inline-mode impl does not have.
-        let impl_attribute = if impl_has_julia {
-            Attribute::Julia
-        } else {
-            Attribute::None
-        };
-
-        for ii in &imp.items {
-            let ImplItem::Fn(func) = ii else { continue };
-            let wrap = match mode {
-                // Historical inline rule: every `pub fn` of an inherent impl.
-                Mode::Inline => matches!(func.vis, Visibility::Public(_)),
-                // Proc-macro rule: `#[julia]` methods inside a `#[julia] impl`.
-                Mode::Crate => impl_has_julia && func.attrs.iter().any(is_julia_attr),
-            };
-            if wrap && !model.methods.iter().any(|m| func.sig.ident == m.name()) {
-                model
-                    .methods
-                    .push(MethodModel::from_fn(func, impl_attribute));
-            }
+        if let Some(model) = models.iter_mut().find(|m| m.name() == target) {
+            model.attach_impl(imp, mode, &[]);
         }
     }
 

--- a/deps/rustcall_core/src/paths.rs
+++ b/deps/rustcall_core/src/paths.rs
@@ -1,0 +1,432 @@
+//! Resolving the type path an `impl` header writes to the struct it names.
+//!
+//! Rust does not require an `impl C` to live next to `struct C`: it is legal in
+//! any module that has `C` in scope, and in a multi-file crate the two are
+//! routinely in different files. Both scans — `#[pymethods]` blocks for
+//! `#[pyclass]` structs (#275) and `#[julia] impl` blocks for `#[julia]`
+//! structs (#315) — collect the structs and the impl blocks of the whole crate
+//! separately and marry them afterwards, and this module is the one resolver
+//! they share: the qualifier written in front of the type (`crate::a::C`,
+//! `super::C`, `self::C`, `a::C`, a bare `C`), the `use` declarations of the
+//! impl's module, and finally the one struct of that name anywhere.
+
+use syn::{Ident, Item, ItemUse, Type};
+
+use crate::types::unparen;
+
+/// Where a written path is rooted, which decides what a qualifier may match.
+///
+/// `crate::a::C` and `a::C` are **not** the same struct when the enclosing
+/// module `m` also has an `a`: the first is `a::C` at the crate root, the
+/// second is `m::a::C` (2018 paths) or, through a `use`, whatever brought `a`
+/// into scope. Collapsing the two attached a `#[pymethods]` block to the wrong
+/// class, which Phase 2 then compiled into a call to the wrong type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathAnchor {
+    /// `crate::…` — the crate root, and nothing else.
+    Crate,
+    /// `self::…` — the module the path was written in, and nothing else.
+    SelfModule,
+    /// A bare path: the enclosing module first, then the crate root.
+    Relative,
+    /// `super::…` (repeated `n` times): the module `n` levels above the one
+    /// the path was written in, and nothing else. Treating it as
+    /// uninformative sent `impl super::C` to a same-named `C` in the impl's
+    /// own module (#307 review).
+    Super(usize),
+    /// A path this matcher cannot follow: `super` after another segment,
+    /// which Rust itself rejects, or a qualified `<T as Trait>::C`. Nothing is
+    /// matched on the qualifier at all.
+    Unknown,
+}
+
+/// A path qualifier: where it is rooted and the module segments it names,
+/// without the type's own name (`a::b::C` -> `["a", "b"]`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathQualifier {
+    pub anchor: PathAnchor,
+    pub segments: Vec<String>,
+}
+
+impl PathQualifier {
+    pub fn relative(segments: Vec<String>) -> Self {
+        PathQualifier {
+            anchor: PathAnchor::Relative,
+            segments,
+        }
+    }
+
+    /// Whether the qualifier says nothing (a bare `impl C`, or a path this
+    /// matcher cannot follow).
+    pub fn is_uninformative(&self) -> bool {
+        self.anchor == PathAnchor::Unknown
+            || (self.anchor == PathAnchor::Relative && self.segments.is_empty())
+    }
+
+    /// Whether the qualifier names one place and one place only, so that when
+    /// no struct is found there the block must be dropped rather than matched
+    /// by its bare name: `super::C` is never the impl's own module's `C`.
+    pub fn forbids_fallback(&self) -> bool {
+        matches!(self.anchor, PathAnchor::Super(_))
+    }
+
+    /// The module paths this qualifier can name, from inside `module_path`,
+    /// nearest first. A `super::` that walks past the crate root names
+    /// nothing.
+    pub fn candidates(&self, module_path: &[String]) -> Vec<Vec<String>> {
+        let mut nested = module_path.to_vec();
+        nested.extend(self.segments.iter().cloned());
+        match self.anchor {
+            PathAnchor::Unknown => Vec::new(),
+            PathAnchor::Crate => vec![self.segments.clone()],
+            PathAnchor::SelfModule => vec![nested],
+            PathAnchor::Relative => vec![nested, self.segments.clone()],
+            PathAnchor::Super(levels) => {
+                if levels > module_path.len() {
+                    return Vec::new();
+                }
+                let mut base = module_path[..module_path.len() - levels].to_vec();
+                base.extend(self.segments.iter().cloned());
+                vec![base]
+            }
+        }
+    }
+
+    /// The module path the **proc-macro** takes the struct to live at when it
+    /// expands `#[julia] impl <qualifier>::C` inside the `#[julia]` modules
+    /// `symbol_path` (#315).
+    ///
+    /// The macro sees the header and the marked modules around it, nothing
+    /// else — not the struct, not the `use` declarations of a file module, not
+    /// whether a segment names a file module (transparent to the symbol
+    /// scheme, #300) or a marked inline one. So it reads the header literally:
+    /// `crate::a::C` is `a::C`; `self::C` and a bare `C` are in the impl's own
+    /// marked path; `super::C` one level up from it, and a `super::` that
+    /// walks past the marked root lands at the crate root, because the file
+    /// modules above it qualify nothing; a relative `a::C` is `a` below the
+    /// impl's path, as a 2018 path is; a path it cannot follow is treated as
+    /// bare. The extraction pass, which knows where the struct really is,
+    /// compares this against the struct's own path and refuses the impl when
+    /// they disagree, so the symbols the macro emits and the manifest describes
+    /// cannot drift apart.
+    pub fn macro_target_path(&self, symbol_path: &[String]) -> Vec<String> {
+        let below = |base: &[String]| {
+            let mut out = base.to_vec();
+            out.extend(self.segments.iter().cloned());
+            out
+        };
+        match self.anchor {
+            PathAnchor::Crate => self.segments.clone(),
+            PathAnchor::SelfModule | PathAnchor::Relative => below(symbol_path),
+            PathAnchor::Unknown => symbol_path.to_vec(),
+            PathAnchor::Super(levels) if levels <= symbol_path.len() => {
+                below(&symbol_path[..symbol_path.len() - levels])
+            }
+            PathAnchor::Super(_) => self.segments.clone(),
+        }
+    }
+
+    /// The qualifier as the header spelled it, for diagnostics
+    /// (`crate::a::` for `impl crate::a::C`; empty for a bare `impl C`).
+    pub fn display_prefix(&self) -> String {
+        let mut parts: Vec<String> = match self.anchor {
+            PathAnchor::Crate => vec!["crate".to_string()],
+            PathAnchor::SelfModule => vec!["self".to_string()],
+            PathAnchor::Super(levels) => vec!["super".to_string(); levels],
+            PathAnchor::Relative | PathAnchor::Unknown => Vec::new(),
+        };
+        parts.extend(self.segments.iter().cloned());
+        if parts.is_empty() {
+            String::new()
+        } else {
+            format!("{}::", parts.join("::"))
+        }
+    }
+}
+
+/// The qualifier of a path type, anchor included. A qualified path
+/// (`<T as Trait>::C`) cannot be followed.
+pub fn type_path_qualifier(ty: &Type) -> PathQualifier {
+    let Type::Path(p) = unparen(ty) else {
+        return PathQualifier::relative(Vec::new());
+    };
+    if p.qself.is_some() {
+        return PathQualifier {
+            anchor: PathAnchor::Unknown,
+            segments: Vec::new(),
+        };
+    }
+    path_qualifier(p.path.segments.iter().map(|s| s.ident.to_string()))
+}
+
+/// Split a written path into its anchor and its module segments, dropping the
+/// final segment (the item's own name).
+pub fn path_qualifier(segments: impl IntoIterator<Item = String>) -> PathQualifier {
+    let all: Vec<String> = segments.into_iter().collect();
+    let mut anchor = PathAnchor::Relative;
+    let mut out = Vec::new();
+    let mut levels = 0usize;
+    let count = all.len();
+    for (i, name) in all.into_iter().enumerate() {
+        if i == 0 {
+            match name.as_str() {
+                "crate" => {
+                    anchor = PathAnchor::Crate;
+                    continue;
+                }
+                "self" => {
+                    anchor = PathAnchor::SelfModule;
+                    continue;
+                }
+                "super" => {
+                    levels = 1;
+                    anchor = PathAnchor::Super(levels);
+                    continue;
+                }
+                _ => {}
+            }
+        } else if name == "super" {
+            // A run of leading `super`s walks up one level each; a `super`
+            // after a named segment is not a path Rust accepts.
+            if matches!(anchor, PathAnchor::Super(_)) && out.is_empty() {
+                levels += 1;
+                anchor = PathAnchor::Super(levels);
+                continue;
+            }
+            return PathQualifier {
+                anchor: PathAnchor::Unknown,
+                segments: Vec::new(),
+            };
+        }
+        if i + 1 < count {
+            out.push(name);
+        }
+    }
+    PathQualifier {
+        anchor,
+        segments: out,
+    }
+}
+
+/// One `use` path in scope: where it was written, the name it binds, and the
+/// module path it names.
+#[derive(Debug, Clone)]
+pub struct ScannedImport {
+    pub module_path: Vec<String>,
+    /// The name the import binds — the last segment, or the `as` alias.
+    pub alias: String,
+    /// The full path it names, anchor stripped: `crate::a::C` -> `["a", "C"]`.
+    pub path: Vec<String>,
+    /// Where that path is rooted, so `use crate::a::C;` and `use a::C;` are
+    /// not confused when the enclosing module also has an `a`.
+    pub qualifier: PathQualifier,
+}
+
+/// What a bare `impl C` in `module_path` could be referring to through the
+/// `use` declaration `item`.
+pub fn imports_of_use(item: &ItemUse, module_path: &[String]) -> Vec<ScannedImport> {
+    let mut bindings = Vec::new();
+    let mut prefix = Vec::new();
+    flatten_use_tree(&item.tree, &mut prefix, &mut bindings);
+    bindings
+        .into_iter()
+        .map(|(alias, anchored)| {
+            let qualifier = path_qualifier(anchored.iter().cloned());
+            // The anchor segments are not part of the module path; the
+            // qualifier keeps what they meant.
+            let path: Vec<String> = anchored
+                .into_iter()
+                .filter(|s| s != "crate" && s != "self" && s != "super")
+                .collect();
+            ScannedImport {
+                module_path: module_path.to_vec(),
+                alias,
+                path,
+                qualifier,
+            }
+        })
+        .collect()
+}
+
+/// Flatten a `use` tree into the names it binds and the paths they name,
+/// **anchor included**.
+///
+/// `use crate::a::{C, D as E};` yields `("C", ["crate", "a", "C"])` and
+/// `("E", ["crate", "a", "D"])`; the caller splits the anchor off with
+/// [`path_qualifier`], so `use crate::a::C;` and `use a::C;` stay distinct.
+/// A glob (`use a::*;`) binds no name it can be matched on and is skipped.
+/// `super::` is kept: [`path_qualifier`] resolves it against the module the
+/// `use` was written in, like any other anchor (#307 review).
+fn flatten_use_tree(
+    tree: &syn::UseTree,
+    prefix: &mut Vec<String>,
+    out: &mut Vec<(String, Vec<String>)>,
+) {
+    match tree {
+        syn::UseTree::Path(path) => {
+            let segment = path.ident.to_string();
+            prefix.push(segment);
+            flatten_use_tree(&path.tree, prefix, out);
+            prefix.pop();
+        }
+        syn::UseTree::Name(name) => {
+            let mut full = prefix.clone();
+            full.push(name.ident.to_string());
+            out.push((name.ident.to_string(), full));
+        }
+        syn::UseTree::Rename(rename) => {
+            let mut full = prefix.clone();
+            full.push(rename.ident.to_string());
+            out.push((rename.rename.to_string(), full));
+        }
+        syn::UseTree::Group(group) => {
+            for item in &group.items {
+                flatten_use_tree(item, prefix, out);
+            }
+        }
+        // A glob binds no name this matcher can key on.
+        syn::UseTree::Glob(_) => {}
+    }
+}
+
+/// An `impl` header as far as resolution is concerned: the type's own name,
+/// the qualifier written in front of it, and the module the block sits in.
+#[derive(Debug, Clone)]
+pub struct ImplHeader {
+    pub target: Ident,
+    pub qualifier: PathQualifier,
+    pub module_path: Vec<String>,
+}
+
+impl ImplHeader {
+    /// The header of an inherent `impl`; `None` for a trait impl or a target
+    /// that is not a path type.
+    pub fn of(item: &syn::ItemImpl, module_path: &[String]) -> Option<Self> {
+        if item.trait_.is_some() {
+            return None;
+        }
+        let target = crate::types::last_ident(&item.self_ty)?.clone();
+        Some(ImplHeader {
+            target,
+            qualifier: type_path_qualifier(&item.self_ty),
+            module_path: module_path.to_vec(),
+        })
+    }
+
+    /// The header as written, `impl crate::a::C`, for diagnostics.
+    pub fn display(&self) -> String {
+        format!("impl {}{}", self.qualifier.display_prefix(), self.target)
+    }
+}
+
+/// A struct a header can be matched against: its name and the module it is
+/// declared in.
+pub trait Located {
+    fn name(&self) -> &str;
+    fn module_path(&self) -> &[String];
+}
+
+/// Why a header matched no struct, for the diagnostic of a scan that must not
+/// drop the block silently (#315).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Unresolved {
+    /// No struct of that name is where the header points (or anywhere, for a
+    /// bare name).
+    NotFound,
+    /// A bare name that several modules declare, and nothing — qualifier,
+    /// `use`, the impl's own module — picks one; the paths of the candidates.
+    Ambiguous(Vec<Vec<String>>),
+}
+
+/// Locate the struct an `impl` header names among `structs`.
+///
+/// A header is matched, in order, to: the struct named by an explicit
+/// qualifier (`impl a::C`, resolved against the impl's own module and against
+/// the crate root); the struct of that name in the impl's own module; the one
+/// a `use` in that module brought into scope under that name; and finally the
+/// one struct of that name anywhere in the crate. When two modules declare
+/// structs of the same name and nothing disambiguates, the block is not
+/// attached to a guess — a wrong `Struct::method` would not compile — and the
+/// caller decides how to report that.
+pub fn locate<T: Located>(
+    structs: &[T],
+    header: &ImplHeader,
+    imports: &[ScannedImport],
+) -> Result<usize, Unresolved> {
+    let name = header.target.to_string();
+    let named = |s: &T| s.name() == name;
+
+    if !header.qualifier.is_uninformative() {
+        // `impl a::C` inside module `m` means `m::a::C`, or `a::C` from the
+        // crate root — try both, nearest first. `impl crate::a::C` means
+        // only the second, and `impl self::a::C` only the first.
+        for candidate in header.qualifier.candidates(&header.module_path) {
+            if let Some(i) = structs
+                .iter()
+                .position(|s| named(s) && s.module_path() == candidate.as_slice())
+            {
+                return Ok(i);
+            }
+        }
+        // `impl super::C` names the parent module's `C` and nothing else:
+        // with none there, attaching to a `C` in the impl's own module —
+        // or to the one `C` anywhere — would be exactly the wrong struct
+        // (#307 review).
+        if header.qualifier.forbids_fallback() {
+            return Err(Unresolved::NotFound);
+        }
+    }
+
+    if let Some(i) = structs
+        .iter()
+        .position(|s| named(s) && s.module_path() == header.module_path.as_slice())
+    {
+        return Ok(i);
+    }
+
+    // A bare `impl C` is disambiguated by whatever brought `C` into scope:
+    // `use crate::a::C;` in the impl's module names `a::C` exactly, even
+    // though the impl itself writes no qualifier.
+    for import in imports {
+        if import.module_path != header.module_path || import.alias != name {
+            continue;
+        }
+        let target = import.path.last().map(String::as_str).unwrap_or(&name);
+        for candidate in import.qualifier.candidates(&header.module_path) {
+            if let Some(i) = structs
+                .iter()
+                .position(|s| s.name() == target && s.module_path() == candidate.as_slice())
+            {
+                return Ok(i);
+            }
+        }
+    }
+
+    let matching: Vec<usize> = structs
+        .iter()
+        .enumerate()
+        .filter(|(_, s)| named(s))
+        .map(|(i, _)| i)
+        .collect();
+    match matching.as_slice() {
+        [one] => Ok(*one),
+        [] => Err(Unresolved::NotFound),
+        many => Err(Unresolved::Ambiguous(
+            many.iter()
+                .map(|&i| structs[i].module_path().to_vec())
+                .collect(),
+        )),
+    }
+}
+
+/// The `use` declarations among one level of items, for [`locate`].
+pub fn imports_in(items: &[Item], module_path: &[String]) -> Vec<ScannedImport> {
+    items
+        .iter()
+        .filter_map(|item| match item {
+            Item::Use(u) => Some(imports_of_use(u, module_path)),
+            _ => None,
+        })
+        .flatten()
+        .collect()
+}

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -42,9 +42,10 @@ use crate::extract::fn_args;
 use crate::manifest::{
     skip_reason, Attribute, Field, Function, Manifest, Method, ReturnKind, Struct,
 };
+use crate::paths::{imports_of_use, locate, ImplHeader, Located, ScannedImport};
 use crate::types::{
     extract_option_type, extract_result_type, generics_to_type_params, has_impl_trait,
-    has_type_params, is_ffi_compatible_type, is_str_ref_type, is_string_type, last_ident,
+    has_type_params, is_ffi_compatible_type, is_str_ref_type, is_string_type,
     return_type_to_string, type_to_string, unparen,
 };
 
@@ -115,13 +116,11 @@ struct ScannedClass {
 
 #[derive(Debug)]
 struct ScannedImpl {
-    module_path: Vec<String>,
-    /// The module qualifier written in front of the type: `impl a::C` gives a
-    /// relative `["a"]`, a bare `impl C` gives an empty one. It names the class
-    /// exactly when several modules define one of that name, so it is kept
-    /// rather than collapsed to the final identifier.
-    qualifier: PathQualifier,
-    target: syn::Ident,
+    /// The type the block is for, the qualifier written in front of it
+    /// (`impl a::C` names the class exactly when several modules define a
+    /// `C`) and the module the block sits in — what the shared resolver in
+    /// `crate::paths` matches on.
+    header: ImplHeader,
     line: usize,
     funcs: Vec<ImplItemFn>,
     /// The `#[cfg]` of the block itself and of every module enclosing it: a
@@ -130,138 +129,13 @@ struct ScannedImpl {
     cfg: Vec<syn::Attribute>,
 }
 
-/// Where a written path is rooted, which decides what a qualifier may match.
-///
-/// `crate::a::C` and `a::C` are **not** the same class when the enclosing
-/// module `m` also has an `a`: the first is `a::C` at the crate root, the
-/// second is `m::a::C` (2018 paths) or, through a `use`, whatever brought `a`
-/// into scope. Collapsing the two attached a `#[pymethods]` block to the wrong
-/// class, which Phase 2 then compiled into a call to the wrong type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PathAnchor {
-    /// `crate::…` — the crate root, and nothing else.
-    Crate,
-    /// `self::…` — the module the path was written in, and nothing else.
-    SelfModule,
-    /// A bare path: the enclosing module first, then the crate root.
-    Relative,
-    /// `super::…` (repeated `n` times): the module `n` levels above the one
-    /// the path was written in, and nothing else. Treating it as
-    /// uninformative sent `impl super::C` to a same-named `C` in the impl's
-    /// own module (#307 review).
-    Super(usize),
-    /// A path this matcher cannot follow: `super` after another segment,
-    /// which Rust itself rejects. Nothing is matched on the qualifier at all.
-    Unknown,
-}
-
-/// A path qualifier: where it is rooted and the module segments it names,
-/// without the type's own name (`a::b::C` -> `["a", "b"]`).
-#[derive(Debug, Clone)]
-struct PathQualifier {
-    anchor: PathAnchor,
-    segments: Vec<String>,
-}
-
-impl PathQualifier {
-    fn relative(segments: Vec<String>) -> Self {
-        PathQualifier {
-            anchor: PathAnchor::Relative,
-            segments,
-        }
+impl Located for ScannedClass {
+    fn name(&self) -> &str {
+        &self.entry.name
     }
 
-    /// Whether the qualifier says nothing (a bare `impl C`, or a path this
-    /// matcher cannot follow).
-    fn is_uninformative(&self) -> bool {
-        self.anchor == PathAnchor::Unknown
-            || (self.anchor == PathAnchor::Relative && self.segments.is_empty())
-    }
-
-    /// Whether the qualifier names one place and one place only, so that when
-    /// no class is found there the block must be dropped rather than matched
-    /// by its bare name: `super::C` is never the impl's own module's `C`.
-    fn forbids_fallback(&self) -> bool {
-        matches!(self.anchor, PathAnchor::Super(_))
-    }
-
-    /// The module paths this qualifier can name, from inside `module_path`,
-    /// nearest first. A `super::` that walks past the crate root names
-    /// nothing.
-    fn candidates(&self, module_path: &[String]) -> Vec<Vec<String>> {
-        let mut nested = module_path.to_vec();
-        nested.extend(self.segments.iter().cloned());
-        match self.anchor {
-            PathAnchor::Unknown => Vec::new(),
-            PathAnchor::Crate => vec![self.segments.clone()],
-            PathAnchor::SelfModule => vec![nested],
-            PathAnchor::Relative => vec![nested, self.segments.clone()],
-            PathAnchor::Super(levels) => {
-                if levels > module_path.len() {
-                    return Vec::new();
-                }
-                let mut base = module_path[..module_path.len() - levels].to_vec();
-                base.extend(self.segments.iter().cloned());
-                vec![base]
-            }
-        }
-    }
-}
-
-/// The qualifier of a path type, anchor included.
-fn type_path_qualifier(ty: &Type) -> PathQualifier {
-    let Type::Path(p) = unparen(ty) else {
-        return PathQualifier::relative(Vec::new());
-    };
-    path_qualifier(p.path.segments.iter().map(|s| s.ident.to_string()))
-}
-
-/// Split a written path into its anchor and its module segments, dropping the
-/// final segment (the item's own name).
-fn path_qualifier(segments: impl IntoIterator<Item = String>) -> PathQualifier {
-    let all: Vec<String> = segments.into_iter().collect();
-    let mut anchor = PathAnchor::Relative;
-    let mut out = Vec::new();
-    let mut levels = 0usize;
-    let count = all.len();
-    for (i, name) in all.into_iter().enumerate() {
-        if i == 0 {
-            match name.as_str() {
-                "crate" => {
-                    anchor = PathAnchor::Crate;
-                    continue;
-                }
-                "self" => {
-                    anchor = PathAnchor::SelfModule;
-                    continue;
-                }
-                "super" => {
-                    levels = 1;
-                    anchor = PathAnchor::Super(levels);
-                    continue;
-                }
-                _ => {}
-            }
-        } else if name == "super" {
-            // A run of leading `super`s walks up one level each; a `super`
-            // after a named segment is not a path Rust accepts.
-            if matches!(anchor, PathAnchor::Super(_)) && out.is_empty() {
-                levels += 1;
-                anchor = PathAnchor::Super(levels);
-                continue;
-            }
-            return PathQualifier {
-                anchor: PathAnchor::Unknown,
-                segments: Vec::new(),
-            };
-        }
-        if i + 1 < count {
-            out.push(name);
-        }
-    }
-    PathQualifier {
-        anchor,
-        segments: out,
+    fn module_path(&self) -> &[String] {
+        &self.module_path
     }
 }
 
@@ -361,18 +235,11 @@ impl Pyo3Scan {
                     if pyo3_marker(&imp.attrs) != Some(Pyo3Marker::Methods) {
                         continue;
                     }
-                    let Some(target) = last_ident(&imp.self_ty).cloned() else {
+                    let Some(header) = ImplHeader::of(imp, module_path) else {
                         continue;
                     };
-                    if imp.trait_.is_some() {
-                        continue;
-                    }
                     self.impls.push(ScannedImpl {
-                        module_path: module_path.clone(),
-                        // The qualifier of an explicit `impl a::C`, which names
-                        // the class exactly when several modules define a `C`.
-                        qualifier: type_path_qualifier(&imp.self_ty),
-                        target,
+                        header,
                         line: imp.span().start().line,
                         cfg: crate::cfg::effective_cfg_attrs(enclosing_cfg, &imp.attrs),
                         funcs: imp
@@ -387,24 +254,7 @@ impl Pyo3Scan {
                 }
                 Item::Use(u) => {
                     // What a bare `impl C` in this module could be referring to.
-                    let mut bindings = Vec::new();
-                    let mut prefix = Vec::new();
-                    flatten_use_tree(&u.tree, &mut prefix, &mut bindings);
-                    for (alias, anchored) in bindings {
-                        let qualifier = path_qualifier(anchored.iter().cloned());
-                        // The anchor segments are not part of the module path;
-                        // the qualifier keeps what they meant.
-                        let path: Vec<String> = anchored
-                            .into_iter()
-                            .filter(|s| s != "crate" && s != "self" && s != "super")
-                            .collect();
-                        self.imports.push(ScannedImport {
-                            module_path: module_path.clone(),
-                            alias,
-                            path,
-                            qualifier,
-                        });
-                    }
+                    self.imports.extend(imports_of_use(u, module_path));
                 }
                 Item::Mod(m) => {
                     let inner_reachable = reachable && matches!(m.vis, syn::Visibility::Public(_));
@@ -455,11 +305,18 @@ impl Pyo3Scan {
     /// Order is by (module path, line) so the result does not depend on the
     /// order the caller happened to visit files in.
     pub fn finish(mut self, manifest: &mut Manifest) {
-        self.impls
-            .sort_by(|a, b| a.module_path.cmp(&b.module_path).then(a.line.cmp(&b.line)));
+        self.impls.sort_by(|a, b| {
+            a.header
+                .module_path
+                .cmp(&b.header.module_path)
+                .then(a.line.cmp(&b.line))
+        });
 
         for imp in &self.impls {
-            let Some(index) = self.locate_class(imp) else {
+            // A block that names no class, or an ambiguous one, is dropped: the
+            // PyO3 scan describes what a wrapper crate could wrap, and a wrong
+            // `Struct::method` would not compile in Phase 2.
+            let Ok(index) = locate(&self.classes, &imp.header, &self.imports) else {
                 continue;
             };
             let owner_skip = self.classes[index].entry.skip_reason.clone();
@@ -467,7 +324,8 @@ impl Pyo3Scan {
             // still wraps `a::C`'s methods (#300).
             let class_path = self.classes[index].module_path.clone();
             for func in &imp.funcs {
-                let entry = method_entry(&imp.target, &class_path, func, &owner_skip, &imp.cfg);
+                let entry =
+                    method_entry(&imp.header.target, &class_path, func, &owner_skip, &imp.cfg);
                 self.classes[index].entry.methods.push(entry);
             }
         }
@@ -480,122 +338,6 @@ impl Pyo3Scan {
         // class its `String` getters' helper (#307 review).
         mark_julia_surface_collisions(manifest);
         mark_symbol_collisions(manifest);
-    }
-
-    fn locate_class(&self, imp: &ScannedImpl) -> Option<usize> {
-        let name = imp.target.to_string();
-        let named = |c: &ScannedClass| c.entry.name == name;
-
-        if !imp.qualifier.is_uninformative() {
-            // `impl a::C` inside module `m` means `m::a::C`, or `a::C` from the
-            // crate root — try both, nearest first. `impl crate::a::C` means
-            // only the second, and `impl self::a::C` only the first.
-            for candidate in imp.qualifier.candidates(&imp.module_path) {
-                if let Some(i) = self
-                    .classes
-                    .iter()
-                    .position(|c| named(c) && c.module_path == candidate)
-                {
-                    return Some(i);
-                }
-            }
-            // `impl super::C` names the parent module's `C` and nothing else:
-            // with none there, attaching to a `C` in the impl's own module —
-            // or to the one `C` anywhere — would be exactly the wrong class
-            // (#307 review).
-            if imp.qualifier.forbids_fallback() {
-                return None;
-            }
-        }
-
-        if let Some(i) = self
-            .classes
-            .iter()
-            .position(|c| named(c) && c.module_path == imp.module_path)
-        {
-            return Some(i);
-        }
-
-        // A bare `impl C` is disambiguated by whatever brought `C` into scope:
-        // `use crate::a::C;` in the impl's module names `a::C` exactly, even
-        // though the impl itself writes no qualifier.
-        for import in &self.imports {
-            if import.module_path != imp.module_path || import.alias != name {
-                continue;
-            }
-            let target = import.path.last().map(String::as_str).unwrap_or(&name);
-            for candidate in import.qualifier.candidates(&imp.module_path) {
-                if let Some(i) = self
-                    .classes
-                    .iter()
-                    .position(|c| c.entry.name == target && c.module_path == candidate)
-                {
-                    return Some(i);
-                }
-            }
-        }
-
-        let mut matching = self.classes.iter().enumerate().filter(|(_, c)| named(c));
-        match (matching.next(), matching.next()) {
-            (Some((i, _)), None) => Some(i),
-            // No class of that name, or an ambiguous one.
-            _ => None,
-        }
-    }
-}
-
-/// One `use` path in scope: where it was written, the name it binds, and the
-/// module path it names.
-#[derive(Debug)]
-struct ScannedImport {
-    module_path: Vec<String>,
-    /// The name the import binds — the last segment, or the `as` alias.
-    alias: String,
-    /// The full path it names, anchor stripped: `crate::a::C` -> `["a", "C"]`.
-    path: Vec<String>,
-    /// Where that path is rooted, so `use crate::a::C;` and `use a::C;` are
-    /// not confused when the enclosing module also has an `a`.
-    qualifier: PathQualifier,
-}
-
-/// Flatten a `use` tree into the names it binds and the paths they name,
-/// **anchor included**.
-///
-/// `use crate::a::{C, D as E};` yields `("C", ["crate", "a", "C"])` and
-/// `("E", ["crate", "a", "D"])`; the caller splits the anchor off with
-/// [`path_qualifier`], so `use crate::a::C;` and `use a::C;` stay distinct.
-/// A glob (`use a::*;`) binds no name it can be matched on and is skipped.
-/// `super::` is kept: [`path_qualifier`] resolves it against the module the
-/// `use` was written in, like any other anchor (#307 review).
-fn flatten_use_tree(
-    tree: &syn::UseTree,
-    prefix: &mut Vec<String>,
-    out: &mut Vec<(String, Vec<String>)>,
-) {
-    match tree {
-        syn::UseTree::Path(path) => {
-            let segment = path.ident.to_string();
-            prefix.push(segment);
-            flatten_use_tree(&path.tree, prefix, out);
-            prefix.pop();
-        }
-        syn::UseTree::Name(name) => {
-            let mut full = prefix.clone();
-            full.push(name.ident.to_string());
-            out.push((name.ident.to_string(), full));
-        }
-        syn::UseTree::Rename(rename) => {
-            let mut full = prefix.clone();
-            full.push(rename.ident.to_string());
-            out.push((rename.rename.to_string(), full));
-        }
-        syn::UseTree::Group(group) => {
-            for item in &group.items {
-                flatten_use_tree(item, prefix, out);
-            }
-        }
-        // A glob binds no name this matcher can key on.
-        syn::UseTree::Glob(_) => {}
     }
 }
 

--- a/deps/rustcall_core/tests/cfg_pruning.rs
+++ b/deps/rustcall_core/tests/cfg_pruning.rs
@@ -599,24 +599,34 @@ fn enclosing_module_cfg_is_inherited() {
     assert_eq!(m.structs[0].cfg, "feature = \"x\"");
     // ... and a file reached through a gated `mod a;` declaration, whose
     // predicate the tree walk hands to the file's scan.
-    let root: syn::File = syn::parse_str("#[cfg(feature = \"x\")] pub mod a;").unwrap();
-    let mut scan = rustcall_core::pyo3::Pyo3Scan::new();
+    let mut scan = rustcall_core::extract::TreeScan::new();
     let mut manifest = rustcall_core::Manifest::new(Mode::Crate);
-    let pending = scan.file(&root.items, &[], true, &[], &mut manifest);
+    let pending = scan
+        .file(
+            "#[cfg(feature = \"x\")] pub mod a;",
+            None,
+            &[],
+            true,
+            &[],
+            &mut manifest,
+            "src/lib.rs",
+        )
+        .unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].cfg.len(), 1);
-    let more = rustcall_core::extract::extract_pyo3_file(
-        "#[pyfunction] pub fn run() -> i32 { 1 }",
-        None,
-        &pending[0].module_path,
-        pending[0].reachable,
-        &pending[0].cfg,
-        &mut scan,
-        &mut manifest,
-    )
-    .unwrap();
+    let more = scan
+        .file(
+            "#[pyfunction] pub fn run() -> i32 { 1 }",
+            None,
+            &pending[0].module_path,
+            pending[0].reachable,
+            &pending[0].cfg,
+            &mut manifest,
+            "src/a.rs",
+        )
+        .unwrap();
     assert!(more.is_empty());
-    scan.finish(&mut manifest);
+    scan.finish(&mut manifest).unwrap();
     assert_eq!(manifest.functions[0].module_path, vec!["a"]);
     assert_eq!(manifest.functions[0].cfg, "feature = \"x\"");
     assert_eq!(manifest.functions[0].cfg_features, vec!["x"]);

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.crate.toml
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.crate.toml
@@ -1,0 +1,270 @@
+schema_version = 7
+mode = "crate"
+functions = []
+
+[[structs]]
+name = "Gauge"
+ffi_name = "Gauge"
+attribute = "julia"
+vis = "pub"
+skip_reason = ""
+python_name = ""
+cfg = ""
+cfg_features = []
+type_params = []
+derives = []
+has_clone = false
+has_owned_string_helper = false
+has_borrowed_string_helper = false
+context_source = ""
+generic_wrappers = []
+line = 12
+module_path = []
+
+[[structs.fields]]
+name = "value"
+rust_type = "i32"
+abi = ""
+ffi_compatible = true
+getter = "Gauge_get_value"
+setter = "Gauge_set_value"
+python_name = ""
+vis = ""
+
+[[structs.methods]]
+name = "new"
+symbol = "rustcall_Gauge_new"
+is_static = true
+is_mutable = false
+is_constructor = true
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = true
+return_type = "Self"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods.args]]
+name = "value"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods]]
+name = "label"
+symbol = "rustcall_Gauge_label"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "String"
+return_abi = "string"
+generic_wrapper = ""
+
+[[structs.methods]]
+name = "scaled"
+symbol = "rustcall_Gauge_scaled"
+is_static = true
+is_mutable = false
+is_constructor = true
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = true
+return_type = "Self"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods.args]]
+name = "value"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods.args]]
+name = "factor"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods]]
+name = "read"
+symbol = "rustcall_Gauge_read"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "i32"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods]]
+name = "bump"
+symbol = "rustcall_Gauge_bump"
+is_static = false
+is_mutable = true
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "unit"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "()"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods]]
+name = "halved"
+symbol = "rustcall_Gauge_halved"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "result"
+ok_type = "i32"
+err_type = "String"
+inner_type = ""
+ok_abi = ""
+err_abi = "string"
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "Result<i32, String>"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs]]
+name = "C"
+ffi_name = "a__C"
+attribute = "julia"
+vis = "pub"
+skip_reason = ""
+python_name = ""
+cfg = ""
+cfg_features = []
+type_params = []
+derives = []
+has_clone = false
+has_owned_string_helper = false
+has_borrowed_string_helper = false
+context_source = ""
+generic_wrappers = []
+line = 77
+module_path = ["a"]
+
+[[structs.fields]]
+name = "v"
+rust_type = "i32"
+abi = ""
+ffi_compatible = true
+getter = "a__C_get_v"
+setter = "a__C_set_v"
+python_name = ""
+vis = ""
+
+[[structs.methods]]
+name = "new"
+symbol = "rustcall_a__C_new"
+is_static = true
+is_mutable = false
+is_constructor = true
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = true
+return_type = "Self"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods.args]]
+name = "v"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods]]
+name = "get"
+symbol = "rustcall_a__C_get"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "i32"
+return_abi = ""
+generic_wrapper = ""

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.expanded.rs
@@ -1,0 +1,787 @@
+//! A `#[julia] impl` block in another module than its struct (#315).
+//!
+//! The struct sits at the crate root; its methods come from a marked child
+//! module through `super::`, from another through `crate::`, and from an
+//! unmarked module through a `use`. Every method symbol follows the *struct*
+//! (`rustcall_Gauge_read`), not the module the block was written in, in both
+//! flavours: the crate flavour reads the header (`impl_target_module_path`),
+//! the inline flavour resolves it against the whole block (`ModelTree`).
+//! A second struct lives in a marked module and gets a method from a sibling
+//! marked module by its full path.
+pub struct Gauge {
+    pub value: i32,
+}
+#[no_mangle]
+pub extern "C" fn Gauge_free(ptr: *mut Gauge) {
+    if !ptr.is_null() {
+        unsafe {
+            drop(Box::from_raw(ptr));
+        }
+    }
+}
+#[repr(C)]
+pub struct Gauge_RustCallOwnedString {
+    pub ptr: *mut u8,
+    pub len: usize,
+    pub cap: usize,
+}
+#[no_mangle]
+pub extern "C" fn Gauge_free_rust_string(ptr: *mut u8, len: usize, cap: usize) {
+    if !ptr.is_null() {
+        unsafe {
+            drop(Vec::from_raw_parts(ptr, len, cap));
+        }
+    }
+}
+#[no_mangle]
+pub extern "C" fn Gauge_get_value(ptr: *const Gauge) -> i32 {
+    unsafe { (*ptr).value }
+}
+#[no_mangle]
+pub extern "C" fn Gauge_set_value(ptr: *mut Gauge, value: i32) {
+    unsafe {
+        (*ptr).value = value;
+    }
+}
+thread_local! {
+    static __RUSTCALL_PANIC_RUSTCALL_GAUGE_NEW : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_new_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_PANIC_RUSTCALL_GAUGE_NEW
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_new(value: i32) -> *mut Gauge {
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            let obj = Gauge::new(value);
+            Box::into_raw(Box::new(obj))
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge::new", rustcall_message
+            );
+            __RUSTCALL_PANIC_RUSTCALL_GAUGE_NEW
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            ::std::ptr::null_mut()
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_PANIC_RUSTCALL_GAUGE_READ : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_read_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_PANIC_RUSTCALL_GAUGE_READ
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_read(ptr: *const Gauge) -> i32 {
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            let self_obj = unsafe { &*ptr };
+            self_obj.read()
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge::read", rustcall_message
+            );
+            __RUSTCALL_PANIC_RUSTCALL_GAUGE_READ
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<i32>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_PANIC_RUSTCALL_GAUGE_BUMP : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_bump_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_PANIC_RUSTCALL_GAUGE_BUMP
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_bump(ptr: *mut Gauge) {
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            let self_obj = unsafe { &mut *ptr };
+            self_obj.bump()
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge::bump", rustcall_message
+            );
+            __RUSTCALL_PANIC_RUSTCALL_GAUGE_BUMP
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_PANIC_RUSTCALL_GAUGE_LABEL : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_label_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_PANIC_RUSTCALL_GAUGE_LABEL
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_label(ptr: *const Gauge) -> Gauge_RustCallOwnedString {
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            let self_obj = unsafe { &*ptr };
+            let rustcall_value = self_obj.label();
+            let mut rustcall_bytes = ToString::to_string(&rustcall_value).into_bytes();
+            let rustcall_ret = Gauge_RustCallOwnedString {
+                ptr: rustcall_bytes.as_mut_ptr(),
+                len: rustcall_bytes.len(),
+                cap: rustcall_bytes.capacity(),
+            };
+            std::mem::forget(rustcall_bytes);
+            rustcall_ret
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge::label", rustcall_message
+            );
+            __RUSTCALL_PANIC_RUSTCALL_GAUGE_LABEL
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            Gauge_RustCallOwnedString {
+                ptr: ::std::ptr::null_mut(),
+                len: 0,
+                cap: 0,
+            }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_PANIC_RUSTCALL_GAUGE_SCALED : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_scaled_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_PANIC_RUSTCALL_GAUGE_SCALED
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_scaled(value: i32, factor: i32) -> *mut Gauge {
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            let obj = Gauge::scaled(value, factor);
+            Box::into_raw(Box::new(obj))
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge::scaled", rustcall_message
+            );
+            __RUSTCALL_PANIC_RUSTCALL_GAUGE_SCALED
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            ::std::ptr::null_mut()
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_PANIC_RUSTCALL_GAUGE_HALVED : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_halved_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_PANIC_RUSTCALL_GAUGE_HALVED
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
+#[repr(C)]
+pub struct CResult_Gauge_halved {
+    is_ok: u8,
+    /// Only initialized when `is_ok == 1`. `MaybeUninit` keeps the
+    /// inactive field free of validity invariants (e.g. `NonZeroU32`).
+    ok_value: ::std::mem::MaybeUninit<i32>,
+    /// Only initialized when `is_ok == 0`.
+    err_value: ::std::mem::MaybeUninit<Gauge_RustCallOwnedString>,
+}
+impl CResult_Gauge_halved {
+    /// Wrap a `Result` in the C-compatible representation.
+    pub fn new(value: Result<i32, Gauge_RustCallOwnedString>) -> Self {
+        match value {
+            Ok(v) => {
+                Self {
+                    is_ok: 1,
+                    ok_value: ::std::mem::MaybeUninit::new(v),
+                    err_value: ::std::mem::MaybeUninit::zeroed(),
+                }
+            }
+            Err(e) => {
+                Self {
+                    is_ok: 0,
+                    ok_value: ::std::mem::MaybeUninit::zeroed(),
+                    err_value: ::std::mem::MaybeUninit::new(e),
+                }
+            }
+        }
+    }
+    /// Whether the call succeeded.
+    pub fn is_ok(&self) -> bool {
+        self.is_ok == 1
+    }
+    /// The `Ok` value, if any.
+    pub fn ok(&self) -> Option<&i32> {
+        if self.is_ok == 1 {
+            Some(unsafe { self.ok_value.assume_init_ref() })
+        } else {
+            None
+        }
+    }
+    /// The `Err` value, if any.
+    pub fn err(&self) -> Option<&Gauge_RustCallOwnedString> {
+        if self.is_ok == 0 {
+            Some(unsafe { self.err_value.assume_init_ref() })
+        } else {
+            None
+        }
+    }
+    /// The value returned after a caught panic (#244): the `Err`
+    /// discriminant with **no** payload initialized.
+    ///
+    /// Julia reads this wrapper's panic channel before it decodes
+    /// anything, and raises `RustPanicError`, so neither payload is
+    /// ever observed. Both stay `MaybeUninit::zeroed()`, which is what
+    /// `new` already writes for the inactive side.
+    pub fn panicked() -> Self {
+        Self {
+            is_ok: 0,
+            ok_value: ::std::mem::MaybeUninit::zeroed(),
+            err_value: ::std::mem::MaybeUninit::zeroed(),
+        }
+    }
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Gauge_halved(ptr: *const Gauge) -> CResult_Gauge_halved {
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            let self_obj = unsafe { &*ptr };
+            CResult_Gauge_halved::new(
+                match self_obj.halved() {
+                    ::std::result::Result::Ok(rustcall_ok) => {
+                        ::std::result::Result::Ok(rustcall_ok)
+                    }
+                    ::std::result::Result::Err(rustcall_err) => {
+                        ::std::result::Result::Err({
+                            let mut rustcall_bytes = ToString::to_string(&rustcall_err)
+                                .into_bytes();
+                            let rustcall_buf = Gauge_RustCallOwnedString {
+                                ptr: rustcall_bytes.as_mut_ptr(),
+                                len: rustcall_bytes.len(),
+                                cap: rustcall_bytes.capacity(),
+                            };
+                            ::std::mem::forget(rustcall_bytes);
+                            rustcall_buf
+                        })
+                    }
+                },
+            )
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge::halved", rustcall_message
+            );
+            __RUSTCALL_PANIC_RUSTCALL_GAUGE_HALVED
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            CResult_Gauge_halved::panicked()
+        }
+    }
+}
+impl Gauge {
+    pub fn new(value: i32) -> Self {
+        Self { value }
+    }
+}
+pub mod ops {
+    impl super::Gauge {
+        pub fn read(&self) -> i32 {
+            self.value
+        }
+        pub fn bump(&mut self) {
+            self.value += 1;
+        }
+    }
+}
+pub mod more {
+    impl crate::Gauge {
+        pub fn label(&self) -> String {
+            format!("Gauge({})", self.value)
+        }
+        pub fn scaled(value: i32, factor: i32) -> Self {
+            Self { value: value * factor }
+        }
+    }
+}
+pub mod plain {
+    use super::Gauge;
+    impl Gauge {
+        pub fn halved(&self) -> Result<i32, String> {
+            if self.value % 2 == 0 {
+                Ok(self.value / 2)
+            } else {
+                Err(format!("{} is odd", self.value))
+            }
+        }
+    }
+}
+pub mod a {
+    pub struct C {
+        pub v: i32,
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_free(ptr: *mut C) {
+        if !ptr.is_null() {
+            unsafe {
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_get_v(ptr: *const C) -> i32 {
+        unsafe { (*ptr).v }
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_set_v(ptr: *mut C, value: i32) {
+        unsafe {
+            (*ptr).v = value;
+        }
+    }
+    thread_local! {
+        static __RUSTCALL_PANIC_RUSTCALL_A__C_NEW : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn rustcall_a__C_new_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_PANIC_RUSTCALL_A__C_NEW
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
+    #[no_mangle]
+    pub extern "C" fn rustcall_a__C_new(v: i32) -> *mut C {
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                let obj = C::new(v);
+                Box::into_raw(Box::new(obj))
+            }),
+        ) {
+            ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "C::new", rustcall_message
+                );
+                __RUSTCALL_PANIC_RUSTCALL_A__C_NEW
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+                ::std::ptr::null_mut()
+            }
+        }
+    }
+    thread_local! {
+        static __RUSTCALL_PANIC_RUSTCALL_A__C_GET : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn rustcall_a__C_get_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_PANIC_RUSTCALL_A__C_GET
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
+    #[no_mangle]
+    pub extern "C" fn rustcall_a__C_get(ptr: *const C) -> i32 {
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                let self_obj = unsafe { &*ptr };
+                self_obj.get()
+            }),
+        ) {
+            ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "C::get", rustcall_message
+                );
+                __RUSTCALL_PANIC_RUSTCALL_A__C_GET
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+                unsafe { ::std::mem::zeroed::<i32>() }
+            }
+        }
+    }
+    impl C {
+        pub fn new(v: i32) -> Self {
+            Self { v }
+        }
+    }
+}
+pub mod b {
+    impl crate::a::C {
+        pub fn get(&self) -> i32 {
+            self.v
+        }
+    }
+}

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.inline.toml
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.inline.toml
@@ -1,0 +1,270 @@
+schema_version = 7
+mode = "inline"
+functions = []
+
+[[structs]]
+name = "Gauge"
+ffi_name = "Gauge"
+attribute = "julia"
+vis = "pub"
+skip_reason = ""
+python_name = ""
+cfg = ""
+cfg_features = []
+type_params = []
+derives = []
+has_clone = false
+has_owned_string_helper = true
+has_borrowed_string_helper = false
+context_source = ""
+generic_wrappers = []
+line = 12
+module_path = []
+
+[[structs.fields]]
+name = "value"
+rust_type = "i32"
+abi = ""
+ffi_compatible = true
+getter = "Gauge_get_value"
+setter = "Gauge_set_value"
+python_name = ""
+vis = ""
+
+[[structs.methods]]
+name = "new"
+symbol = "rustcall_Gauge_new"
+is_static = true
+is_mutable = false
+is_constructor = true
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = true
+return_type = "Self"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods.args]]
+name = "value"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods]]
+name = "read"
+symbol = "rustcall_Gauge_read"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "i32"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods]]
+name = "bump"
+symbol = "rustcall_Gauge_bump"
+is_static = false
+is_mutable = true
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "unit"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "()"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods]]
+name = "label"
+symbol = "rustcall_Gauge_label"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "String"
+return_abi = "string"
+generic_wrapper = ""
+
+[[structs.methods]]
+name = "scaled"
+symbol = "rustcall_Gauge_scaled"
+is_static = true
+is_mutable = false
+is_constructor = true
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = true
+return_type = "Self"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods.args]]
+name = "value"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods.args]]
+name = "factor"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods]]
+name = "halved"
+symbol = "rustcall_Gauge_halved"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "result"
+ok_type = "i32"
+err_type = "String"
+inner_type = ""
+ok_abi = ""
+err_abi = "string"
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "Result<i32, String>"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs]]
+name = "C"
+ffi_name = "a__C"
+attribute = "julia"
+vis = "pub"
+skip_reason = ""
+python_name = ""
+cfg = ""
+cfg_features = []
+type_params = []
+derives = []
+has_clone = false
+has_owned_string_helper = false
+has_borrowed_string_helper = false
+context_source = ""
+generic_wrappers = []
+line = 77
+module_path = ["a"]
+
+[[structs.fields]]
+name = "v"
+rust_type = "i32"
+abi = ""
+ffi_compatible = true
+getter = "a__C_get_v"
+setter = "a__C_set_v"
+python_name = ""
+vis = ""
+
+[[structs.methods]]
+name = "new"
+symbol = "rustcall_a__C_new"
+is_static = true
+is_mutable = false
+is_constructor = true
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = true
+return_type = "Self"
+return_abi = ""
+generic_wrapper = ""
+
+[[structs.methods.args]]
+name = "v"
+rust_type = "i32"
+abi = ""
+
+[[structs.methods]]
+name = "get"
+symbol = "rustcall_a__C_get"
+is_static = false
+is_mutable = false
+is_constructor = false
+vis = "pub"
+skip_reason = ""
+python_name = ""
+accessor = ""
+attribute = "julia"
+return_kind = "plain"
+ok_type = ""
+err_type = ""
+inner_type = ""
+ok_abi = ""
+err_abi = ""
+inner_abi = ""
+returns_boxed_struct = false
+args = []
+return_type = "i32"
+return_abi = ""
+generic_wrapper = ""

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.rs
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.rs
@@ -1,0 +1,100 @@
+//! A `#[julia] impl` block in another module than its struct (#315).
+//!
+//! The struct sits at the crate root; its methods come from a marked child
+//! module through `super::`, from another through `crate::`, and from an
+//! unmarked module through a `use`. Every method symbol follows the *struct*
+//! (`rustcall_Gauge_read`), not the module the block was written in, in both
+//! flavours: the crate flavour reads the header (`impl_target_module_path`),
+//! the inline flavour resolves it against the whole block (`ModelTree`).
+//! A second struct lives in a marked module and gets a method from a sibling
+//! marked module by its full path.
+
+#[julia]
+pub struct Gauge {
+    pub value: i32,
+}
+
+#[julia]
+impl Gauge {
+    #[julia]
+    pub fn new(value: i32) -> Self {
+        Self { value }
+    }
+}
+
+#[julia]
+pub mod ops {
+    #[julia]
+    impl super::Gauge {
+        #[julia]
+        pub fn read(&self) -> i32 {
+            self.value
+        }
+
+        #[julia]
+        pub fn bump(&mut self) {
+            self.value += 1;
+        }
+    }
+}
+
+#[julia]
+pub mod more {
+    #[julia]
+    impl crate::Gauge {
+        #[julia]
+        pub fn label(&self) -> String {
+            format!("Gauge({})", self.value)
+        }
+
+        #[julia]
+        pub fn scaled(value: i32, factor: i32) -> Self {
+            Self { value: value * factor }
+        }
+    }
+}
+
+// Unmarked: the block is expanded by the item-level macro, which sees no
+// module, so a bare `Gauge` brought in by `use` names the root struct.
+pub mod plain {
+    use super::Gauge;
+
+    #[julia]
+    impl Gauge {
+        #[julia]
+        pub fn halved(&self) -> Result<i32, String> {
+            if self.value % 2 == 0 {
+                Ok(self.value / 2)
+            } else {
+                Err(format!("{} is odd", self.value))
+            }
+        }
+    }
+}
+
+#[julia]
+pub mod a {
+    #[julia]
+    pub struct C {
+        pub v: i32,
+    }
+
+    #[julia]
+    impl C {
+        #[julia]
+        pub fn new(v: i32) -> Self {
+            Self { v }
+        }
+    }
+}
+
+#[julia]
+pub mod b {
+    #[julia]
+    impl crate::a::C {
+        #[julia]
+        pub fn get(&self) -> i32 {
+            self.v
+        }
+    }
+}

--- a/deps/rustcall_core/tests/cross_module_impl.rs
+++ b/deps/rustcall_core/tests/cross_module_impl.rs
@@ -1,0 +1,401 @@
+//! A `#[julia] impl` block in another module than its struct (#315).
+//!
+//! The crate scan collects structs and impl blocks across the whole module
+//! tree and marries them by resolved path, so the manifest lists the methods
+//! the proc-macro emits wherever the block was written. The multi-file layouts
+//! walk the tree the way `rustcall-extract --crate-root` does, one
+//! `TreeScan::file` call per file with its real module path.
+
+use rustcall_core::extract::{extract_crate, TreeScan};
+use rustcall_core::manifest::{Manifest, Mode, Struct};
+
+/// Scan `files` — `(module path, label, source)` — as one crate.
+fn scan_tree(files: &[(&[&str], &str, &str)]) -> Result<Manifest, String> {
+    let mut manifest = Manifest::new(Mode::Crate);
+    let mut scan = TreeScan::new();
+    for (path, label, source) in files {
+        let path: Vec<String> = path.iter().map(|s| s.to_string()).collect();
+        scan.file(source, None, &path, true, &[], &mut manifest, label)
+            .map_err(|e| e.to_string())?;
+    }
+    scan.finish(&mut manifest).map_err(|e| e.to_string())?;
+    manifest.sort();
+    Ok(manifest)
+}
+
+fn the_struct<'a>(manifest: &'a Manifest, name: &str) -> &'a Struct {
+    manifest
+        .structs
+        .iter()
+        .find(|s| s.name == name)
+        .unwrap_or_else(|| panic!("no struct `{name}` in {manifest:?}"))
+}
+
+fn method_symbols(s: &Struct) -> Vec<String> {
+    let mut v: Vec<String> = s.methods.iter().map(|m| m.symbol.clone()).collect();
+    v.sort();
+    v
+}
+
+const LIB_RS: &str = r#"
+    mod ops;
+    mod more;
+    #[julia] pub struct Gauge { pub value: i32 }
+    #[julia] impl Gauge { #[julia] pub fn new(value: i32) -> Self { Self { value } } }
+"#;
+
+/// The layout of the issue: `struct Gauge` in `lib.rs`, `impl crate::Gauge`
+/// in `ops.rs`. The proc-macro emits `rustcall_Gauge_read`; so says the
+/// manifest, and the method sits on the struct.
+#[test]
+fn an_impl_in_a_sibling_file_binds_its_methods() {
+    let manifest = scan_tree(&[
+        (&[], "src/lib.rs", LIB_RS),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "#[julia] impl crate::Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }",
+        ),
+        (
+            &["more"],
+            "src/more.rs",
+            r#"
+            use crate::Gauge;
+            #[julia] impl Gauge {
+                #[julia] pub fn label(&self) -> String { format!("{}", self.value) }
+            }
+            "#,
+        ),
+    ])
+    .unwrap();
+    let gauge = the_struct(&manifest, "Gauge");
+    assert_eq!(gauge.ffi_name, "Gauge");
+    assert!(gauge.module_path.is_empty());
+    assert_eq!(
+        method_symbols(gauge),
+        vec![
+            "rustcall_Gauge_label",
+            "rustcall_Gauge_new",
+            "rustcall_Gauge_read"
+        ]
+    );
+    // The string method's buffer hangs off the struct's FFI name, which is
+    // what Julia derives it from.
+    let label = gauge.methods.iter().find(|m| m.name == "label").unwrap();
+    assert_eq!(label.return_abi, "string");
+    assert!(manifest.structs.len() == 1, "{:?}", manifest.structs);
+}
+
+/// `super::Gauge` from a child file module: the file module is transparent to
+/// the symbol scheme, so `super::` from `ops` is the crate root for the macro
+/// as well as for the resolver.
+#[test]
+fn super_from_a_child_file_module_reaches_the_root_struct() {
+    let manifest = scan_tree(&[
+        (&[], "src/lib.rs", LIB_RS),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "#[julia] impl super::Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }",
+        ),
+    ])
+    .unwrap();
+    assert_eq!(
+        method_symbols(the_struct(&manifest, "Gauge")),
+        vec!["rustcall_Gauge_new", "rustcall_Gauge_read"]
+    );
+}
+
+/// The same within one file: a marked child module through `super::` and
+/// `crate::`, an unmarked one through `use`. (The golden corpus holds the full
+/// manifest of this layout, `cross_module_impl.crate.toml`.)
+#[test]
+fn marked_and_unmarked_inline_modules_attach_to_the_root_struct() {
+    let manifest = extract_crate(
+        r#"
+        #[julia] pub struct Gauge { pub value: i32 }
+        #[julia] pub mod ops {
+            #[julia] impl super::Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }
+        }
+        #[julia] pub mod more {
+            #[julia] impl crate::Gauge { #[julia] pub fn bump(&mut self) { self.value += 1 } }
+        }
+        pub mod plain {
+            use super::Gauge;
+            #[julia] impl Gauge { #[julia] pub fn twice(&self) -> i32 { self.value * 2 } }
+        }
+        "#,
+    )
+    .unwrap();
+    let gauge = the_struct(&manifest, "Gauge");
+    assert_eq!(
+        method_symbols(gauge),
+        vec![
+            "rustcall_Gauge_bump",
+            "rustcall_Gauge_read",
+            "rustcall_Gauge_twice"
+        ]
+    );
+    let bump = gauge.methods.iter().find(|m| m.name == "bump").unwrap();
+    assert!(bump.is_mutable);
+}
+
+/// A struct in a marked module, its block in a sibling marked module by full
+/// path: the symbols are the struct's (`a__C`), not the block's (`b__C`).
+#[test]
+fn a_full_path_names_a_struct_in_another_marked_module() {
+    let manifest = extract_crate(
+        r#"
+        #[julia] pub mod a { #[julia] pub struct C { pub v: i32 } }
+        #[julia] pub mod b {
+            #[julia] impl crate::a::C { #[julia] pub fn get(&self) -> i32 { self.v } }
+        }
+        "#,
+    )
+    .unwrap();
+    let c = the_struct(&manifest, "C");
+    assert_eq!(c.ffi_name, "a__C");
+    assert_eq!(c.module_path, vec!["a".to_string()]);
+    assert_eq!(method_symbols(c), vec!["rustcall_a__C_get"]);
+}
+
+/// The resolver keeps two same-named structs apart the way the PyO3 scan does:
+/// a bare `impl C` in `b` is `b::C`, `impl super::C` from `b::inner` is `b::C`,
+/// `impl crate::a::C` is `a::C` wherever it is written.
+#[test]
+fn same_named_structs_in_two_modules_get_their_own_blocks() {
+    let manifest = extract_crate(
+        r#"
+        #[julia] pub mod a { #[julia] pub struct C { pub v: i32 } }
+        #[julia] pub mod b {
+            #[julia] pub struct C { pub v: i32 }
+            #[julia] impl C { #[julia] pub fn own(&self) -> i32 { self.v } }
+            #[julia] pub mod inner {
+                #[julia] impl super::C { #[julia] pub fn up(&self) -> i32 { self.v } }
+            }
+            #[julia] impl crate::a::C { #[julia] pub fn far(&self) -> i32 { self.v } }
+        }
+        "#,
+    )
+    .unwrap();
+    let a = manifest
+        .structs
+        .iter()
+        .find(|s| s.ffi_name == "a__C")
+        .unwrap();
+    let b = manifest
+        .structs
+        .iter()
+        .find(|s| s.ffi_name == "b__C")
+        .unwrap();
+    assert_eq!(method_symbols(a), vec!["rustcall_a__C_far"]);
+    assert_eq!(
+        method_symbols(b),
+        vec!["rustcall_b__C_own", "rustcall_b__C_up"]
+    );
+}
+
+/// A block whose header names no `#[julia]` struct fails the scan with the
+/// path it looked at — never a struct silently without its methods.
+#[test]
+fn an_unresolved_header_is_reported_not_dropped() {
+    let err = scan_tree(&[
+        (
+            &[],
+            "src/lib.rs",
+            "mod ops; #[julia] pub struct Gauge { pub value: i32 }",
+        ),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "#[julia] impl crate::Meter { #[julia] pub fn read(&self) -> i32 { 0 } }",
+        ),
+    ])
+    .expect_err("an impl naming no #[julia] struct must fail the scan");
+    assert!(
+        err.contains("`impl crate::Meter` (line 1 in src/ops.rs)"),
+        "{err}"
+    );
+    assert!(err.contains("names no #[julia] struct"), "{err}");
+    assert!(err.contains("at `crate`"), "{err}");
+
+    // A plain struct without `#[julia]` is not a target either.
+    let err = extract_crate(
+        r#"
+        pub struct Plain { pub v: i32 }
+        #[julia] impl Plain { #[julia] pub fn get(&self) -> i32 { self.v } }
+        "#,
+    )
+    .expect_err("a #[julia] impl of a plain struct must fail the scan")
+    .to_string();
+    assert!(err.contains("no `struct Plain` marked `#[julia]`"), "{err}");
+    assert!(err.contains("anywhere in the crate"), "{err}");
+
+    // A block with no `#[julia]` method emits nothing, whatever it names.
+    let manifest = extract_crate(
+        r#"
+        pub struct Plain { pub v: i32 }
+        #[julia] impl Plain { pub fn get(&self) -> i32 { self.v } }
+        "#,
+    )
+    .unwrap();
+    assert!(manifest.structs.is_empty());
+}
+
+/// Two structs of one name and a bare header that nothing disambiguates: the
+/// scan says which two and how to pick.
+#[test]
+fn an_ambiguous_bare_header_is_reported() {
+    let err = extract_crate(
+        r#"
+        #[julia] pub mod a { #[julia] pub struct C { pub v: i32 } }
+        #[julia] pub mod b { #[julia] pub struct C { pub v: i32 } }
+        #[julia] pub mod c {
+            #[julia] impl C { #[julia] pub fn get(&self) -> i32 { self.v } }
+        }
+        "#,
+    )
+    .expect_err("an ambiguous impl header must fail the scan")
+    .to_string();
+    assert!(err.contains("`impl C` (line 5) is ambiguous"), "{err}");
+    assert!(err.contains("`crate::a` and `crate::b`"), "{err}");
+    assert!(err.contains("`impl crate::a::C`"), "{err}");
+}
+
+/// The proc-macro derives a method's symbol from the header and the marked
+/// modules around the block. When that is not the struct's own path the
+/// wrappers would be exported under one stem and `free` under another, so the
+/// scan refuses the block and spells the header that agrees.
+#[test]
+fn a_header_the_macro_would_qualify_differently_is_refused() {
+    // Bare `impl Gauge` inside a marked module, for the root struct: the macro
+    // would emit `rustcall_ops__Gauge_read`; `Gauge_free` is the struct's.
+    let err = extract_crate(
+        r#"
+        #[julia] pub struct Gauge { pub value: i32 }
+        #[julia] pub mod ops {
+            use super::Gauge;
+            #[julia] impl Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }
+        }
+        "#,
+    )
+    .expect_err("a header the macro qualifies differently must fail the scan")
+    .to_string();
+    assert!(err.contains("`impl Gauge` (line 5)"), "{err}");
+    assert!(err.contains("inside the `#[julia]` module `ops`"), "{err}");
+    assert!(err.contains("`rustcall_ops__Gauge_<method>`"), "{err}");
+    assert!(err.contains("has the FFI name `Gauge`"), "{err}");
+    assert!(
+        err.contains("write the header as `impl crate::Gauge`"),
+        "{err}"
+    );
+
+    // A struct in a file module named by its full path: `shapes` does not
+    // qualify symbols, but the macro cannot know that from `crate::shapes::Gauge`.
+    let err = scan_tree(&[
+        (&[], "src/lib.rs", "mod shapes; mod ops;"),
+        (
+            &["shapes"],
+            "src/shapes.rs",
+            "#[julia] pub struct Gauge { pub value: i32 }",
+        ),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "#[julia] impl crate::shapes::Gauge { #[julia] pub fn read(&self) -> i32 { 0 } }",
+        ),
+    ])
+    .expect_err("a header naming a file module must fail the scan");
+    assert!(
+        err.contains("`impl crate::shapes::Gauge` (line 1 in src/ops.rs)"),
+        "{err}"
+    );
+    assert!(err.contains("`rustcall_shapes__Gauge_<method>`"), "{err}");
+    assert!(
+        err.contains("`crate::shapes::Gauge`, has the FFI name `Gauge`"),
+        "{err}"
+    );
+    assert!(err.contains("`use crate::shapes::Gauge;`"), "{err}");
+
+    // The spelling the message asks for passes.
+    let manifest = scan_tree(&[
+        (&[], "src/lib.rs", "mod shapes; mod ops;"),
+        (
+            &["shapes"],
+            "src/shapes.rs",
+            "#[julia] pub struct Gauge { pub value: i32 }",
+        ),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "use crate::shapes::Gauge; #[julia] impl Gauge { #[julia] pub fn read(&self) -> i32 { 0 } }",
+        ),
+    ])
+    .unwrap();
+    assert_eq!(
+        method_symbols(the_struct(&manifest, "Gauge")),
+        vec!["rustcall_Gauge_read"]
+    );
+}
+
+/// An unmarked inline module cuts the chain of marked modules: whatever is
+/// inside it is expanded by the item-level macro, which sees no module, so a
+/// marked module below it starts a chain of its own — `b::f`, not `a::b::f`.
+/// The scan records what the macro does.
+#[test]
+fn an_unmarked_module_cuts_the_symbol_path() {
+    let manifest = extract_crate(
+        r#"
+        #[julia] pub mod a {
+            pub mod x {
+                #[julia] pub mod b { #[julia] pub fn f() -> i32 { 1 } }
+            }
+        }
+        "#,
+    )
+    .unwrap();
+    assert_eq!(manifest.functions[0].symbol, "rustcall_b__f");
+    assert_eq!(manifest.functions[0].module_path, vec!["b".to_string()]);
+}
+
+/// The crate-wide duplicate check runs across files with both locations.
+#[test]
+fn duplicate_symbols_across_files_name_both_files() {
+    let err = scan_tree(&[
+        (&[], "src/lib.rs", "mod x; mod y;"),
+        (&["x"], "src/x.rs", "#[julia] pub fn run() -> i32 { 1 }"),
+        (&["y"], "src/y.rs", "#[julia] pub fn run() -> i32 { 2 }"),
+    ])
+    .expect_err("two file modules exporting one symbol must fail the scan");
+    assert!(
+        err.contains("duplicate exported symbol `rustcall_run`"),
+        "{err}"
+    );
+    assert!(err.contains("in src/x.rs"), "{err}");
+    assert!(err.contains("in src/y.rs"), "{err}");
+}
+
+/// The inline flavour matches across the block too, so a `rust"""` block with
+/// the split layout wraps the same methods and both flavours agree.
+#[test]
+fn the_inline_flavour_attaches_across_modules_as_well() {
+    let src = r#"
+        #[julia] pub struct Gauge { pub value: i32 }
+        pub mod ops {
+            #[julia] impl super::Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }
+        }
+    "#;
+    let inline = rustcall_core::expand::expand(src).unwrap();
+    let gauge = the_struct(&inline.manifest, "Gauge");
+    assert_eq!(method_symbols(gauge), vec!["rustcall_Gauge_read"]);
+    assert!(
+        inline.source.contains("fn rustcall_Gauge_read("),
+        "{}",
+        inline.source
+    );
+    let krate = extract_crate(&src.replace("pub mod ops", "#[julia] pub mod ops")).unwrap();
+    assert_eq!(
+        method_symbols(the_struct(&krate, "Gauge")),
+        method_symbols(gauge)
+    );
+}

--- a/deps/rustcall_core/tests/cross_module_impl.rs
+++ b/deps/rustcall_core/tests/cross_module_impl.rs
@@ -228,8 +228,10 @@ fn an_unresolved_header_is_reported_not_dropped() {
     )
     .expect_err("a #[julia] impl of a plain struct must fail the scan")
     .to_string();
-    assert!(err.contains("no `struct Plain` marked `#[julia]`"), "{err}");
-    assert!(err.contains("anywhere in the crate"), "{err}");
+    // The struct is found — resolution follows Rust's own rules — and refused
+    // for carrying no `#[julia]`, which names the fix (#315 review).
+    assert!(err.contains("not a `#[julia]` struct"), "{err}");
+    assert!(err.contains("the crate root"), "{err}");
 
     // A block with no `#[julia]` method emits nothing, whatever it names.
     let manifest = extract_crate(
@@ -398,4 +400,86 @@ fn the_inline_flavour_attaches_across_modules_as_well() {
         method_symbols(the_struct(&krate, "Gauge")),
         method_symbols(gauge)
     );
+}
+
+/// Rust resolves `impl Gauge` by scope, not by attribute: a plain `struct
+/// Gauge` beside the block is its target even though a `#[julia] struct Gauge`
+/// exists elsewhere. Attaching the methods to the annotated one would describe
+/// wrappers that dereference a pointer to the wrong type, so the scan refuses
+/// and says which struct to annotate (#315 review).
+#[test]
+fn an_impl_on_a_plain_local_struct_is_refused() {
+    let err = scan_tree(&[
+        (
+            &[],
+            "src/lib.rs",
+            "mod ops;\n#[julia] pub struct Gauge { pub value: i32 }",
+        ),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "pub struct Gauge { pub other: i32 }\n\
+             #[julia] impl Gauge { #[julia] pub fn read(&self) -> i32 { self.other } }",
+        ),
+    ])
+    .expect_err("an impl on the module's own plain struct must not attach to the annotated one");
+    assert!(err.contains("not a `#[julia]` struct"), "{err}");
+    assert!(err.contains("module `ops`"), "{err}");
+    assert!(err.contains("src/ops.rs"), "{err}");
+}
+
+/// The same layout with an explicit path names the annotated struct, and binds.
+#[test]
+fn an_explicit_path_reaches_past_a_plain_local_struct() {
+    let manifest = scan_tree(&[
+        (
+            &[],
+            "src/lib.rs",
+            "mod ops;\n#[julia] pub struct Gauge { pub value: i32 }",
+        ),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "pub struct Gauge { pub other: i32 }\n\
+             #[julia] impl crate::Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }",
+        ),
+    ])
+    .expect("`impl crate::Gauge` names the annotated struct");
+    assert_eq!(
+        method_symbols(the_struct(&manifest, "Gauge")),
+        vec!["rustcall_Gauge_read"]
+    );
+}
+
+/// `include!("api.rs")` compiles that file's items into the including module,
+/// with no `mod` declaration to follow: the tree walk reads it, so the items
+/// the proc-macro wraps are in the manifest too (#315 review).
+#[test]
+fn a_literal_include_is_followed() {
+    let dir = std::env::temp_dir().join(format!(
+        "rustcall_include_{}_{}",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("api.rs"),
+        "#[julia] pub fn included_add(a: i32, b: i32) -> i32 { a + b }",
+    )
+    .unwrap();
+    // A fragment that is not a module is left to the compiler, as before.
+    std::fs::write(dir.join("table.rs"), "[1, 2, 3]").unwrap();
+    let lib = dir.join("lib.rs");
+    let manifest = scan_tree(&[(
+        &[],
+        lib.to_str().unwrap(),
+        "include!(\"api.rs\");\n\
+         const TABLE: [i32; 3] = include!(\"table.rs\");\n\
+         #[julia] pub fn root_add(a: i32, b: i32) -> i32 { a + b }",
+    )])
+    .expect("a literal include! is followed");
+    let mut names: Vec<&str> = manifest.functions.iter().map(|f| f.name.as_str()).collect();
+    names.sort();
+    assert_eq!(names, vec!["included_add", "root_add"]);
+    std::fs::remove_dir_all(&dir).ok();
 }

--- a/deps/rustcall_core/tests/cross_module_impl.rs
+++ b/deps/rustcall_core/tests/cross_module_impl.rs
@@ -483,3 +483,54 @@ fn a_literal_include_is_followed() {
     assert_eq!(names, vec!["included_add", "root_add"]);
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// An `enum` or a `union` is a target too — neither can carry `#[julia]`, so a
+/// local one shadows a same-named annotated struct elsewhere and the block is
+/// refused rather than attached to the wrong type (#315 review).
+#[test]
+fn an_impl_on_a_plain_local_enum_is_refused() {
+    for (kind, decl) in [
+        ("enum", "pub enum Gauge { A, B }"),
+        ("union", "pub union Gauge { a: i32, b: u32 }"),
+    ] {
+        let err = scan_tree(&[
+            (
+                &[],
+                "src/lib.rs",
+                "mod ops;\n#[julia] pub struct Gauge { pub value: i32 }",
+            ),
+            (
+                &["ops"],
+                "src/ops.rs",
+                &format!(
+                    "{decl}\n#[julia] impl Gauge {{ #[julia] pub fn read(&self) -> i32 {{ 0 }} }}"
+                ),
+            ),
+        ])
+        .expect_err("a #[julia] impl of a plain local type must fail the scan");
+        assert!(err.contains("not a `#[julia]` struct"), "{kind}: {err}");
+        assert!(err.contains("module `ops`"), "{kind}: {err}");
+    }
+}
+
+/// A renamed import makes the proc-macro export `rustcall_Meter_*` while the
+/// manifest resolves the struct to `Gauge`: the stems differ, so the scan
+/// refuses and names the header to write (#315 review).
+#[test]
+fn a_renamed_import_in_an_impl_header_is_refused() {
+    let err = scan_tree(&[
+        (
+            &[],
+            "src/lib.rs",
+            "mod ops;\n#[julia] pub struct Gauge { pub value: i32 }",
+        ),
+        (
+            &["ops"],
+            "src/ops.rs",
+            "use crate::Gauge as Meter;\n\
+             #[julia] impl Meter { #[julia] pub fn read(&self) -> i32 { self.value } }",
+        ),
+    ])
+    .expect_err("a renamed import must not silently bind the wrong symbol");
+    assert!(err.contains("impl crate::Gauge"), "{err}");
+}

--- a/deps/rustcall_core/tests/golden.rs
+++ b/deps/rustcall_core/tests/golden.rs
@@ -92,6 +92,10 @@ fn corpus_matches_golden_files() {
     }
 }
 
+/// The expanded inline flavour of the corpus sources that exercise the struct
+/// wrappers must be Rust that `rustc` accepts as a `cdylib`: `struct_wrappers`
+/// for the `Result` / `Option` / string shapes, `cross_module_impl` for method
+/// wrappers whose impl block sits in another module than the struct (#315).
 #[test]
 fn compilable_wrappers_build_as_cdylib() {
     if Command::new("rustc").arg("--version").output().is_err() {
@@ -99,38 +103,40 @@ fn compilable_wrappers_build_as_cdylib() {
         return;
     }
 
-    let source_path = corpus_dir().join("struct_wrappers.rs");
-    let source = fs::read_to_string(&source_path).expect("failed to read compilation corpus");
-    let expanded = rustcall_core::expand::expand(&source).expect("failed to expand corpus");
+    for stem in ["struct_wrappers", "cross_module_impl"] {
+        let source_path = corpus_dir().join(format!("{stem}.rs"));
+        let source = fs::read_to_string(&source_path).expect("failed to read compilation corpus");
+        let expanded = rustcall_core::expand::expand(&source).expect("failed to expand corpus");
 
-    let temp_dir = std::env::temp_dir().join(format!(
-        "rustcall_core_golden_{}_{}",
-        std::process::id(),
-        std::thread::current().name().unwrap_or("test")
-    ));
-    fs::create_dir_all(&temp_dir).expect("failed to create rustc output directory");
-    let expanded_path = temp_dir.join("struct_wrappers.rs");
-    fs::write(&expanded_path, expanded.source).expect("failed to write expanded Rust source");
-    let library_path = temp_dir.join("rustcall_golden_cdylib");
+        let temp_dir = std::env::temp_dir().join(format!(
+            "rustcall_core_golden_{}_{}_{stem}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        fs::create_dir_all(&temp_dir).expect("failed to create rustc output directory");
+        let expanded_path = temp_dir.join(format!("{stem}.rs"));
+        fs::write(&expanded_path, expanded.source).expect("failed to write expanded Rust source");
+        let library_path = temp_dir.join("rustcall_golden_cdylib");
 
-    let output = Command::new("rustc")
-        .arg("--edition=2021")
-        .arg("--crate-name=rustcall_golden")
-        .arg("--crate-type=cdylib")
-        .arg(&expanded_path)
-        .arg("-o")
-        .arg(&library_path)
-        .output()
-        .expect("failed to invoke rustc");
+        let output = Command::new("rustc")
+            .arg("--edition=2021")
+            .arg("--crate-name=rustcall_golden")
+            .arg("--crate-type=cdylib")
+            .arg(&expanded_path)
+            .arg("-o")
+            .arg(&library_path)
+            .output()
+            .expect("failed to invoke rustc");
 
-    if let Err(error) = fs::remove_dir_all(&temp_dir) {
-        eprintln!("failed to remove {}: {error}", temp_dir.display());
+        if let Err(error) = fs::remove_dir_all(&temp_dir) {
+            eprintln!("failed to remove {}: {error}", temp_dir.display());
+        }
+        assert!(
+            output.status.success(),
+            "rustc rejected the expanded wrappers of {stem}.rs:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
-    assert!(
-        output.status.success(),
-        "rustc rejected expanded struct/Result/Option wrappers:\n{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
 }
 
 /// The #275 Phase-2 wrapper crate of every corpus source that has PyO3 items:

--- a/deps/rustcall_core/tests/method_payloads.rs
+++ b/deps/rustcall_core/tests/method_payloads.rs
@@ -179,7 +179,7 @@ fn cfg_is_propagated_to_every_generated_item() {
         #[cfg_attr(feature = "x", cfg(target_pointer_width = "64"))]
         pub fn describe(&self, unit: String) -> Result<String, String> { Ok(unit) }
     };
-    let ty: syn::Ident = syn::parse_quote!(Div);
+    let ty: syn::Type = syn::parse_quote!(Div);
     let src = flatten(&prettyplease::unparse(
         &syn::parse2(generate_method_wrapper_crate(&ty, &[], &method)).unwrap(),
     ));

--- a/deps/rustcall_core/tests/strings.rs
+++ b/deps/rustcall_core/tests/strings.rs
@@ -334,7 +334,7 @@ impl Greeter {
 "#,
     )
     .unwrap();
-    let struct_name: syn::Ident = syn::parse_str("Greeter").unwrap();
+    let struct_name: syn::Type = syn::parse_str("Greeter").unwrap();
     let mut out = proc_macro2::TokenStream::new();
     for i in &item.items {
         if let syn::ImplItem::Fn(m) = i {

--- a/deps/rustcall_core/tests/symbols.rs
+++ b/deps/rustcall_core/tests/symbols.rs
@@ -261,7 +261,6 @@ fn symbol_owners_feed_the_duplicate_check() {
     let m = extract(
         r#"
             #[julia] pub mod a { #[julia] pub fn run() -> i32 { 1 } }
-            #[julia] pub fn a__run() -> i32 { 2 }
             #[cfg(unix)] #[julia] pub fn portable() -> i32 { 1 }
             #[cfg(windows)] #[julia] pub fn portable() -> i32 { 2 }
             #[julia] pub struct C { pub v: i32 }
@@ -272,17 +271,37 @@ fn symbol_owners_feed_the_duplicate_check() {
     .unwrap();
     let owners = m.symbol_owners();
     let claims = |symbol: &str| owners.iter().filter(|(s, _)| s == symbol).count();
-    assert_eq!(claims("rustcall_a__run"), 2, "{owners:?}");
+    assert_eq!(claims("rustcall_a__run"), 1, "{owners:?}");
     assert_eq!(claims("rustcall_portable"), 0, "cfg variants are left out");
     assert_eq!(claims("C_free"), 1);
     assert_eq!(claims("C_get_v"), 1);
     assert_eq!(claims("C_set_v"), 1);
     assert_eq!(claims("rustcall_C_get"), 1);
     let (_, who) = owners.iter().find(|(s, _)| s == "rustcall_a__run").unwrap();
+    assert!(who.contains("`a::run`"), "{who}");
+}
+
+/// A crate-root `fn a__run` spells the symbol of `a::run`: the one coincidence
+/// the encoding cannot exclude. The scan refuses it with both owners instead
+/// of describing a `cdylib` that could not be linked — within one file as
+/// much as across files (#300, #315).
+#[test]
+fn a_duplicate_symbol_fails_extraction_with_both_owners() {
+    let err = extract(
+        r#"
+            #[julia] pub mod a { #[julia] pub fn run() -> i32 { 1 } }
+            #[julia] pub fn a__run() -> i32 { 2 }
+        "#,
+        Mode::Crate,
+    )
+    .expect_err("a duplicate exported symbol must fail the scan")
+    .to_string();
     assert!(
-        who.contains("`a::run`") || who.contains("`a__run`"),
-        "{who}"
+        err.contains("duplicate exported symbol `rustcall_a__run`"),
+        "{err}"
     );
+    assert!(err.contains("`a::run` (line 2)"), "{err}");
+    assert!(err.contains("`a__run` (line 3)"), "{err}");
 }
 
 /// The PyO3 wrapper generator names the destructor and the string helpers
@@ -331,11 +350,13 @@ fn pyo3_wrapper_flavour() {
         .any(|m| m.skip_reason.starts_with("symbol_collision"))),);
 }
 
-/// A `#[julia] impl C` away from its `#[julia] struct C` would take the
-/// symbol of the module it sits in, not the struct's; crate extraction refuses
-/// it instead of dropping the methods silently (#300 review).
+/// A bare `#[julia] impl C` at the crate root for a struct in `#[julia] mod a`:
+/// the proc-macro would export `rustcall_C_run` while the struct's symbols
+/// are `a__C`'s, so crate extraction refuses it and spells the header that
+/// agrees (`impl crate::a::C`); next to the struct, and through that header,
+/// the method is wrapped under the struct's stem (#300 review, #315).
 #[test]
-fn an_impl_outside_its_structs_module_is_refused() {
+fn an_impl_the_macro_would_qualify_differently_is_refused() {
     let src = r#"
         #[julia] pub mod a { #[julia] pub struct C { pub v: i32 } }
         use a::C;
@@ -344,12 +365,25 @@ fn an_impl_outside_its_structs_module_is_refused() {
     let err = extract(src, Mode::Crate).unwrap_err();
     assert!(matches!(err, ExtractError::Unsupported(_)), "{err}");
     let msg = err.to_string();
-    assert!(msg.contains("#[julia] impl `C` at the crate root"), "{msg}");
-    assert!(msg.contains("move the impl next to the struct"), "{msg}");
-    // Next to the struct it is wrapped under the struct's stem.
+    assert!(msg.contains("`impl C` (line 4)"), "{msg}");
+    assert!(msg.contains("`rustcall_C_<method>`"), "{msg}");
+    assert!(msg.contains("has the FFI name `a__C`"), "{msg}");
+    assert!(
+        msg.contains("write the header as `impl crate::a::C`"),
+        "{msg}"
+    );
+    // Next to the struct it is wrapped under the struct's stem ...
     let ok = extract(
         "#[julia] pub mod a { #[julia] pub struct C { pub v: i32 } \
          #[julia] impl C { #[julia] pub fn run(&self) -> i32 { self.v } } }",
+        Mode::Crate,
+    )
+    .unwrap();
+    assert_eq!(ok.structs[0].methods[0].symbol, "rustcall_a__C_run");
+    // ... and so is a block anywhere else whose header spells the path.
+    let ok = extract(
+        "#[julia] pub mod a { #[julia] pub struct C { pub v: i32 } } \
+         #[julia] impl crate::a::C { #[julia] pub fn run(&self) -> i32 { self.v } }",
         Mode::Crate,
     )
     .unwrap();

--- a/deps/rustcall_extract/src/main.rs
+++ b/deps/rustcall_extract/src/main.rs
@@ -1,8 +1,8 @@
 //! `rustcall-extract`: command-line front end over `rustcall_core`.
 //!
 //! ```text
-//! rustcall-extract manifest   --mode <inline|crate> [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] [--crate-root FILE] FILE...
-//! rustcall-extract wrap       --crate-name NAME [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] [--crate-root FILE] FILE...
+//! rustcall-extract manifest   --mode <inline|crate> [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] (--crate-root FILE | FILE...)
+//! rustcall-extract wrap       --crate-name NAME [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] (--crate-root FILE | FILE...)
 //! rustcall-extract expand     [--manifest FILE] [--cfg-file FILE] [--cfg-lenient] FILE
 //! rustcall-extract specialize --fn NAME --new-name NAME --bind T=TYPE... [--manifest FILE] FILE
 //! rustcall-extract schema-version
@@ -27,8 +27,8 @@ use rustcall_core::extract::ExtractError;
 use rustcall_core::manifest::{Manifest, Mode, SCHEMA_VERSION};
 
 const USAGE: &str = "usage:
-  rustcall-extract manifest   --mode <inline|crate> [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] [--crate-root FILE] FILE...
-  rustcall-extract wrap       --crate-name NAME [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] [--crate-root FILE] FILE...
+  rustcall-extract manifest   --mode <inline|crate> [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] (--crate-root FILE | FILE...)
+  rustcall-extract wrap       --crate-name NAME [--out FILE] [--cfg-file FILE] [--cfg-lenient] [--skip-unparsable] (--crate-root FILE | FILE...)
   rustcall-extract expand     [--manifest FILE] [--cfg-file FILE] [--cfg-lenient] FILE
   rustcall-extract specialize --fn NAME --new-name NAME --bind PARAM=TYPE... [--manifest FILE] FILE
   rustcall-extract schema-version
@@ -44,10 +44,12 @@ wrap: generate the `src/lib.rs` of a wrapper crate for the PyO3 items of the cra
 scanned from FILE... (#275 Phase 2), and write it, together with the manifest that
 describes what it exports, as one TOML document to --out or stdout. Always crate
 mode; --crate-name is the dependency's package name.
---crate-root: crate-mode only. Scan PyO3 items (#275) by following the crate's
-module tree from this file (src/lib.rs) instead of treating every FILE as a root,
-so each item's module_path and the visibility of its enclosing modules are real.
-The FILE list still drives #[julia] extraction.";
+--crate-root: crate-mode only. Scan the crate by following its module tree from
+this file (src/lib.rs) instead of treating every FILE as a root, so each item's
+module_path and the visibility of its enclosing modules are real (#275) and a
+#[julia] impl block finds its struct in another file (#315). The tree is the file
+list: FILE arguments are not accepted with it, and a file no `mod` reaches is not
+compiled by rustc, so it exports nothing.";
 
 /// One command-line argument: either an option/value that must be UTF-8, or a
 /// path that may not be.
@@ -156,44 +158,41 @@ struct ScanOptions {
 /// Run the scan `opts` describes and return the merged manifest.
 fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
     let mut merged = Manifest::new(opts.mode);
-    // With --crate-root the PyO3 scan runs once over the module tree below, so
-    // the per-file pass must not report the same items again as crate-root ones.
-    let per_file_pyo3_scan = opts.crate_root.is_none();
-    // Every exported symbol seen so far and the file:item that claims it, so a
-    // second claimant is reported with both locations (#300).
-    let mut claimed: Vec<(String, String)> = Vec::new();
-    for f in &opts.files {
-        let src = read_source(f)?;
-        let extracted = match opts.mode {
-            Mode::Crate => rustcall_core::extract::extract_crate_with_cfg_scan(
-                &src,
-                opts.cfg.as_ref(),
-                per_file_pyo3_scan,
-            ),
-            Mode::Inline => {
-                rustcall_core::extract::extract_with_cfg(&src, opts.mode, opts.cfg.as_ref())
-            }
-        };
-        match extracted {
-            Ok(m) => {
-                if opts.mode == Mode::Crate {
-                    claim_symbols(&mut claimed, &m, f)?;
+    match (opts.mode, &opts.crate_root) {
+        (Mode::Inline, _) => {
+            for f in &opts.files {
+                let src = read_source(f)?;
+                match rustcall_core::extract::extract_with_cfg(&src, opts.mode, opts.cfg.as_ref()) {
+                    Ok(m) => merged.merge(m),
+                    Err(e) => skip_or_fail(e, f, opts.skip_unparsable)?,
                 }
-                merged.merge(m);
             }
-            // Only a file that is not a Rust module is skippable (an
-            // `include!()` fragment); an item RustCall refuses fails the scan.
-            Err(ExtractError::Parse(e)) if opts.skip_unparsable => {
-                eprintln!(
-                    "rustcall-extract: skipping {}: not a complete Rust module ({e})",
-                    f.display()
-                );
-            }
-            Err(e) => return Err(format!("{}: {e}", f.display())),
         }
-    }
-    if let Some(root) = &opts.crate_root {
-        scan_pyo3_tree(root, opts.cfg.as_ref(), opts.skip_unparsable, &mut merged)?;
+        (Mode::Crate, Some(root)) => {
+            scan_crate_tree(root, opts.cfg.as_ref(), opts.skip_unparsable, &mut merged)?;
+        }
+        // No root: every FILE is its own module root. Structs and impl blocks
+        // are still married across the files (#315) and exported symbols
+        // checked crate-wide (#300).
+        (Mode::Crate, None) => {
+            let mut scan = rustcall_core::extract::TreeScan::new();
+            for f in &opts.files {
+                let src = read_source(f)?;
+                let scanned = scan.file(
+                    &src,
+                    opts.cfg.as_ref(),
+                    &[],
+                    true,
+                    &[],
+                    &mut merged,
+                    &f.display().to_string(),
+                );
+                if let Err(e) = scanned {
+                    skip_or_fail(e, f, opts.skip_unparsable)?;
+                }
+            }
+            scan.finish(&mut merged).map_err(|e| e.to_string())?;
+        }
     }
     if opts.files.len() > 1 || opts.crate_root.is_some() {
         merged.sort();
@@ -201,33 +200,19 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
     Ok(merged)
 }
 
-/// Record the exported symbols of one file's manifest, failing on the first
-/// one another file (or another item of this file) already claims (#300).
-///
-/// The symbol scheme keeps items of different modules apart, so a duplicate
-/// here is either two file modules — transparent to the scheme — defining the
-/// same `#[julia]` item, or a crate-root name that spells a qualified one. The
-/// `cdylib` could not export both, and a wrong binding is worse than no
-/// binding, so the scan fails closed and names the fix.
-fn claim_symbols(
-    claimed: &mut Vec<(String, String)>,
-    manifest: &Manifest,
-    file: &Path,
-) -> Result<(), String> {
-    for (symbol, owner) in manifest.symbol_owners() {
-        let here = format!("{} in {}", owner, file.display());
-        if let Some((_, first)) = claimed.iter().find(|(s, _)| *s == symbol) {
-            return Err(format!(
-                "duplicate exported symbol `{symbol}`: claimed by {first} and by {here}. \
-                 Two #[julia] items of one crate export the same symbol; only inline modules \
-                 marked `#[julia]` (`#[julia] pub mod name {{ ... }}`) qualify a symbol by \
-                 their name, while file modules (`mod name;`) do not. Wrap one of the items in \
-                 a `#[julia]` module block or rename it (#300)."
-            ));
+/// Only a file that is not a Rust module is skippable (an `include!()`
+/// fragment); an item RustCall refuses fails the scan.
+fn skip_or_fail(e: ExtractError, file: &Path, skip_unparsable: bool) -> Result<(), String> {
+    match e {
+        ExtractError::Parse(e) if skip_unparsable => {
+            eprintln!(
+                "rustcall-extract: skipping {}: not a complete Rust module ({e})",
+                file.display()
+            );
+            Ok(())
         }
-        claimed.push((symbol, here));
+        e => Err(format!("{}: {e}", file.display())),
     }
-    Ok(())
 }
 
 /// Generate the wrapper crate of a PyO3 crate (#275 Phase 2).
@@ -262,9 +247,7 @@ fn cmd_wrap(args: &[Arg]) -> Result<(), String> {
         i += 1;
     }
     let crate_name = crate_name.ok_or("--crate-name is required")?;
-    if files.is_empty() {
-        return Err("at least one FILE is required".into());
-    }
+    check_inputs(&files, crate_root.as_deref())?;
     let cfg = read_cfg_file(cfg_file.as_deref(), cfg_lenient)?;
     // Whether the scan decided every `#[cfg]` predicate. When it did not,
     // `wrapper_crate` refuses a `#[cfg]`-carrying item rather than generating
@@ -323,9 +306,7 @@ fn cmd_manifest(args: &[Arg]) -> Result<(), String> {
         i += 1;
     }
     let mode = mode.ok_or("--mode is required")?;
-    if files.is_empty() {
-        return Err("at least one FILE is required".into());
-    }
+    check_inputs(&files, crate_root.as_deref())?;
     if crate_root.is_some() && mode != Mode::Crate {
         return Err("--crate-root is only meaningful with --mode crate".into());
     }
@@ -340,16 +321,15 @@ fn cmd_manifest(args: &[Arg]) -> Result<(), String> {
     write_manifest(&merged, out.as_deref())
 }
 
-/// Scan the PyO3 items of a whole crate by following its module tree from
-/// `root` (#275).
+/// Scan a whole crate by following its module tree from `root` (#275, #315).
 ///
 /// Only this layer touches the filesystem: `rustcall_core` hands back the
 /// out-of-line `mod` declarations of each file and this resolves them the way
 /// rustc does — `#[path = "..."]` first, then `<dir>/<name>.rs`, then
 /// `<dir>/<name>/mod.rs`. A declaration whose file does not exist (a `mod`
-/// behind a `#[cfg]` that was pruned, or a generated file) is skipped rather
-/// than failing the run: the scan describes what it can see.
-fn scan_pyo3_tree(
+/// behind a `#[cfg]` that was pruned, or a generated file) is noted on stderr
+/// and skipped rather than failing the run: the scan describes what it can see.
+fn scan_crate_tree(
     root: &Path,
     cfg: Option<&CfgSet>,
     skip_unparsable: bool,
@@ -370,7 +350,7 @@ fn scan_pyo3_tree(
     // the manifest — under their own module paths, and colliding with each
     // other on the wrapper symbols.
     let mut visited: Vec<(PathBuf, Vec<String>)> = Vec::new();
-    let mut scan = rustcall_core::pyo3::Pyo3Scan::new();
+    let mut scan = rustcall_core::extract::TreeScan::new();
 
     while let Some((file, dir, module_path, reachable, enclosing_cfg)) = queue.pop() {
         let canonical = fs::canonicalize(&file).unwrap_or_else(|_| file.clone());
@@ -381,28 +361,31 @@ fn scan_pyo3_tree(
         visited.push(key);
 
         let src = read_source(&file)?;
-        let pending = match rustcall_core::extract::extract_pyo3_file(
+        let scanned = scan.file(
             &src,
             cfg,
             &module_path,
             reachable,
             &enclosing_cfg,
-            &mut scan,
             manifest,
-        ) {
+            &file.display().to_string(),
+        );
+        let pending = match scanned {
             Ok(v) => v,
-            Err(e) if skip_unparsable => {
-                eprintln!(
-                    "rustcall-extract: skipping {}: not a complete Rust module ({e})",
-                    file.display()
-                );
+            Err(e) => {
+                skip_or_fail(e, &file, skip_unparsable)?;
                 continue;
             }
-            Err(e) => return Err(format!("{}: {e}", file.display())),
         };
 
         for m in pending {
             let Some((child_file, child_dir)) = resolve_module_file(&dir, &m) else {
+                eprintln!(
+                    "rustcall-extract: `mod {};` in {} names no file under {}; skipping it",
+                    m.name,
+                    file.display(),
+                    dir.display()
+                );
                 continue;
             };
             queue.push((
@@ -414,11 +397,10 @@ fn scan_pyo3_tree(
             ));
         }
     }
-    // `#[pyclass]` structs and their `#[pymethods]` blocks may live in
-    // different files, so the classes are only emitted once every file of the
+    // Structs and their impl blocks — `#[julia]` and PyO3 alike — may live in
+    // different files, so the structs are only emitted once every file of the
     // tree has been seen.
-    scan.finish(manifest);
-    Ok(())
+    scan.finish(manifest).map_err(|e| e.to_string())
 }
 
 /// Where a `mod name;` declaration's file lives, and the directory its own
@@ -453,6 +435,20 @@ fn resolve_module_file(
         return Some((nested, base.join(&m.name)));
     }
     None
+}
+
+/// A scan reads either the module tree below `--crate-root` or the FILEs
+/// given, never both: a file the tree does not reach is not compiled by rustc
+/// and exports nothing, so listing it would describe items that do not exist.
+fn check_inputs(files: &[PathBuf], crate_root: Option<&Path>) -> Result<(), String> {
+    match (files.is_empty(), crate_root) {
+        (true, None) => Err("at least one FILE or --crate-root is required".into()),
+        (false, Some(_)) => Err(
+            "--crate-root scans the crate's module tree; FILE arguments are not accepted with it"
+                .into(),
+        ),
+        _ => Ok(()),
+    }
 }
 
 fn single_file(file: &mut Option<PathBuf>, arg: &Arg, cmd: &str) -> Result<(), String> {

--- a/docs/src/crate_bindings.md
+++ b/docs/src/crate_bindings.md
@@ -161,6 +161,18 @@ The generated Julia bindings keep the Rust names (`Counter(1)`, `get(c)`);
 they resolve the exported symbol through the manifest, so nothing in the Julia
 API changes.
 
+The impl block may live in any module of the crate, not only next to the
+struct: `#[julia] impl crate::Counter { ... }` in `src/ops.rs`, `impl
+super::Counter` from a child module, or `use crate::Counter; #[julia] impl
+Counter` all bind their methods to `Counter` (#315). The method symbols follow
+the struct the header names (`rustcall_Counter_get`), never the module the
+block was written in, so the header has to spell the struct's path the way the
+proc-macro reads it: `crate::…` and `super::…` as written, a bare name as the
+block's own `#[julia]` module path. A block whose header names no `#[julia]`
+struct — or one whose symbols the proc-macro would qualify differently, such
+as a bare `impl Counter` inside a `#[julia] mod` for a struct at the crate root
+— fails the scan with the header to write instead of silently binding nothing.
+
 ### Static methods
 
 A method without `self` (other than a constructor) is called with the type as

--- a/docs/src/crate_bindings.md
+++ b/docs/src/crate_bindings.md
@@ -172,6 +172,25 @@ block's own `#[julia]` module path. A block whose header names no `#[julia]`
 struct — or one whose symbols the proc-macro would qualify differently, such
 as a bare `impl Counter` inside a `#[julia] mod` for a struct at the crate root
 — fails the scan with the header to write instead of silently binding nothing.
+A header that resolves to a struct **without** `#[julia]` — a plain `struct
+Counter` declared beside the block, which is what Rust itself resolves to —
+fails the same way rather than attaching to a same-named annotated struct
+elsewhere: annotate that struct, or spell the intended one
+(`impl crate::Counter`).
+
+A file reached only by a literal `include!("api.rs")` is scanned too: its items
+are compiled into the including module, so that is where they bind. An include
+whose path is not a literal (`include!(concat!(env!("OUT_DIR"), "/api.rs"))`)
+names a file the build writes later and is left to the compiler.
+
+!!! note "Inline blocks: keep the method signature in scope at the struct"
+    In a `rust"""` block the wrappers are emitted next to the struct, so a
+    cross-module method whose signature names a type that only the impl's
+    module can see (`type Count = i32;` beside the block) does not compile.
+    Qualify it (`super::ops::Count`) or keep the impl beside the struct;
+    [#342](https://github.com/AtelierArith/RustCall.jl/issues/342) tracks
+    emitting such a wrapper inside the impl's module instead. A crate's
+    wrappers are emitted at the impl site by the proc-macro and are unaffected.
 
 ### Static methods
 

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -150,10 +150,10 @@ function scan_crate(crate_path::String; cfg = :lenient,
     # `cfg = :cargo`, and then every `#[cfg]` is decided, which is what lets
     # mutually exclusive feature variants of one `#[julia] fn` collapse to the
     # one that exists (#277 Phase B).
-    # The PyO3 scan (#275) needs the crate's module tree, not a bag of files:
-    # `src/api.rs` is `api`, and a `mod api;` that is not `pub` puts everything
-    # below it out of a wrapper crate's reach. The `#[julia]` extraction stays
-    # per file.
+    # Both scans need the crate's module tree, not a bag of files: `src/api.rs`
+    # is `api`, a `mod api;` that is not `pub` puts everything below it out of
+    # a wrapper crate's reach (#275), and a `#[julia] impl crate::Gauge` in
+    # `ops.rs` has to find the `Gauge` declared in `lib.rs` (#315).
     lib_root, tree_files = _crate_scan_inputs(crate_path, cargo_toml, source_files)
     manifest = extract_manifest(tree_files; mode = "crate", skip_unparsable = true,
                                 cfg = cfg, cfg_text = cfg_text,

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -733,41 +733,49 @@ function expand_inline(code::String; cfg = :strict, cfg_text::Union{Nothing, Abs
 end
 
 """
-    extract_manifest(files::Vector{String}; mode::String, skip_unparsable=false) -> Dict
+    extract_manifest(files::Vector{String}; mode::String, skip_unparsable=false,
+                     crate_root=nothing) -> Dict
 
 Run the extractor over source files (`mode` is `"inline"` or `"crate"`).
 With `skip_unparsable`, files that are not complete Rust modules (for example
 `include!("table.rs")` fragments) are skipped with a warning instead of failing.
 
 `crate_root` (crate mode only) names the crate's root source file, usually
-`src/lib.rs`. The PyO3 scan of #275 then follows the crate's module tree from
-there — recording each item's real `module_path` and whether every enclosing
-`mod` is `pub` — instead of reporting every file's items as crate-root items.
+`src/lib.rs`. The extractor then scans the crate by following its module tree
+from there — recording each item's real `module_path`, whether every enclosing
+`mod` is `pub` (#275), and marrying a `#[julia] impl` block to a struct declared
+in another file (#315) — instead of treating every file as a root. The tree *is*
+the file list then: `files` is not passed on, because a file no `mod` reaches is
+not compiled by rustc and exports nothing.
 """
 function extract_manifest(files::Vector{String}; mode::String, skip_unparsable::Bool = false,
                           cfg = :strict, cfg_text::Union{Nothing, AbstractString} = nothing,
                           crate_root::Union{Nothing, AbstractString} = nothing)
     mode in ("inline", "crate") || throw(ArgumentError("mode must be \"inline\" or \"crate\""))
-    isempty(files) && return Dict{String, Any}(
+    isempty(files) && crate_root === nothing && return Dict{String, Any}(
         "schema_version" => MANIFEST_SCHEMA_VERSION, "mode" => mode,
         "functions" => Any[], "structs" => Any[])
     args = ["manifest", "--mode", mode]
     skip_unparsable && push!(args, "--skip-unparsable")
-    # With a crate root the extractor scans PyO3 items (#275) by following the
-    # crate's `mod` tree instead of treating each file as a root, so an item in
-    # `src/api.rs` is reported as `api::item` and a `mod api;` that is not `pub`
-    # makes everything below it unreachable.
-    if crate_root !== nothing
-        push!(args, "--crate-root")
-        push!(args, String(crate_root))
-    end
     if cfg_text === nothing
         append!(args, _cfg_file_args(cfg))
     else
         append!(args, _cfg_file_args(cfg; cfg_text = cfg_text))
     end
-    text = _run_extractor(vcat(args, files))
+    text = _run_extractor(vcat(args, _scan_inputs(files, crate_root)))
     return _parse_manifest(text)
+end
+
+"""
+    _scan_inputs(files, crate_root) -> Vector{String}
+
+What a crate-mode scan reads: the module tree below `crate_root` when there is
+one (`--crate-root`, which the extractor does not accept FILE arguments with),
+otherwise every file, each as its own root.
+"""
+function _scan_inputs(files::Vector{String}, crate_root::Union{Nothing, AbstractString})
+    crate_root === nothing && return files
+    return ["--crate-root", String(crate_root)]
 end
 
 """
@@ -811,19 +819,16 @@ function wrap_crate(files::Vector{String}; crate_name::AbstractString,
                     cfg = :strict, cfg_text::Union{Nothing, AbstractString} = nothing,
                     crate_root::Union{Nothing, AbstractString} = nothing,
                     skip_unparsable::Bool = false)
-    isempty(files) && throw(ArgumentError("wrap_crate needs at least one source file"))
+    isempty(files) && crate_root === nothing &&
+        throw(ArgumentError("wrap_crate needs at least one source file"))
     args = ["wrap", "--crate-name", String(crate_name)]
     skip_unparsable && push!(args, "--skip-unparsable")
-    if crate_root !== nothing
-        push!(args, "--crate-root")
-        push!(args, String(crate_root))
-    end
     if cfg_text === nothing
         append!(args, _cfg_file_args(cfg))
     else
         append!(args, _cfg_file_args(cfg; cfg_text = cfg_text))
     end
-    text = _run_extractor(vcat(args, files))
+    text = _run_extractor(vcat(args, _scan_inputs(files, crate_root)))
     doc = try
         TOML.parse(text)
     catch e

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -746,7 +746,10 @@ from there — recording each item's real `module_path`, whether every enclosing
 `mod` is `pub` (#275), and marrying a `#[julia] impl` block to a struct declared
 in another file (#315) — instead of treating every file as a root. The tree *is*
 the file list then: `files` is not passed on, because a file no `mod` reaches is
-not compiled by rustc and exports nothing.
+not compiled by rustc and exports nothing. The walk follows a literal
+`include!("api.rs")` as well, since that file's items are compiled into the
+including module (#315 review); an include whose path is not a literal, or that
+holds a fragment rather than items, is left to the compiler.
 """
 function extract_manifest(files::Vector{String}; mode::String, skip_unparsable::Bool = false,
                           cfg = :strict, cfg_text::Union{Nothing, AbstractString} = nothing,

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -189,3 +189,48 @@ end
         end
     end
 end
+
+@testset "A literal include! is part of the including module (#315 review)" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping the include! scan test"
+    else
+        mktempdir() do dir
+            mkpath(joinpath(dir, "src"))
+            macros = replace(CMI_MACROS_PATH, "\\" => "/")
+            write(joinpath(dir, "Cargo.toml"), """
+                [package]
+                name = "included_items"
+                version = "0.1.0"
+                edition = "2021"
+
+                [lib]
+                crate-type = ["cdylib"]
+
+                [dependencies]
+                juliacall_macros = { path = "$macros" }
+                """)
+            # `api.rs` is reached by no `mod` declaration: rustc compiles its
+            # items into the crate root, and so must the scan.
+            write(joinpath(dir, "src", "api.rs"), """
+                #[julia]
+                pub fn included_add(a: i32, b: i32) -> i32 { a + b }
+                """)
+            write(joinpath(dir, "src", "table.rs"), "[1, 2, 3]\n")
+            write(joinpath(dir, "src", "lib.rs"), """
+                use juliacall_macros::julia;
+                include!("api.rs");
+                const TABLE: [i32; 3] = include!("table.rs");
+                #[julia]
+                pub fn root_sum() -> i32 { TABLE.iter().sum() }
+                """)
+
+            info = RustCall.scan_crate(dir)
+            names = sort([f.name for f in info.julia_functions])
+            @test names == ["included_add", "root_sum"]
+            # The included items sit in the module that included them, so they
+            # keep the crate-root symbols the proc-macro gives them (#300).
+            symbols = Dict(f.name => f.symbol for f in info.julia_functions)
+            @test symbols["included_add"] == "rustcall_included_add"
+        end
+    end
+end

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -1,0 +1,191 @@
+# A `#[julia] impl` block in another module than its struct (#315).
+#
+# The crate scan used to attach an impl block only to a struct found at the
+# same file / module level, so for `struct Gauge` in `lib.rs` and
+# `impl crate::Gauge` in `ops.rs` the proc-macro emitted `rustcall_Gauge_read`
+# while the manifest listed `Gauge` with no methods and the Julia module had no
+# `read`. The scan now collects structs and `#[julia] impl` blocks across the
+# whole module tree and marries them by resolved path; a block whose header
+# names no `#[julia]` struct fails the scan with the path it looked at.
+
+using Test
+using RustCall
+using RustToolChain: cargo
+
+const CMI_MACROS_PATH = joinpath(dirname(@__DIR__), "deps", "juliacall_macros")
+
+const _CMI_HAVE_CARGO = try
+    success(run(pipeline(`$(cargo()) --version`, devnull, devnull); wait = true))
+catch
+    false
+end
+
+# The split layout of the issue: the struct in `lib.rs`, its methods from a
+# sibling file through `crate::`, from another through a `use`, and from a
+# marked child module through `super::`.
+function _cmi_write_split_crate(dir::AbstractString; ops_header::AbstractString = "impl crate::Gauge")
+    mkpath(joinpath(dir, "src"))
+    macros = replace(CMI_MACROS_PATH, "\\" => "/")
+    write(joinpath(dir, "Cargo.toml"), """
+        [package]
+        name = "split_gauge"
+        version = "0.1.0"
+        edition = "2021"
+
+        [lib]
+        crate-type = ["cdylib"]
+
+        [dependencies]
+        juliacall_macros = { path = "$macros" }
+
+        [workspace]
+        """)
+    write(joinpath(dir, "src", "lib.rs"), """
+        use juliacall_macros::julia;
+
+        mod more;
+        mod ops;
+
+        #[julia]
+        pub struct Gauge { pub value: i32 }
+
+        #[julia]
+        impl Gauge {
+            #[julia]
+            pub fn new(value: i32) -> Self { Self { value } }
+        }
+
+        #[julia]
+        pub mod nested {
+            use juliacall_macros::julia;
+
+            #[julia]
+            impl super::Gauge {
+                #[julia]
+                pub fn halved(&self) -> Result<i32, String> {
+                    if self.value % 2 == 0 { Ok(self.value / 2) } else { Err(format!("{} is odd", self.value)) }
+                }
+            }
+        }
+        """)
+    write(joinpath(dir, "src", "ops.rs"), """
+        use juliacall_macros::julia;
+
+        #[julia]
+        $ops_header {
+            #[julia]
+            pub fn read(&self) -> i32 { self.value }
+
+            #[julia]
+            pub fn bump(&mut self) { self.value += 1; }
+        }
+        """)
+    write(joinpath(dir, "src", "more.rs"), """
+        use juliacall_macros::julia;
+        use crate::Gauge;
+
+        #[julia]
+        impl Gauge {
+            #[julia]
+            pub fn label(&self) -> String { format!("Gauge({})", self.value) }
+        }
+        """)
+    return dir
+end
+
+@testset "Cross-module #[julia] impl blocks (#315)" begin
+    @testset "the scan attaches every block to the struct it names" begin
+        mktempdir() do dir
+            _cmi_write_split_crate(dir)
+            info = RustCall.scan_crate(dir)
+            @test length(info.julia_structs) == 1
+            gauge = only(info.julia_structs)
+            @test gauge.ffi_name == "Gauge"
+            @test isempty(gauge.module_path)
+            # Every method symbol follows the struct, not the module of its block.
+            @test Dict(m.name => m.symbol for m in gauge.methods) ==
+                  Dict("new" => "rustcall_Gauge_new", "read" => "rustcall_Gauge_read",
+                       "bump" => "rustcall_Gauge_bump", "label" => "rustcall_Gauge_label",
+                       "halved" => "rustcall_Gauge_halved")
+            by_name = Dict(m.name => m for m in gauge.methods)
+            @test by_name["bump"].is_mutable
+            @test by_name["label"].return_abi == "string"
+            @test by_name["halved"].return_kind == :result
+        end
+    end
+
+    @testset "a block naming no #[julia] struct fails the scan, with the path" begin
+        mktempdir() do dir
+            _cmi_write_split_crate(dir; ops_header = "impl crate::Meter")
+            err = try
+                RustCall.scan_crate(dir)
+                nothing
+            catch e
+                e
+            end
+            @test err isa RustCall.ExtractorError
+            if err isa RustCall.ExtractorError
+                @test occursin("`impl crate::Meter`", err.msg)
+                @test occursin("names no #[julia] struct", err.msg)
+                @test occursin("ops.rs", err.msg)
+            end
+        end
+    end
+
+    if !_CMI_HAVE_CARGO || !RustCall.check_rustc_available()
+        @warn "cargo/rustc not available, skipping the behavioural #315 tests"
+    else
+        @testset "the methods are callable through @rust_crate" begin
+            mktempdir() do dir
+                _cmi_write_split_crate(dir)
+                bindings = @rust_crate dir name="SplitGaugeBindings"
+                call = Base.invokelatest
+                g = call(bindings.Gauge, Int32(4))
+                @test bindings.read(g) == 4
+                bindings.bump(g)
+                @test bindings.read(g) == 5
+                @test call(getproperty, g, :value) == 5
+                # The `String` buffer hangs off `Gauge_label`, the Result
+                # aggregate is `CResult_Gauge_halved` (#268).
+                @test bindings.label(g) == "Gauge(5)"
+                odd = bindings.halved(g)
+                @test odd isa RustCall.RustResult && !odd.is_ok && odd.value == "5 is odd"
+                bindings.bump(g)
+                even = bindings.halved(g)
+                @test even.is_ok && even.value == 3
+                try
+                    RustCall.unload_library(getfield(bindings, :module_ref)._LIB_NAME; close = true)
+                catch
+                end
+            end
+        end
+
+        @testset "a module written by write_bindings_to_file binds them too" begin
+            mktempdir() do dir
+                _cmi_write_split_crate(dir)
+                output_path = joinpath(dir, "SplitGauge.jl")
+                RustCall.write_bindings_to_file(dir, output_path;
+                                                output_module_name = "SplitGaugeWritten")
+                content = read(output_path, String)
+                @test occursin("\"rustcall_Gauge_read\"", content)
+                @test occursin("\"rustcall_Gauge_label\"", content)
+                @test occursin("_ctor_target(\"rustcall_Gauge_new\", \"Gauge_free\")", content)
+
+                sandbox = Module(:CmiSandbox)
+                Base.include(sandbox, output_path)
+                mod = Base.invokelatest(getfield, sandbox, :SplitGaugeWritten)
+                get_in(m, names...) = foldl((acc, n) -> Base.invokelatest(getfield, acc, n), names; init = m)
+                call = Base.invokelatest
+                g = call(get_in(mod, :Gauge), Int32(6))
+                @test call(get_in(mod, :read), g) == 6
+                call(get_in(mod, :bump), g)
+                @test call(get_in(mod, :read), g) == 7
+                @test call(get_in(mod, :label), g) == "Gauge(7)"
+                try
+                    RustCall.unload_library(Base.invokelatest(getfield, mod, :_LIB_NAME); close = true)
+                catch
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary

A `#[julia] impl` block in another module than its struct was not attached by the crate scan: `collect_struct_models_in` matched impl blocks only at the same file / module level, so for `struct Gauge` in `lib.rs` and `impl crate::Gauge` in `ops.rs` the proc-macro emitted `rustcall_Gauge_read` while the manifest listed `Gauge` with no methods and the Julia module had no `read`.

- **One resolver for both scans.** The `PathQualifier` machinery of `Pyo3Scan` (`crate::` / `super::` / `self::` / relative qualifiers, `use` imports, the one struct of that name) moves to `rustcall_core::paths` behind a `Located` trait; the PyO3 scan is its first caller (no behaviour change).
- **`extract::CrateScan`** collects `#[julia]` structs and `#[julia] impl` blocks across the whole module tree and marries them in `finish` through `paths::locate`. Each item carries its real **module path** (what headers resolve against) and its **symbol path** (the `#[julia]` inline modules the macro folds into symbols; file modules are transparent, an unmarked module cuts the chain as `transform_module` leaves it as written). **Nothing is dropped silently**: a header naming no `#[julia]` struct, an ambiguous one, or one the proc-macro would qualify differently from the struct fails the scan with the header to write instead (`ExtractError::Unsupported`). The #300 duplicate-symbol check moves into the scan (`Function/Struct::claimed_symbols`), so it runs within one file as well as across files.
- **`extract::TreeScan`** feeds both scans one file at a time; `rustcall-extract --crate-root` walks the tree once for `#[julia]` and PyO3 items and takes no FILE arguments (a file no `mod` reaches is not compiled by rustc and exports nothing). Without a root every file is its own root, still married and checked crate-wide. `extract_manifest` / `wrap_crate` pass only `--crate-root` when there is one.
- **The proc-macro reads the header.** `codegen::impl_target_module_path` derives the struct's path the way the macro can see it — `crate::…` as written, `super::…` up from the block's marked path (past the marked root lands at the crate root), a bare name as the block's own path — so `impl super::Gauge` inside `#[julia] mod ops` exports `rustcall_Gauge_read`, not `rustcall_ops__Gauge_read`. The wrapper spells the struct as the header does (`*const super::Gauge`), so nothing needs to be in scope next to the block. The scan replicates the same derivation and refuses a header where the two stems differ (the case Codex raised on #333: `use a::C; #[julia] impl C` at the crate root → "write the header as `impl crate::a::C`"), replacing #333's same-level-only rule.
- **The inline expander** (`model::ModelTree`) attaches impl blocks across a `rust"""` block the same way, so both flavours agree (golden corpus `cross_module_impl`, also compiled as a cdylib).
- Method `cfg` now folds in the impl block's and its modules' predicates, as #333 did for `#[pymethods]`.

The `#[julia_pyo3]` acceptance bullet of the issue is obsolete: that macro was removed in v0.3.0 (#330).

## Acceptance criteria → tests

| Criterion | Test |
| --- | --- |
| A `#[julia] impl` in a sibling file module binds its methods (`impl crate::Gauge` in `ops.rs`, `use crate::Gauge; impl Gauge` in `more.rs`) | `test/test_cross_module_impl.jl` ("the scan attaches every block", `@rust_crate`, `write_bindings_to_file`); `deps/rustcall_core/tests/cross_module_impl.rs::an_impl_in_a_sibling_file_binds_its_methods` |
| A `#[julia] impl` in a child module binds its methods (`impl super::Gauge` from a `#[julia] mod`, from a file module, from an unmarked module) | `test/test_cross_module_impl.jl` (`nested` module, `halved`); `cross_module_impl.rs::super_from_a_child_file_module_reaches_the_root_struct`, `::marked_and_unmarked_inline_modules_attach_to_the_root_struct`; `deps/juliacall_macros/tests/cross_module_impl.rs` (the symbols the macro actually exports) |
| Symbols follow the struct, not the block's module; same-named structs in two modules keep their own blocks | `cross_module_impl.rs::a_full_path_names_a_struct_in_another_marked_module`, `::same_named_structs_in_two_modules_get_their_own_blocks`; `tests/symbols.rs::an_impl_the_macro_would_qualify_differently_is_refused` |
| An unresolved / ambiguous header is reported, never silently dropped | `cross_module_impl.rs::an_unresolved_header_is_reported_not_dropped`, `::an_ambiguous_bare_header_is_reported`; `test/test_cross_module_impl.jl` ("a block naming no #[julia] struct fails the scan") |
| A header the macro would qualify differently from the struct is refused with the fix | `cross_module_impl.rs::a_header_the_macro_would_qualify_differently_is_refused` |
| The golden corpus gains a split-layout case | `deps/rustcall_core/tests/corpus/cross_module_impl.{rs,crate.toml,inline.toml,expanded.rs}` (crate + inline flavours; `golden.rs::compilable_wrappers_build_as_cdylib` compiles it) |
| Crate-wide duplicate check keeps working inside the scan | `tests/symbols.rs::a_duplicate_symbol_fails_extraction_with_both_owners`; `cross_module_impl.rs::duplicate_symbols_across_files_name_both_files` |
| `#[julia_pyo3] impl` in another module | obsolete — the macro was removed in v0.3.0 (#330) |

Docs: `docs/src/crate_bindings.md` "For Impl Blocks" says the block may live in any module of the crate. CHANGELOG `### Fixed` under `[Unreleased]`.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
