### PR TITLE
A local type alias blocks an impl from a struct elsewhere too (#315)

### DIFF
--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -659,6 +659,16 @@ impl CrateScan {
                         file: file.to_string(),
                     });
                 }
+                // `type Gauge = …;` names a type an inherent impl can be
+                // written through, so it shadows a same-named annotated struct
+                // in another module exactly as a local declaration does.
+                Item::Type(t) => {
+                    self.plain_structs.push(PlainStruct {
+                        name: t.ident.to_string(),
+                        module_path: module_path.clone(),
+                        file: file.to_string(),
+                    });
+                }
                 Item::Struct(s) => {
                     let Some(model) = StructModel::of(s, Mode::Crate) else {
                         // Not a `#[julia]` struct, but still a name an `impl`

--- a/deps/rustcall_core/tests/cross_module_impl.rs
+++ b/deps/rustcall_core/tests/cross_module_impl.rs
@@ -492,6 +492,10 @@ fn an_impl_on_a_plain_local_enum_is_refused() {
     for (kind, decl) in [
         ("enum", "pub enum Gauge { A, B }"),
         ("union", "pub union Gauge { a: i32, b: u32 }"),
+        (
+            "type alias",
+            "pub struct Other { pub v: i32 }\npub type Gauge = Other;",
+        ),
     ] {
         let err = scan_tree(&[
             (


### PR DESCRIPTION
## Summary

Round 3 of #340's review, landing after that PR merged: the blocker list the crate scan resolves `impl` headers against (`CrateScan::plain_structs`) covered `struct`, `enum` and `union` but not `type Gauge = Other;`. Rust lets an inherent impl be written through a local alias, so an alias shadows a same-named `#[julia] struct` in another module the same way a local declaration does — and without it the block would attach to that other struct, describing wrappers whose receiver is a different type.

`Item::Type` now joins the list, and `an_impl_on_a_plain_local_enum_is_refused` covers all four kinds (struct, enum, union, type alias).

Verification: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` clean in `deps/rustcall_core`; the full `Pkg.test()` was green with this change on #340's branch (9266 passed, 0 failed, 2 known broken).

The remaining findings of that round — cfg pruning inside `include!`d files, and the inline flavour's own resolver — are recorded on #343 with acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw