### PR TITLE
Crate-bindings layout: refuse fn/struct same-name in a module and Base-exported module names (#338 items 3 and 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A module name Julia cannot define next to a parent binding — Rust keeps
     `fn a` and `mod a` in separate namespaces, Julia does not — is refused when
     the bindings are laid out (functions, structs, methods, field accessors and
-    the generated helpers and the imported names all count), naming both sides
-    and the fix. A raw identifier module (`r#type`) is bound as `type`; a
+    the generated helpers, the imported names and the exports of `Base` all
+    count), naming both sides and the fix; a struct whose type name repeats a
+    function-like binding of its own module (`fn C` + `struct C`, legal in
+    Rust) is refused the same way. A raw identifier module (`r#type`) is bound as `type`; a
     module whose name is a Julia keyword (`end`, `function`, `macro`, …) is
     refused rather than written into a file Julia cannot parse.
   - A `#[julia] impl C` must sit in the same module as its `#[julia] struct

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -747,15 +747,31 @@ function _check_module_names(tree::ModuleNode)
         f.is_generic && continue
         get!(taken, f.name, "the function `$(qualified_name(f.module_path, f.name))`")
     end
-    for s in tree.structs
+    # A method or an accessor is emitted *after* its struct, so it only clashes
+    # with a type name a **later** struct of this node defines: `function C(...)`
+    # before `mutable struct C` is a constant redefinition, the other order is
+    # an outer constructor. A method that repeats its own struct's name is
+    # therefore fine, and so is one that repeats a free function's — that adds a
+    # method to it (#341 review).
+    struct_position = Dict{String, Int}()
+    for (i, s) in enumerate(tree.structs)
+        get!(struct_position, s.name, i)
+    end
+    later_struct(name, i) = get(struct_position, name, typemax(Int)) > i
+    for (i, s) in enumerate(tree.structs)
         owner = qualified_name(s.module_path, s.name)
         for m in s.methods
             (isempty(m.skip_reason) && !m.is_constructor) || continue
+            later_struct(m.name, i) || continue
             get!(taken, m.name, "the method `$owner::$(m.name)`")
         end
         for (field, _) in s.fields
-            field_is_accessible(s, field) && get!(taken, "get_$field", "the accessor of `$owner.$field`")
-            field_is_writable(s, field) && get!(taken, "set_$(field)!", "the accessor of `$owner.$field`")
+            if field_is_accessible(s, field) && later_struct("get_$field", i)
+                get!(taken, "get_$field", "the accessor of `$owner.$field`")
+            end
+            if field_is_writable(s, field) && later_struct("set_$(field)!", i)
+                get!(taken, "set_$(field)!", "the accessor of `$owner.$field`")
+            end
         end
     end
     # A struct is a Julia type *and* its constructor: Rust keeps `fn C` and

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -713,12 +713,17 @@ that takes the whole bindings module down (#300 review). Every child module
 name is therefore checked against everything its parent binds: free functions,
 struct types, every method name (static or instance — both become functions of
 the parent), field accessors (`get_<f>`, `set_<f>!`), the helpers every
-generated module defines (`_call_target`, `_LIB_GEN`, ...) and the names it
-imports (`RustCall`, `Libdl`, the `import RustCall: ...` prelude). Module segments
-must also spell a Julia identifier (`_julia_module_name`). The error names both
-sides and the fix.
+generated module defines (`_call_target`, `_LIB_GEN`, ...), the names it
+imports (`RustCall`, `Libdl`, the `import RustCall: ...` prelude) and the
+exports of `Base` / `Core` it implicitly uses. Within one node a struct's type
+name must not repeat a function-like binding either (`fn C` + `struct C`).
+Module segments must also spell a Julia identifier (`_julia_module_name`). The
+error names both sides and the fix.
 """
 function _check_module_names(tree::ModuleNode)
+    where_ = isempty(tree.path) ? "the crate root" : "module `$(join(tree.path, "::"))`"
+    # Every function-like binding of this node: what a struct's type name and a
+    # child module's name must not repeat.
     taken = Dict{String, String}()
     for name in _CRATE_MODULE_HELPERS
         taken[String(name)] = "a helper every generated module defines"
@@ -732,13 +737,18 @@ function _check_module_names(tree::ModuleNode)
     for name in _CRATE_MODULE_IMPORTED_MODULES
         taken[String(name)] = "a module every generated module imports"
     end
+    # Every generated module implicitly `using Base`, and the wrappers name
+    # `String`, `Int32`, `convert`, ...: a module or type of such a name would
+    # replace the binding they resolve (#300 review).
+    for base_name in _BASE_EXPORTED_NAMES
+        get!(taken, base_name, "a name exported by Base")
+    end
     for f in tree.functions
         f.is_generic && continue
         get!(taken, f.name, "the function `$(qualified_name(f.module_path, f.name))`")
     end
     for s in tree.structs
         owner = qualified_name(s.module_path, s.name)
-        get!(taken, s.name, "the struct `$owner`")
         for m in s.methods
             (isempty(m.skip_reason) && !m.is_constructor) || continue
             get!(taken, m.name, "the method `$owner::$(m.name)`")
@@ -748,10 +758,22 @@ function _check_module_names(tree::ModuleNode)
             field_is_writable(s, field) && get!(taken, "set_$(field)!", "the accessor of `$owner.$field`")
         end
     end
+    # A struct is a Julia type *and* its constructor: Rust keeps `fn C` and
+    # `struct C` in separate namespaces, Julia does not, so `function C` followed
+    # by `mutable struct C` is a constant redefinition (#300 review). Two
+    # methods of one name on different structs are fine — that is dispatch.
+    for s in tree.structs
+        owner = qualified_name(s.module_path, s.name)
+        if haskey(taken, s.name)
+            error("cannot lay out the bindings of $where_: the struct `$owner` and " *
+                  "$(taken[s.name]) both bind `$(s.name)`, and Julia keeps functions and types " *
+                  "in one namespace. Rename one of them (#300).")
+        end
+        taken[s.name] = "the struct `$owner`"
+    end
     for child in tree.children
         name = _julia_module_name(last(child.path))
         if haskey(taken, name)
-            where_ = isempty(tree.path) ? "the crate root" : "module `$(join(tree.path, "::"))`"
             error("cannot lay out the bindings of module `$(join(child.path, "::"))`: " *
                   "$where_ already binds `$name` as $(taken[name]), and Julia keeps " *
                   "functions, types and modules in one namespace, so the submodule " *
@@ -792,6 +814,10 @@ const _CRATE_MODULE_PRELUDE = (:call_rust_function, :get_function_pointer_from_l
                                :_call_rust_borrowed_string_ptr, :convert_return, :_result_payload,
                                :FFIByValue)
 const _CRATE_MODULE_IMPORTED_MODULES = (:RustCall, :Libdl, :Base, :Core)
+# What the implicit `using Base` of every generated module brings into scope
+# (plus `Core`'s exports), computed once: a child module or struct of such a
+# name would shadow the binding the wrappers themselves use (#300 review).
+const _BASE_EXPORTED_NAMES = Set{String}(String(n) for n in vcat(names(Base), names(Core)))
 const _CRATE_MODULE_PRELUDE_NAMES = "call_rust_function, get_function_pointer_from_lib, RustResult, RustOption, _check_not_freed,\n" *
     "                 _call_rust_owned_string_ptr, _call_rust_borrowed_string_ptr, convert_return,\n" *
     "                 _result_payload, FFIByValue"

--- a/test/test_module_symbols.jl
+++ b/test/test_module_symbols.jl
@@ -242,8 +242,21 @@ end
         named_like_struct = RustCall.RustStructInfo("D", String[],
             [RustCall.RustMethod("C", false, false, String[], String[], "i32")], "",
             Tuple{String, String}[], true, Dict{String, Bool}())
+        # A method binds its name where its struct is emitted, so it clashes
+        # only with a type name a *later* struct defines (#341 review):
+        # `function C(self::D)` before `mutable struct C` is a redefinition…
         @test_throws ErrorException RustCall._check_module_names(
-            RustCall._module_tree(RustCall.RustFunctionSignature[], [plain, named_like_struct]))
+            RustCall._module_tree(RustCall.RustFunctionSignature[], [named_like_struct, plain]))
+        # …the other order is an outer constructor of `C`, which Julia allows.
+        @test RustCall._check_module_names(
+            RustCall._module_tree(RustCall.RustFunctionSignature[],
+                                  [plain, named_like_struct])) === nothing
+        # A method that repeats its own struct's name is that same overload.
+        self_named = RustCall.RustStructInfo("E", String[],
+            [RustCall.RustMethod("E", false, false, String[], String[], "i32")], "",
+            Tuple{String, String}[], true, Dict{String, Bool}())
+        @test RustCall._check_module_names(
+            RustCall._module_tree(RustCall.RustFunctionSignature[], [self_named])) === nothing
         @test_throws ErrorException RustCall._check_module_names(
             RustCall._module_tree(RustCall.RustFunctionSignature[],
                 [RustCall.RustStructInfo("String", String[], RustCall.RustMethod[], "",

--- a/test/test_module_symbols.jl
+++ b/test/test_module_symbols.jl
@@ -222,10 +222,38 @@ end
         # prelude import.
         helper = RustCall._module_tree([sig("f", ["_call_target"])], RustCall.RustStructInfo[])
         @test_throws ErrorException RustCall._check_module_names(helper)
-        for reserved in ("RustCall", "Libdl", "call_rust_function", "RustResult", "FFIByValue")
+        for reserved in ("RustCall", "Libdl", "call_rust_function", "RustResult", "FFIByValue",
+                         "String", "sum", "Int32", "convert")   # Base exports too
             @test_throws ErrorException RustCall._check_module_names(
                 RustCall._module_tree([sig("f", [reserved])], RustCall.RustStructInfo[]))
         end
+        # Rust keeps `fn C` and `struct C` apart; Julia does not: the struct's
+        # type name must not repeat a function-like binding of its own module.
+        plain = RustCall.RustStructInfo("C", String[], RustCall.RustMethod[], "",
+                                        Tuple{String, String}[], true, Dict{String, Bool}())
+        err = try
+            RustCall._check_module_names(RustCall._module_tree([sig("C", String[])], [plain]))
+            nothing
+        catch e
+            e
+        end
+        @test err isa ErrorException
+        @test occursin("the struct `C`", err.msg) && occursin("the function `C`", err.msg)
+        named_like_struct = RustCall.RustStructInfo("D", String[],
+            [RustCall.RustMethod("C", false, false, String[], String[], "i32")], "",
+            Tuple{String, String}[], true, Dict{String, Bool}())
+        @test_throws ErrorException RustCall._check_module_names(
+            RustCall._module_tree(RustCall.RustFunctionSignature[], [plain, named_like_struct]))
+        @test_throws ErrorException RustCall._check_module_names(
+            RustCall._module_tree(RustCall.RustFunctionSignature[],
+                [RustCall.RustStructInfo("String", String[], RustCall.RustMethod[], "",
+                                         Tuple{String, String}[], true, Dict{String, Bool}())]))
+        # Two structs with a method of one name are ordinary dispatch, not a clash.
+        m_get = RustCall.RustMethod("get", false, false, String[], String[], "i32")
+        a_ = RustCall.RustStructInfo("A", String[], [m_get], "", Tuple{String, String}[], true, Dict{String, Bool}())
+        b_ = RustCall.RustStructInfo("B", String[], [m_get], "", Tuple{String, String}[], true, Dict{String, Bool}())
+        @test RustCall._check_module_names(
+            RustCall._module_tree(RustCall.RustFunctionSignature[], [a_, b_])) === nothing
         # Instance methods and field accessors are parent bindings too: `run(self::C)`
         # and `get_v(self::C)` would each be redefined by a submodule of that name.
         meth = RustCall.RustMethod("run", false, false, String[], String[], "i32")


### PR DESCRIPTION
## Summary

Follow-up to #333 (Codex round 4, recorded as a scope decision there): two of the four name-coincidence corners of the per-module Julia layout, both small extensions of `_check_module_names` in `src/crate_bindings.jl`.

- **`fn C` + `struct C` in one module** (item 3 of #338). Rust keeps values and types in separate namespaces; Julia does not, and the emitters would define `function C` then `mutable struct C` — a constant redefinition that takes the whole bindings module down. A struct whose type name repeats any function-like binding of its own node (free function, method of any struct, field accessor, generated helper, imported name) is now refused with a message naming both sides. Two structs sharing a method name stay ordinary dispatch.
- **Names exported by `Base` / `Core`** (item 4 of #338). Every generated module implicitly `using Base`, and the wrappers themselves name `String`, `Int32`, `convert`, …; a child module or struct of such a name would replace the binding they resolve. `names(Base)` and `names(Core)` are reserved (`_BASE_EXPORTED_NAMES`) for child modules and structs alike.

Items 1 and 2 of #338 (derived exports in the crate-wide duplicate scan; a crate-wide check for inline blocks) stay open there.

## Tests

`test/test_module_symbols.jl`, "a module named like a parent binding is refused": `fn C` + `struct C` refused naming both; a method named like a sibling struct refused; a struct named `String` refused; child modules named `String` / `sum` / `Int32` / `convert` refused; two structs with a `get` method accepted.

Advances #338 (items 3 and 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
