### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-08
+
 ### Breaking
 - **Exported symbols carry the module path** ([#300](https://github.com/AtelierArith/RustCall.jl/issues/300)).
   The scheme of #279 (`rustcall_<name>`, `<Struct>_free`, ...) had no module
@@ -1216,7 +1218,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for Rust helpers library
 - Documentation examples tests
 
-[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/atelierarith/RustCall.jl/compare/6e98d5cb62c0a0ca8b2f894c6fe53af209d9d3ea...v0.2.0
 [0.1.0]: https://github.com/atelierarith/RustCall.jl/commit/6e98d5cb62c0a0ca8b2f894c6fe53af209d9d3ea

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustCall"
 uuid = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
 
 [deps]

--- a/examples/MyExample.jl/Project.toml
+++ b/examples/MyExample.jl/Project.toml
@@ -8,7 +8,7 @@ RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
 
 [compat]
 julia = "1.12"
-RustCall = "0.2"
+RustCall = "0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/examples/SampleCrate.jl/Project.toml
+++ b/examples/SampleCrate.jl/Project.toml
@@ -9,7 +9,7 @@ RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
 
 [compat]
 julia = "1.12"
-RustCall = "0.2"
+RustCall = "0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/examples/SampleCratePyO3.jl/Project.toml
+++ b/examples/SampleCratePyO3.jl/Project.toml
@@ -9,7 +9,7 @@ RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
 
 [compat]
 julia = "1.12"
-RustCall = "0.2"
+RustCall = "0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/examples/SampleCratePyO3Only.jl/Project.toml
+++ b/examples/SampleCratePyO3Only.jl/Project.toml
@@ -9,7 +9,7 @@ RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
 
 [compat]
 julia = "1.12"
-RustCall = "0.2"
+RustCall = "0.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
## Summary

Release preparation for **v0.3.0**, a **breaking** release: `Project.toml` goes from `0.2.1` to `0.3.0`, the CHANGELOG's `[Unreleased]` section becomes `[0.3.0] - 2026-09-08` with a fresh empty `[Unreleased]` above it, and the compare links are updated. Nothing else changes.

## What 0.3.0 breaks

- **Exported symbols carry the module path** (#300, PR #333). `a::run` exports `rustcall_a__run`; `#[julia]` items inside an inline module of a crate need `#[julia] mod`; the generated Julia bindings place such items in one submodule per Rust module; manifest schema 7 (`ffi_name`, populated `module_path`). Root-only crates keep every symbol and Julia name.
- **`#[julia_pyo3]` is removed** (#312, PR #330): write `#[julia]` beside PyO3's own attributes; the migration guide stays in `docs/src/pyo3.md`.
- **`@rust_llvm` and the LLVM IR integration path are removed** (#265 Phase 2, PR #331): `src/llvm*.jl`, `OptimizationConfig`, `compile_rust_to_llvm_ir`, `RUST_MODULE_REGISTRY`, … and the `LLVM.jl` dependency are gone; use `@rust`.

## Also in 0.3.0

- A `#[julia] impl` block in any module of the crate binds its methods (#315, PRs #340, #344); a header that resolves to a type without `#[julia]` — a plain struct, enum, union or alias — or through a renamed import is refused with the header to write, and a literal `include!("api.rs")` is scanned.
- Julia-layout name checks for the module-per-module bindings (#341).
- `examples/` are self-contained, each package embedding its crate, with the fixtures under `test/fixtures/` (#332); a third example package `SampleCratePyO3Only.jl` (#335); CI runs every example package and the Pluto notebook (#324, #326).
- Docs: what a `:link_libpython` build needs, and which testsets skip without a linkable Python (#334).

Known limitations recorded for later: #336 (the skip paths of the PyO3 wrapper testsets), #339 (`@rust_crate` at a package's top level cannot be precompiled), #342 (inline cross-module method signatures), #343 (`include!` corners and the inline resolver).

## After the merge

Comment `@JuliaRegistrator register` with breaking-change release notes on issue #229; TagBot then creates `v0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
