### PR TITLE
Follow out-of-line `mod` declarations inside include!d files (#343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where the struct has no local string helper that symbol does not exist, so
   the buffer leaks in silence. `src/manifest.jl` validates exact equality, so
   the version is what makes such a consumer refuse the manifest.
+- **An out-of-line `mod` inside an `include!`d file is followed**
+  ([#343](https://github.com/AtelierArith/RustCall.jl/issues/343)). The crate
+  walk followed a literal `include!("api.rs")` since #315, but it did so inside
+  `rustcall_core`, which is not the layer that owns the filesystem: a
+  `mod nested;` written in the fragment was reported to nobody, so a `#[julia]`
+  item in `nested.rs` was missing from the manifest while the proc-macro still
+  wrapped it, and the PyO3 scan never saw a fragment's items at all. Both scans
+  are now fed by one walk. `TreeScan::file` returns a `PullIns` — the
+  out-of-line `mod` declarations *and* the `include!` fragments — and
+  `rustcall-extract`, the only layer that touches files, follows both: a
+  fragment is read and scanned as a file of its own at the *including* item's
+  position (same module path, same `#[julia] mod` chain, same `#[cfg]`), and a
+  `mod` declared inside it resolves against the **fragment's own directory**,
+  which is rustc's rule (`include!("frag/api.rs")` in `src/lib.rs` with
+  `mod nested;` inside wants `src/frag/nested.rs`, whether or not the
+  `include!` sits in an inline module). A fragment that does not exist, or that
+  is not a list of items (`include!("table.rs")` holding `[1, 2, 3]`), is noted
+  on stderr and skipped as a missing `mod` target already was — never a failed
+  scan.
 
 ## [0.3.0] - 2026-09-08
 

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -332,7 +332,14 @@ pub fn extract_crate_with_cfg_scan(
     }
     let mut manifest = Manifest::new(Mode::Crate);
     let mut scan = CrateScan::new();
-    scan.file(&file.items, &[], &[], &mut manifest, "")?;
+    // A single source with no file behind it: an `include!` in it names a path
+    // this layer cannot resolve, so the fragments it reports are dropped.
+    scan.file(
+        &file.items,
+        &FilePosition::module(&[], true, &[]),
+        &mut manifest,
+        "",
+    )?;
     scan.finish(&mut manifest)?;
     // Items that carry only PyO3 attributes (#275). Reported with a PyO3
     // origin, `exported = false` and the symbol a Phase-2 wrapper crate will
@@ -344,15 +351,95 @@ pub fn extract_crate_with_cfg_scan(
     Ok(manifest)
 }
 
+/// One `include!("...")` found while scanning a file (#315, #343).
+///
+/// `include!` is not a module: the fragment's items are compiled into the
+/// module that includes them, so it is scanned at the **including item's**
+/// position — the same module path, the same `#[julia] mod` chain, the same
+/// `#[cfg]` — and only the file it is read from differs.
+///
+/// Following it needs the filesystem, so the scan reports it the way it
+/// reports an out-of-line `mod` and the caller resolves it: `path` is relative
+/// to the directory of the file the `include!` was written in. An out-of-line
+/// `mod` **inside** the fragment then resolves against the *fragment's* own
+/// directory, which is rustc's rule and the reason a fragment is scanned as a
+/// file of its own rather than spliced into the including one: `include!(
+/// "frag/api.rs")` in `src/lib.rs` with `mod nested;` inside `api.rs` wants
+/// `src/frag/nested.rs`, and it wants that whether or not the `include!` sits
+/// in an inline module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingInclude {
+    /// The literal argument, relative to the including **file's** directory.
+    pub path: String,
+    /// The position the fragment's items occupy.
+    pub position: FilePosition,
+}
+
+/// Where a file sits when it is scanned.
+///
+/// A file of the module tree is scanned at its own module path with an empty
+/// symbol path and `marked` true: its top level is expanded by the item-level
+/// proc-macro, which sees no module ([`FilePosition::module`]). An `include!`d
+/// fragment instead inherits the position of the `include!` item
+/// ([`PendingInclude::position`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FilePosition {
+    /// Where the file sits in the module tree; empty for the crate root.
+    pub module_path: Vec<String>,
+    /// Whether every `mod` on the way here is `pub` — what decides whether a
+    /// PyO3 item is reachable from outside the crate.
+    pub reachable: bool,
+    /// The `#[cfg]` of every `mod` declaration on the way, which every item in
+    /// the file inherits (#300 review).
+    pub enclosing_cfg: Vec<syn::Attribute>,
+    /// The chain of `#[julia]`-marked inline modules the file's items are
+    /// expanded under — the path the proc-macro folds into their symbols.
+    /// Empty for a file of the module tree.
+    pub symbol_path: Vec<String>,
+    /// Whether this level is a `#[julia]`-marked one; a file's top level is.
+    pub marked: bool,
+}
+
+impl FilePosition {
+    /// The position of a file of the module tree.
+    pub fn module(
+        module_path: &[String],
+        reachable: bool,
+        enclosing_cfg: &[syn::Attribute],
+    ) -> Self {
+        FilePosition {
+            module_path: module_path.to_vec(),
+            reachable,
+            enclosing_cfg: enclosing_cfg.to_vec(),
+            symbol_path: Vec::new(),
+            marked: true,
+        }
+    }
+}
+
+/// What a scanned file pulls in and only a caller that can read files can
+/// follow: its out-of-line `mod` declarations and its `include!` fragments.
+///
+/// Both are followed the same way — one more [`TreeScan::file`] call — so both
+/// scans see every file exactly once, whichever of the two brought it in
+/// (#343: before this the `#[julia]` walk followed `include!` by itself, so
+/// the PyO3 scan never saw a fragment and a `mod` declared inside one was
+/// never resolved at all).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct PullIns {
+    pub modules: Vec<crate::pyo3::PendingModule>,
+    pub includes: Vec<PendingInclude>,
+}
+
 /// Both crate-wide scans of one crate — `#[julia]` items (#315) and PyO3 items
 /// (#275) — fed one file of the module tree at a time.
 ///
 /// A struct and its impl blocks may live in different files, so the structs
 /// are only written to the manifest by [`TreeScan::finish`], once every file
 /// has been seen. The caller — `rustcall-extract` — owns the walk: it resolves
-/// each returned [`crate::pyo3::PendingModule`] to a file and calls
-/// [`TreeScan::file`] again; only it can touch the filesystem. Without a crate
-/// root every file is fed as its own root (an empty `module_path`).
+/// each returned [`PullIns`] entry to a file and calls [`TreeScan::file`]
+/// again; only it can touch the filesystem. Without a crate root every file is
+/// fed as its own root (an empty `module_path`).
 #[derive(Debug, Default)]
 pub struct TreeScan {
     julia: CrateScan,
@@ -364,37 +451,32 @@ impl TreeScan {
         TreeScan::default()
     }
 
-    /// Scan one file. `module_path` is where it sits in the tree (empty for
-    /// the crate root), `reachable` whether every `mod` on the way to it is
-    /// `pub`, `enclosing_cfg` the `#[cfg]` of every `mod` declaration on the
-    /// way (which every item in the file inherits, #300 review), and `file`
-    /// labels it in diagnostics. `#[julia]` and PyO3 functions go straight
-    /// into `manifest`; the out-of-line `mod` declarations found are returned
-    /// for the caller to follow.
-    #[allow(clippy::too_many_arguments)]
+    /// Scan one file at `position` — a file of the module tree
+    /// ([`FilePosition::module`]) or an `include!`d fragment — with `file`
+    /// labelling it in diagnostics. `#[julia]` and PyO3 functions go straight
+    /// into `manifest`; what the file pulls in is returned for the caller to
+    /// follow.
     pub fn file(
         &mut self,
         source: &str,
         cfg: Option<&CfgSet>,
-        module_path: &[String],
-        reachable: bool,
-        enclosing_cfg: &[syn::Attribute],
+        position: &FilePosition,
         manifest: &mut Manifest,
         file: &str,
-    ) -> Result<Vec<crate::pyo3::PendingModule>, ExtractError> {
+    ) -> Result<PullIns, ExtractError> {
         let mut parsed = syn::parse_file(source)?;
         if let Some(set) = cfg {
             crate::cfg::prune_file_or_error(set, &mut parsed)?;
         }
-        self.julia
-            .file(&parsed.items, module_path, enclosing_cfg, manifest, file)?;
-        Ok(self.pyo3.file(
+        let includes = self.julia.file(&parsed.items, position, manifest, file)?;
+        let modules = self.pyo3.file(
             &parsed.items,
-            module_path,
-            reachable,
-            enclosing_cfg,
+            &position.module_path,
+            position.reachable,
+            &position.enclosing_cfg,
             manifest,
-        ))
+        );
+        Ok(PullIns { modules, includes })
     }
 
     /// Attach every impl block to its struct and write the structs of both
@@ -579,25 +661,35 @@ impl CrateScan {
         CrateScan::default()
     }
 
-    /// Scan one file. `module_path` is where the file sits in the module tree
-    /// (empty for the crate root, or for a file scanned as its own root),
-    /// `enclosing_cfg` the `#[cfg]` of every `mod` declaration on the way to
-    /// it, and `file` labels it in diagnostics.
+    /// Scan one file at `position`, with `file` labelling it in diagnostics.
     ///
     /// `#[julia]` functions go straight into `manifest`; structs and impl
-    /// blocks are held until [`CrateScan::finish`].
+    /// blocks are held until [`CrateScan::finish`]. The `include!` fragments
+    /// found are returned for the caller to read and feed back — a file's
+    /// items are expanded by the item-level macro, which sees no module, so a
+    /// file of the module tree starts with an empty symbol path, while a
+    /// fragment keeps the one its `include!` sits under.
     pub fn file(
         &mut self,
         items: &[Item],
-        module_path: &[String],
-        enclosing_cfg: &[syn::Attribute],
+        position: &FilePosition,
         manifest: &mut Manifest,
         file: &str,
-    ) -> Result<(), ExtractError> {
-        let mut path = module_path.to_vec();
-        // A file's items are expanded by the item-level macro, which sees no
-        // module: their symbol path starts empty whatever the file's position.
-        self.level(items, &mut path, &[], enclosing_cfg, true, manifest, file)
+    ) -> Result<Vec<PendingInclude>, ExtractError> {
+        let mut path = position.module_path.clone();
+        let mut includes = Vec::new();
+        self.level(
+            items,
+            &mut path,
+            &position.symbol_path,
+            &position.enclosing_cfg,
+            position.marked,
+            position.reachable,
+            manifest,
+            file,
+            &mut includes,
+        )?;
+        Ok(includes)
     }
 
     /// One level of items; inline modules are visited recursively.
@@ -610,7 +702,10 @@ impl CrateScan {
     /// chain: `codegen::transform_module` leaves it as written, so a marked
     /// module below it is expanded by the item-level macro and starts a chain
     /// of its own. `enclosing_cfg` is the `#[cfg]` of every enclosing module,
-    /// which every entry below inherits (#300 review).
+    /// which every entry below inherits (#300 review). `reachable` says
+    /// whether every `mod` on the way here is `pub`; it means nothing to the
+    /// `#[julia]` items themselves and is carried only so that an `include!`
+    /// found here reports the position the PyO3 scan of the fragment needs.
     #[allow(clippy::too_many_arguments)]
     fn level(
         &mut self,
@@ -619,8 +714,10 @@ impl CrateScan {
         symbol_path: &[String],
         enclosing_cfg: &[syn::Attribute],
         marked: bool,
+        reachable: bool,
         manifest: &mut Manifest,
         file: &str,
+        includes: &mut Vec<PendingInclude>,
     ) -> Result<(), ExtractError> {
         for item in items {
             match item {
@@ -722,35 +819,27 @@ impl CrateScan {
                     // disappear from the manifest while the proc-macro still
                     // wraps them (#315 review). Only a literal path can be
                     // followed: `include!(concat!(env!("OUT_DIR"), …))` names a
-                    // file the build writes later, and a fragment that is not a
-                    // module (`include!("table.rs")` holding `[1, 2, 3]`) does
-                    // not parse — both are left to the compiler.
+                    // file the build writes later, and it is left to the
+                    // compiler. Reading it is the caller's job (#343), which is
+                    // what lets the PyO3 scan see the fragment too and an
+                    // out-of-line `mod` inside it be resolved against the
+                    // fragment's own directory.
                     let Ok(literal) = m.mac.parse_body::<syn::LitStr>() else {
                         continue;
                     };
-                    let base = std::path::Path::new(file)
-                        .parent()
-                        .map(std::path::Path::to_path_buf)
-                        .unwrap_or_default();
-                    let included = base.join(literal.value());
-                    let Ok(source) = std::fs::read_to_string(&included) else {
-                        continue;
-                    };
-                    let Ok(parsed) = syn::parse_file(&source) else {
-                        continue;
-                    };
-                    let label = included.display().to_string();
-                    self.level(
-                        &parsed.items,
-                        module_path,
-                        symbol_path,
-                        enclosing_cfg,
-                        marked,
-                        manifest,
-                        &label,
-                    )?;
+                    includes.push(PendingInclude {
+                        path: literal.value(),
+                        position: FilePosition {
+                            module_path: module_path.clone(),
+                            reachable,
+                            enclosing_cfg: enclosing_cfg.to_vec(),
+                            symbol_path: symbol_path.to_vec(),
+                            marked,
+                        },
+                    });
                 }
                 Item::Mod(m) => {
+                    let inner_reachable = reachable && matches!(m.vis, syn::Visibility::Public(_));
                     let Some((_, inner)) = &m.content else {
                         // `mod name;` lives in another file; the caller follows
                         // it (see `TreeScan`).
@@ -767,11 +856,23 @@ impl CrateScan {
                             &inner_symbol,
                             &cfg,
                             true,
+                            inner_reachable,
                             manifest,
                             file,
+                            includes,
                         )
                     } else {
-                        self.level(inner, module_path, &[], &cfg, false, manifest, file)
+                        self.level(
+                            inner,
+                            module_path,
+                            &[],
+                            &cfg,
+                            false,
+                            inner_reachable,
+                            manifest,
+                            file,
+                            includes,
+                        )
                     };
                     module_path.pop();
                     result?;

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -832,7 +832,15 @@ impl CrateScan {
                         position: FilePosition {
                             module_path: module_path.clone(),
                             reachable,
-                            enclosing_cfg: enclosing_cfg.to_vec(),
+                            // The `include!` item carries `#[cfg]` of its own
+                            // (`#[cfg(feature = "python")] include!("api.rs")`),
+                            // and the fragment's items exist only under it as
+                            // much as under the enclosing modules'. Dropping it
+                            // left a lenient scan describing them as
+                            // unconditional, so a generated wrapper would call
+                            // items the dependency's feature set may not have
+                            // (#343 review).
+                            enclosing_cfg: crate::cfg::effective_cfg_attrs(enclosing_cfg, &m.attrs),
                             symbol_path: symbol_path.to_vec(),
                             marked,
                         },

--- a/deps/rustcall_core/tests/cfg_pruning.rs
+++ b/deps/rustcall_core/tests/cfg_pruning.rs
@@ -2,7 +2,7 @@
 
 use rustcall_core::cfg::CfgSet;
 use rustcall_core::expand::{expand, expand_with_cfg};
-use rustcall_core::extract::extract_with_cfg;
+use rustcall_core::extract::{extract_with_cfg, FilePosition};
 use rustcall_core::manifest::Mode;
 use rustcall_core::specialize::specialize;
 
@@ -605,27 +605,28 @@ fn enclosing_module_cfg_is_inherited() {
         .file(
             "#[cfg(feature = \"x\")] pub mod a;",
             None,
-            &[],
-            true,
-            &[],
+            &FilePosition::module(&[], true, &[]),
             &mut manifest,
             "src/lib.rs",
         )
-        .unwrap();
+        .unwrap()
+        .modules;
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].cfg.len(), 1);
     let more = scan
         .file(
             "#[pyfunction] pub fn run() -> i32 { 1 }",
             None,
-            &pending[0].module_path,
-            pending[0].reachable,
-            &pending[0].cfg,
+            &FilePosition::module(
+                &pending[0].module_path,
+                pending[0].reachable,
+                &pending[0].cfg,
+            ),
             &mut manifest,
             "src/a.rs",
         )
         .unwrap();
-    assert!(more.is_empty());
+    assert!(more.modules.is_empty() && more.includes.is_empty());
     scan.finish(&mut manifest).unwrap();
     assert_eq!(manifest.functions[0].module_path, vec!["a"]);
     assert_eq!(manifest.functions[0].cfg, "feature = \"x\"");

--- a/deps/rustcall_core/tests/cross_module_impl.rs
+++ b/deps/rustcall_core/tests/cross_module_impl.rs
@@ -6,17 +6,54 @@
 //! walk the tree the way `rustcall-extract --crate-root` does, one
 //! `TreeScan::file` call per file with its real module path.
 
-use rustcall_core::extract::{extract_crate, TreeScan};
+use rustcall_core::extract::{extract_crate, FilePosition, TreeScan};
 use rustcall_core::manifest::{Manifest, Mode, Struct};
 
 /// Scan `files` — `(module path, label, source)` — as one crate.
+///
+/// The out-of-line `mod` declarations are *given* by the caller (each file
+/// comes with its module path), but `include!` fragments are followed the way
+/// `rustcall-extract` follows them: read from disk, relative to the including
+/// file's directory, and scanned at the including item's position (#343). A
+/// test that uses `include!` therefore writes real files and passes real
+/// paths as labels.
 fn scan_tree(files: &[(&[&str], &str, &str)]) -> Result<Manifest, String> {
     let mut manifest = Manifest::new(Mode::Crate);
     let mut scan = TreeScan::new();
     for (path, label, source) in files {
         let path: Vec<String> = path.iter().map(|s| s.to_string()).collect();
-        scan.file(source, None, &path, true, &[], &mut manifest, label)
-            .map_err(|e| e.to_string())?;
+        let mut queue = vec![(
+            std::path::PathBuf::from(label),
+            source.to_string(),
+            FilePosition::module(&path, true, &[]),
+            false,
+        )];
+        while let Some((file, source, position, fragment)) = queue.pop() {
+            let pulled = match scan.file(
+                &source,
+                None,
+                &position,
+                &mut manifest,
+                &file.display().to_string(),
+            ) {
+                Ok(v) => v,
+                // A fragment that is not a list of items is left to the
+                // compiler, as `rustcall-extract` leaves it.
+                Err(_) if fragment => continue,
+                Err(e) => return Err(e.to_string()),
+            };
+            let here = file
+                .parent()
+                .unwrap_or(std::path::Path::new("."))
+                .to_path_buf();
+            for inc in pulled.includes {
+                let path = here.join(&inc.path);
+                let Ok(text) = std::fs::read_to_string(&path) else {
+                    continue;
+                };
+                queue.push((path, text, inc.position, true));
+            }
+        }
     }
     scan.finish(&mut manifest).map_err(|e| e.to_string())?;
     manifest.sort();

--- a/deps/rustcall_core/tests/include_walk.rs
+++ b/deps/rustcall_core/tests/include_walk.rs
@@ -1,0 +1,271 @@
+//! What a file pulls in, and who follows it (#343).
+//!
+//! `include!("api.rs")` compiles the fragment's items into the module that
+//! includes them. Before #343 the `#[julia]` walk read the fragment by itself,
+//! which meant the PyO3 scan never saw it and an out-of-line `mod` declared
+//! inside it was reported to nobody. Both scans now see every file exactly
+//! once: the scan *reports* a fragment ([`PendingInclude`]) the way it reports
+//! an out-of-line `mod`, and the caller — `rustcall-extract`, the only layer
+//! that touches the filesystem — reads it and feeds it back at the position
+//! the report carries.
+//!
+//! The position is what makes the two kinds different. A file of the module
+//! tree is its own module; a fragment is not a module at all, so it keeps the
+//! including module's path, the including `#[julia] mod` chain, and the
+//! including `#[cfg]`. Only the *directory* is the fragment's own, which is
+//! rustc's rule: `include!("frag/api.rs")` in `src/lib.rs` with `mod nested;`
+//! inside `api.rs` wants `src/frag/nested.rs`, and it wants that whether or
+//! not the `include!` sits in an inline module.
+
+use rustcall_core::extract::{FilePosition, TreeScan};
+use rustcall_core::manifest::{Manifest, Mode};
+
+/// Scan one source at `position` and return what it pulls in.
+fn pull_ins(
+    scan: &mut TreeScan,
+    manifest: &mut Manifest,
+    source: &str,
+    position: &FilePosition,
+    label: &str,
+) -> rustcall_core::extract::PullIns {
+    scan.file(source, None, position, manifest, label)
+        .unwrap_or_else(|e| panic!("scanning {label} failed: {e}"))
+}
+
+#[test]
+fn an_include_is_reported_with_the_including_position() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let pulled = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "include!(\"api.rs\");",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    assert_eq!(pulled.includes.len(), 1);
+    assert_eq!(pulled.includes[0].path, "api.rs");
+    assert!(pulled.includes[0].position.module_path.is_empty());
+    assert!(pulled.includes[0].position.symbol_path.is_empty());
+    assert!(pulled.includes[0].position.marked);
+    assert!(pulled.includes[0].position.reachable);
+    assert!(pulled.modules.is_empty());
+}
+
+/// The fragment's items are expanded where the `include!` is written, so a
+/// `#[julia] mod` around it qualifies their symbols: the reported position
+/// carries that chain, and dropping it would export the fragment's items under
+/// crate-root symbols (#300).
+#[test]
+fn an_include_inside_a_marked_module_keeps_the_symbol_chain() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let pulled = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "#[julia] pub mod ops { include!(\"api.rs\"); }",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    assert_eq!(pulled.includes.len(), 1);
+    let position = &pulled.includes[0].position;
+    assert_eq!(position.module_path, vec!["ops".to_string()]);
+    assert_eq!(position.symbol_path, vec!["ops".to_string()]);
+    assert!(position.marked);
+
+    // And scanning the fragment at that position gives the item the module's
+    // symbol, not the crate root's.
+    pull_ins(
+        &mut scan,
+        &mut manifest,
+        "#[julia] pub fn run() -> i32 { 1 }",
+        position,
+        "src/api.rs",
+    );
+    scan.finish(&mut manifest).unwrap();
+    let f = &manifest.functions[0];
+    assert_eq!(f.name, "run");
+    assert_eq!(f.module_path, vec!["ops".to_string()]);
+    assert_eq!(f.symbol, "rustcall_ops__run");
+}
+
+/// An unmarked inline module cuts the symbol chain and refuses `#[julia]`
+/// items; a fragment included there inherits exactly that, so the refusal
+/// happens when the fragment is scanned rather than being silently exported at
+/// the crate root.
+#[test]
+fn an_include_inside_an_unmarked_module_inherits_the_refusal() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let pulled = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "pub mod ops { include!(\"api.rs\"); }",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    let position = &pulled.includes[0].position;
+    assert!(!position.marked);
+    let err = scan
+        .file(
+            "#[julia] pub fn run() -> i32 { 1 }",
+            None,
+            position,
+            &mut manifest,
+            "src/api.rs",
+        )
+        .expect_err("a #[julia] item in an unmarked module is refused");
+    assert!(
+        err.to_string().contains("not marked"),
+        "unexpected error: {err}"
+    );
+}
+
+/// The acceptance case of #343: `lib.rs` includes `api.rs`, which declares
+/// `mod nested;`. The declaration is reported — with the *including* module's
+/// path, because the fragment is not a module — so the caller resolves it and
+/// the `#[julia]` item inside lands in the manifest.
+#[test]
+fn a_mod_declared_inside_a_fragment_is_reported() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let root = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "include!(\"api.rs\");",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    let fragment = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "pub mod nested;\n#[julia] pub fn from_api() -> i32 { 1 }",
+        &root.includes[0].position,
+        "src/api.rs",
+    );
+    assert_eq!(fragment.modules.len(), 1);
+    assert_eq!(fragment.modules[0].name, "nested");
+    assert_eq!(fragment.modules[0].module_path, vec!["nested".to_string()]);
+    assert!(fragment.modules[0].dir_components.is_empty());
+
+    pull_ins(
+        &mut scan,
+        &mut manifest,
+        "#[julia] pub fn deep() -> i32 { 2 }",
+        &FilePosition::module(
+            &fragment.modules[0].module_path,
+            fragment.modules[0].reachable,
+            &fragment.modules[0].cfg,
+        ),
+        "src/nested.rs",
+    );
+    scan.finish(&mut manifest).unwrap();
+    manifest.sort();
+    let names: Vec<&str> = manifest.functions.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, vec!["deep", "from_api"]);
+    let deep = manifest
+        .functions
+        .iter()
+        .find(|f| f.name == "deep")
+        .expect("deep");
+    // A **file** module is transparent to the `#[julia]` symbol scheme — the
+    // proc-macro that expands `nested.rs` cannot see the `mod nested;` that
+    // reaches it, so the symbol is the crate-root one (#300). What #343
+    // changes is that the item is in the manifest at all: before, no `mod`
+    // declared inside a fragment was ever followed.
+    assert!(deep.module_path.is_empty());
+    assert_eq!(deep.symbol, "rustcall_deep");
+}
+
+/// The same for PyO3: the scan that generates a wrapper crate (#275 Phase 2)
+/// now sees a fragment's items too, because both scans are fed by the one
+/// walk. Before #343 the `#[julia]` walk read the fragment alone and this
+/// function was missing from the manifest while the wrapper still needed it.
+#[test]
+fn a_pyo3_item_in_a_fragment_reaches_the_manifest() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let root = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "pub mod api;",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    let api = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "include!(\"api/items.rs\");",
+        &FilePosition::module(
+            &root.modules[0].module_path,
+            root.modules[0].reachable,
+            &root.modules[0].cfg,
+        ),
+        "src/api.rs",
+    );
+    pull_ins(
+        &mut scan,
+        &mut manifest,
+        "#[pyfunction] pub fn shout(s: String) -> String { s }\n\
+         #[pyclass] pub struct Point { pub x: f64 }",
+        &api.includes[0].position,
+        "src/api/items.rs",
+    );
+    scan.finish(&mut manifest).unwrap();
+    let f = manifest
+        .functions
+        .iter()
+        .find(|f| f.name == "shout")
+        .expect("the fragment's #[pyfunction] is in the manifest");
+    assert_eq!(f.module_path, vec!["api".to_string()]);
+    let s = manifest
+        .structs
+        .iter()
+        .find(|s| s.name == "Point")
+        .expect("the fragment's #[pyclass] is in the manifest");
+    assert_eq!(s.module_path, vec!["api".to_string()]);
+}
+
+/// A fragment nested in a fragment is followed like any other, and its
+/// position is still the module that started the chain.
+#[test]
+fn an_include_inside_a_fragment_is_reported_too() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let root = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "#[julia] pub mod ops { include!(\"a.rs\"); }",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    let first = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "include!(\"b.rs\");",
+        &root.includes[0].position,
+        "src/a.rs",
+    );
+    assert_eq!(first.includes.len(), 1);
+    assert_eq!(first.includes[0].path, "b.rs");
+    assert_eq!(
+        first.includes[0].position.symbol_path,
+        vec!["ops".to_string()]
+    );
+}
+
+/// A non-literal `include!` names a file only the build knows, and is left to
+/// the compiler rather than guessed at.
+#[test]
+fn a_non_literal_include_is_not_reported() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let pulled = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    assert!(pulled.includes.is_empty());
+}

--- a/deps/rustcall_core/tests/include_walk.rs
+++ b/deps/rustcall_core/tests/include_walk.rs
@@ -269,3 +269,74 @@ fn a_non_literal_include_is_not_reported() {
     );
     assert!(pulled.includes.is_empty());
 }
+
+/// The `include!` item's own `#[cfg]` gates the fragment's items as much as
+/// the enclosing modules' do. Dropping it made a lenient scan describe them as
+/// unconditional, and a wrapper generated from that would call items the
+/// dependency's feature set may not have (#343 review).
+#[test]
+fn an_include_carries_its_own_cfg_into_the_fragment() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let pulled = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "#[cfg(feature = \"python\")] include!(\"api.rs\");",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    assert_eq!(pulled.includes.len(), 1);
+    assert_eq!(pulled.includes[0].position.enclosing_cfg.len(), 1);
+
+    // And it reaches the items, so a consumer sees the predicate.
+    pull_ins(
+        &mut scan,
+        &mut manifest,
+        "#[julia] pub fn gated() -> i32 { 1 }\n#[pyfunction] pub fn py_gated() -> i32 { 2 }",
+        &pulled.includes[0].position,
+        "src/api.rs",
+    );
+    scan.finish(&mut manifest).unwrap();
+    for name in ["gated", "py_gated"] {
+        let f = manifest
+            .functions
+            .iter()
+            .find(|f| f.name == name)
+            .unwrap_or_else(|| panic!("no `{name}` in {manifest:?}"));
+        assert_eq!(
+            f.cfg, "feature = \"python\"",
+            "{name} lost the include's cfg"
+        );
+        assert_eq!(f.cfg_features, vec!["python".to_string()], "{name}");
+    }
+}
+
+/// A fragment that parses as items but holds something RustCall refuses must
+/// fail the scan, not be skipped: the proc-macro still wraps the item, so a
+/// manifest without it is a wrong answer rather than a partial one. Only a
+/// *parse* failure is a "this was never a list of items" skip (#343 review).
+#[test]
+fn an_unsupported_item_in_a_fragment_is_an_error_not_a_skip() {
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let pulled = pull_ins(
+        &mut scan,
+        &mut manifest,
+        "pub mod ops { include!(\"api.rs\"); }",
+        &FilePosition::module(&[], true, &[]),
+        "src/lib.rs",
+    );
+    let err = scan
+        .file(
+            "#[julia] pub fn run() -> i32 { 1 }",
+            None,
+            &pulled.includes[0].position,
+            &mut manifest,
+            "src/api.rs",
+        )
+        .expect_err("a #[julia] item in an unmarked module is refused");
+    assert!(
+        matches!(err, rustcall_core::extract::ExtractError::Unsupported(_)),
+        "expected Unsupported, got {err:?}"
+    );
+}

--- a/deps/rustcall_extract/src/main.rs
+++ b/deps/rustcall_extract/src/main.rs
@@ -200,6 +200,17 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
             // twice by rustc and belongs in the manifest twice, under each
             // module's own path (#343 review).
             let mut seen: Vec<(PathBuf, Vec<String>)> = Vec::new();
+            // What the caller listed. A file it named is scanned as its own
+            // root, and following a fragment into it as well would scan it
+            // twice under two module paths — a `#[julia]` item would then
+            // claim its symbol twice and the run would fail with a
+            // duplicate-symbol error. In this mode the caller's list wins
+            // (#343 review).
+            let listed: Vec<PathBuf> = opts
+                .files
+                .iter()
+                .map(|f| fs::canonicalize(f).unwrap_or_else(|_| f.clone()))
+                .collect();
             while let Some(QueuedFile {
                 file,
                 dir,
@@ -233,7 +244,14 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
                         continue;
                     }
                 };
-                queue.extend(pulled_in(&file, &dir, pending, follow_modules));
+                for next in pulled_in(&file, &dir, pending, follow_modules) {
+                    let canonical =
+                        fs::canonicalize(&next.file).unwrap_or_else(|_| next.file.clone());
+                    if listed.contains(&canonical) {
+                        continue;
+                    }
+                    queue.push(next);
+                }
             }
             scan.finish(&mut merged).map_err(|e| e.to_string())?;
         }

--- a/deps/rustcall_extract/src/main.rs
+++ b/deps/rustcall_extract/src/main.rs
@@ -176,21 +176,23 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
         // checked crate-wide (#300).
         (Mode::Crate, None) => {
             let mut scan = rustcall_core::extract::TreeScan::new();
-            // The `include!` fragments of each file are followed here too —
-            // no `mod` declaration reaches a fragment, so nothing else would
-            // bring it in — but out-of-line `mod`s are not: without a root
-            // there is no module tree to place them in, and the caller listed
-            // the files it wants scanned.
-            let mut queue: Vec<(PathBuf, rustcall_core::extract::FilePosition, bool)> = opts
+            // A listed file's own out-of-line `mod`s are not followed here:
+            // without a root there is no module tree to place them in, and the
+            // caller listed the files it wants scanned. What it *cannot* list
+            // is what a file pulls in implicitly — an `include!` fragment, and
+            // in turn whatever that fragment declares — so those are followed
+            // (#343, #343 review). `follow_modules` marks a file reached that
+            // way.
+            let mut queue: Vec<QueuedFile> = opts
                 .files
                 .iter()
                 .rev()
-                .map(|f| {
-                    (
-                        f.clone(),
-                        rustcall_core::extract::FilePosition::module(&[], true, &[]),
-                        false,
-                    )
+                .map(|f| QueuedFile {
+                    dir: f.parent().unwrap_or(Path::new(".")).to_path_buf(),
+                    file: f.clone(),
+                    position: rustcall_core::extract::FilePosition::module(&[], true, &[]),
+                    follow_modules: false,
+                    fragment: false,
                 })
                 .collect();
             // Keyed by (file, module path) as the crate-root walk is: one
@@ -198,45 +200,40 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
             // twice by rustc and belongs in the manifest twice, under each
             // module's own path (#343 review).
             let mut seen: Vec<(PathBuf, Vec<String>)> = Vec::new();
-            while let Some((f, position, fragment)) = queue.pop() {
-                let canonical = fs::canonicalize(&f).unwrap_or_else(|_| f.clone());
+            while let Some(QueuedFile {
+                file,
+                dir,
+                position,
+                follow_modules,
+                fragment,
+            }) = queue.pop()
+            {
+                let canonical = fs::canonicalize(&file).unwrap_or_else(|_| file.clone());
                 let key = (canonical, position.module_path.clone());
                 if seen.contains(&key) {
                     continue;
                 }
                 seen.push(key);
-                let src = read_source(&f)?;
+                let src = read_source(&file)?;
                 let scanned = scan.file(
                     &src,
                     opts.cfg.as_ref(),
                     &position,
                     &mut merged,
-                    &f.display().to_string(),
+                    &file.display().to_string(),
                 );
                 let pending = match scanned {
                     Ok(v) => v,
                     Err(e) => {
                         if fragment {
-                            skip_fragment_or_fail(e, &f)?;
+                            skip_fragment_or_fail(e, &file)?;
                         } else {
-                            skip_or_fail(e, &f, opts.skip_unparsable)?;
+                            skip_or_fail(e, &file, opts.skip_unparsable)?;
                         }
                         continue;
                     }
                 };
-                let here = f.parent().unwrap_or(Path::new(".")).to_path_buf();
-                for inc in pending.includes {
-                    let fragment_path = here.join(&inc.path);
-                    if !fragment_path.is_file() {
-                        eprintln!(
-                            "rustcall-extract: `include!(\"{}\")` in {} names no file; skipping it",
-                            inc.path,
-                            f.display()
-                        );
-                        continue;
-                    }
-                    queue.push((fragment_path, inc.position, true));
-                }
+                queue.extend(pulled_in(&file, &dir, pending, follow_modules));
             }
             scan.finish(&mut merged).map_err(|e| e.to_string())?;
         }
@@ -401,12 +398,85 @@ struct QueuedFile {
     file: PathBuf,
     dir: PathBuf,
     position: rustcall_core::extract::FilePosition,
+    /// Whether the out-of-line `mod` declarations of this file are followed.
+    /// Always true when there is a crate root; without one, true only for a
+    /// file reached through an `include!`, because a listed file's modules are
+    /// the caller's to list and a fragment's are not (#343 review).
+    follow_modules: bool,
     /// An `include!`d fragment rather than a file of the module tree. A
     /// fragment need not be a list of items at all — `include!("table.rs")`
     /// holding `[1, 2, 3]` is an expression — so one that does not parse as a
     /// file is left to the compiler instead of failing the scan, whatever
     /// `--skip-unparsable` says about the crate's own files.
     fragment: bool,
+}
+
+/// The files `pending` brings in, as queue entries.
+///
+/// One step for both walks, so the crate-root scan and the file-list scan
+/// cannot disagree about what a file pulls in (#343). `dir` is the *module*
+/// directory of `file`, which is where its out-of-line `mod`s live; an
+/// `include!` is relative to the directory of the file it is written in
+/// instead — `src/a.rs` is the file of module `a`, whose child modules live in
+/// `src/a/`, but `include!("x.rs")` in it names `src/x.rs` — and the fragment
+/// then owns its own directory for anything *it* declares.
+///
+/// `follow_modules` is false only for a file the caller listed in a scan with
+/// no crate root: its modules are the caller's to list. Everything reached
+/// from an `include!` sets it, because nothing outside the crate could have
+/// named those files.
+fn pulled_in(
+    file: &Path,
+    dir: &Path,
+    pending: rustcall_core::extract::PullIns,
+    follow_modules: bool,
+) -> Vec<QueuedFile> {
+    let mut out = Vec::new();
+    if follow_modules {
+        for m in pending.modules {
+            let Some((child_file, child_dir)) = resolve_module_file(dir, &m) else {
+                eprintln!(
+                    "rustcall-extract: `mod {};` in {} names no file under {}; skipping it",
+                    m.name,
+                    file.display(),
+                    dir.display()
+                );
+                continue;
+            };
+            out.push(QueuedFile {
+                file: child_file,
+                dir: child_dir,
+                position: rustcall_core::extract::FilePosition::module(
+                    &m.module_path,
+                    m.reachable,
+                    &m.cfg,
+                ),
+                follow_modules: true,
+                fragment: false,
+            });
+        }
+    }
+
+    let here = file.parent().unwrap_or(Path::new(".")).to_path_buf();
+    for inc in pending.includes {
+        let fragment = here.join(&inc.path);
+        if !fragment.is_file() {
+            eprintln!(
+                "rustcall-extract: `include!(\"{}\")` in {} names no file; skipping it",
+                inc.path,
+                file.display()
+            );
+            continue;
+        }
+        out.push(QueuedFile {
+            dir: fragment.parent().unwrap_or(Path::new(".")).to_path_buf(),
+            file: fragment,
+            position: inc.position,
+            follow_modules: true,
+            fragment: true,
+        });
+    }
+    out
 }
 
 /// Scan a whole crate by following its module tree from `root` (#275, #315).
@@ -431,6 +501,7 @@ fn scan_crate_tree(
         file: root.to_path_buf(),
         dir: root_dir,
         position: rustcall_core::extract::FilePosition::module(&[], true, &[]),
+        follow_modules: true,
         fragment: false,
     }];
     // Keyed by (file, module path): `#[path = "shared.rs"] pub mod a;` and the
@@ -445,6 +516,7 @@ fn scan_crate_tree(
         file,
         dir,
         position,
+        follow_modules,
         fragment,
     }) = queue.pop()
     {
@@ -469,51 +541,7 @@ fn scan_crate_tree(
             }
         };
 
-        for m in pending.modules {
-            let Some((child_file, child_dir)) = resolve_module_file(&dir, &m) else {
-                eprintln!(
-                    "rustcall-extract: `mod {};` in {} names no file under {}; skipping it",
-                    m.name,
-                    file.display(),
-                    dir.display()
-                );
-                continue;
-            };
-            queue.push(QueuedFile {
-                file: child_file,
-                dir: child_dir,
-                position: rustcall_core::extract::FilePosition::module(
-                    &m.module_path,
-                    m.reachable,
-                    &m.cfg,
-                ),
-                fragment: false,
-            });
-        }
-
-        // An `include!` is relative to the *file* it is written in, not to the
-        // module directory: `src/a.rs` is the file of module `a`, whose child
-        // modules live in `src/a/`, but `include!("x.rs")` in it names
-        // `src/x.rs`. The fragment then owns its own directory for anything it
-        // declares.
-        let here = file.parent().unwrap_or(Path::new(".")).to_path_buf();
-        for inc in pending.includes {
-            let fragment = here.join(&inc.path);
-            if !fragment.is_file() {
-                eprintln!(
-                    "rustcall-extract: `include!(\"{}\")` in {} names no file; skipping it",
-                    inc.path,
-                    file.display()
-                );
-                continue;
-            }
-            queue.push(QueuedFile {
-                dir: fragment.parent().unwrap_or(Path::new(".")).to_path_buf(),
-                file: fragment,
-                position: inc.position,
-                fragment: true,
-            });
-        }
+        queue.extend(pulled_in(&file, &dir, pending, follow_modules));
     }
     // Structs and their impl blocks — `#[julia]` and PyO3 alike — may live in
     // different files, so the structs are only emitted once every file of the

--- a/deps/rustcall_extract/src/main.rs
+++ b/deps/rustcall_extract/src/main.rs
@@ -176,19 +176,64 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
         // checked crate-wide (#300).
         (Mode::Crate, None) => {
             let mut scan = rustcall_core::extract::TreeScan::new();
-            for f in &opts.files {
-                let src = read_source(f)?;
+            // The `include!` fragments of each file are followed here too —
+            // no `mod` declaration reaches a fragment, so nothing else would
+            // bring it in — but out-of-line `mod`s are not: without a root
+            // there is no module tree to place them in, and the caller listed
+            // the files it wants scanned.
+            let mut queue: Vec<(PathBuf, rustcall_core::extract::FilePosition, bool)> = opts
+                .files
+                .iter()
+                .rev()
+                .map(|f| {
+                    (
+                        f.clone(),
+                        rustcall_core::extract::FilePosition::module(&[], true, &[]),
+                        false,
+                    )
+                })
+                .collect();
+            let mut seen: Vec<PathBuf> = Vec::new();
+            while let Some((f, position, fragment)) = queue.pop() {
+                let canonical = fs::canonicalize(&f).unwrap_or_else(|_| f.clone());
+                if seen.contains(&canonical) {
+                    continue;
+                }
+                seen.push(canonical);
+                let src = read_source(&f)?;
                 let scanned = scan.file(
                     &src,
                     opts.cfg.as_ref(),
-                    &[],
-                    true,
-                    &[],
+                    &position,
                     &mut merged,
                     &f.display().to_string(),
                 );
-                if let Err(e) = scanned {
-                    skip_or_fail(e, f, opts.skip_unparsable)?;
+                let pending = match scanned {
+                    Ok(v) => v,
+                    Err(e) => {
+                        if fragment {
+                            eprintln!(
+                                "rustcall-extract: {} is not a list of items ({e}); skipping it",
+                                f.display()
+                            );
+                        } else {
+                            skip_or_fail(e, &f, opts.skip_unparsable)?;
+                        }
+                        continue;
+                    }
+                };
+                let here = f.parent().unwrap_or(Path::new(".")).to_path_buf();
+                for inc in pending.includes {
+                    let fragment_path = here.join(&inc.path);
+                    if !fragment_path.is_file() {
+                        eprintln!(
+                            "rustcall-extract: `include!(\"{}\")` in {} names no file; skipping it",
+                            inc.path,
+                            f.display()
+                        );
+                        continue;
+                    }
+                    queue.push((fragment_path, inc.position, true));
                 }
             }
             scan.finish(&mut merged).map_err(|e| e.to_string())?;
@@ -321,64 +366,89 @@ fn cmd_manifest(args: &[Arg]) -> Result<(), String> {
     write_manifest(&merged, out.as_deref())
 }
 
+/// One file waiting to be scanned: where it is, which directory its
+/// out-of-line children resolve against, and the position its items occupy.
+///
+/// A file of the module tree and an `include!`d fragment differ only in these
+/// two: a fragment keeps the *including* module's position (#343) and brings
+/// its own directory, because rustc resolves a `mod` written inside a fragment
+/// against the fragment's own directory.
+struct QueuedFile {
+    file: PathBuf,
+    dir: PathBuf,
+    position: rustcall_core::extract::FilePosition,
+    /// An `include!`d fragment rather than a file of the module tree. A
+    /// fragment need not be a list of items at all — `include!("table.rs")`
+    /// holding `[1, 2, 3]` is an expression — so one that does not parse as a
+    /// file is left to the compiler instead of failing the scan, whatever
+    /// `--skip-unparsable` says about the crate's own files.
+    fragment: bool,
+}
+
 /// Scan a whole crate by following its module tree from `root` (#275, #315).
 ///
 /// Only this layer touches the filesystem: `rustcall_core` hands back the
-/// out-of-line `mod` declarations of each file and this resolves them the way
-/// rustc does — `#[path = "..."]` first, then `<dir>/<name>.rs`, then
-/// `<dir>/<name>/mod.rs`. A declaration whose file does not exist (a `mod`
-/// behind a `#[cfg]` that was pruned, or a generated file) is noted on stderr
-/// and skipped rather than failing the run: the scan describes what it can see.
+/// out-of-line `mod` declarations and the `include!` fragments of each file,
+/// and this resolves them. A `mod` is resolved the way rustc does —
+/// `#[path = "..."]` first, then `<dir>/<name>.rs`, then `<dir>/<name>/mod.rs`
+/// — and an `include!` relative to the directory of the file it was written
+/// in. Anything that does not resolve (a `mod` behind a `#[cfg]` that was
+/// pruned, a generated file, an `include!` of a fragment that is not a module
+/// such as `include!("table.rs")` holding `[1, 2, 3]`) is noted on stderr and
+/// skipped rather than failing the run: the scan describes what it can see.
 fn scan_crate_tree(
     root: &Path,
     cfg: Option<&CfgSet>,
     skip_unparsable: bool,
     manifest: &mut Manifest,
 ) -> Result<(), String> {
-    // (file, directory its child modules live in, module path, reachable,
-    // the `#[cfg]` attributes of the enclosing `mod` declarations)
     let root_dir = root.parent().unwrap_or(Path::new(".")).to_path_buf();
-    let mut queue = vec![(
-        root.to_path_buf(),
-        root_dir,
-        Vec::<String>::new(),
-        true,
-        Vec::new(),
-    )];
+    let mut queue = vec![QueuedFile {
+        file: root.to_path_buf(),
+        dir: root_dir,
+        position: rustcall_core::extract::FilePosition::module(&[], true, &[]),
+        fragment: false,
+    }];
     // Keyed by (file, module path): `#[path = "shared.rs"] pub mod a;` and the
     // same for `b` compile one file as two distinct modules, and both belong in
     // the manifest — under their own module paths, and colliding with each
-    // other on the wrapper symbols.
+    // other on the wrapper symbols. An `include!`d fragment is keyed the same
+    // way, under the module that includes it.
     let mut visited: Vec<(PathBuf, Vec<String>)> = Vec::new();
     let mut scan = rustcall_core::extract::TreeScan::new();
 
-    while let Some((file, dir, module_path, reachable, enclosing_cfg)) = queue.pop() {
+    while let Some(QueuedFile {
+        file,
+        dir,
+        position,
+        fragment,
+    }) = queue.pop()
+    {
         let canonical = fs::canonicalize(&file).unwrap_or_else(|_| file.clone());
-        let key = (canonical, module_path.clone());
+        let key = (canonical, position.module_path.clone());
         if visited.contains(&key) {
             continue;
         }
         visited.push(key);
 
         let src = read_source(&file)?;
-        let scanned = scan.file(
-            &src,
-            cfg,
-            &module_path,
-            reachable,
-            &enclosing_cfg,
-            manifest,
-            &file.display().to_string(),
-        );
+        let scanned = scan.file(&src, cfg, &position, manifest, &file.display().to_string());
         let pending = match scanned {
             Ok(v) => v,
             Err(e) => {
-                skip_or_fail(e, &file, skip_unparsable)?;
+                if fragment {
+                    eprintln!(
+                        "rustcall-extract: {} is not a list of items ({e}); skipping it",
+                        file.display()
+                    );
+                } else {
+                    skip_or_fail(e, &file, skip_unparsable)?;
+                }
                 continue;
             }
         };
 
-        for m in pending {
+        for m in pending.modules {
             let Some((child_file, child_dir)) = resolve_module_file(&dir, &m) else {
                 eprintln!(
                     "rustcall-extract: `mod {};` in {} names no file under {}; skipping it",
@@ -388,13 +458,40 @@ fn scan_crate_tree(
                 );
                 continue;
             };
-            queue.push((
-                child_file,
-                child_dir,
-                m.module_path.clone(),
-                m.reachable,
-                m.cfg.clone(),
-            ));
+            queue.push(QueuedFile {
+                file: child_file,
+                dir: child_dir,
+                position: rustcall_core::extract::FilePosition::module(
+                    &m.module_path,
+                    m.reachable,
+                    &m.cfg,
+                ),
+                fragment: false,
+            });
+        }
+
+        // An `include!` is relative to the *file* it is written in, not to the
+        // module directory: `src/a.rs` is the file of module `a`, whose child
+        // modules live in `src/a/`, but `include!("x.rs")` in it names
+        // `src/x.rs`. The fragment then owns its own directory for anything it
+        // declares.
+        let here = file.parent().unwrap_or(Path::new(".")).to_path_buf();
+        for inc in pending.includes {
+            let fragment = here.join(&inc.path);
+            if !fragment.is_file() {
+                eprintln!(
+                    "rustcall-extract: `include!(\"{}\")` in {} names no file; skipping it",
+                    inc.path,
+                    file.display()
+                );
+                continue;
+            }
+            queue.push(QueuedFile {
+                dir: fragment.parent().unwrap_or(Path::new(".")).to_path_buf(),
+                file: fragment,
+                position: inc.position,
+                fragment: true,
+            });
         }
     }
     // Structs and their impl blocks — `#[julia]` and PyO3 alike — may live in

--- a/deps/rustcall_extract/src/main.rs
+++ b/deps/rustcall_extract/src/main.rs
@@ -193,13 +193,18 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
                     )
                 })
                 .collect();
-            let mut seen: Vec<PathBuf> = Vec::new();
+            // Keyed by (file, module path) as the crate-root walk is: one
+            // fragment `include!`d under two different modules is compiled
+            // twice by rustc and belongs in the manifest twice, under each
+            // module's own path (#343 review).
+            let mut seen: Vec<(PathBuf, Vec<String>)> = Vec::new();
             while let Some((f, position, fragment)) = queue.pop() {
                 let canonical = fs::canonicalize(&f).unwrap_or_else(|_| f.clone());
-                if seen.contains(&canonical) {
+                let key = (canonical, position.module_path.clone());
+                if seen.contains(&key) {
                     continue;
                 }
-                seen.push(canonical);
+                seen.push(key);
                 let src = read_source(&f)?;
                 let scanned = scan.file(
                     &src,
@@ -212,10 +217,7 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
                     Ok(v) => v,
                     Err(e) => {
                         if fragment {
-                            eprintln!(
-                                "rustcall-extract: {} is not a list of items ({e}); skipping it",
-                                f.display()
-                            );
+                            skip_fragment_or_fail(e, &f)?;
                         } else {
                             skip_or_fail(e, &f, opts.skip_unparsable)?;
                         }
@@ -247,6 +249,28 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
 
 /// Only a file that is not a Rust module is skippable (an `include!()`
 /// fragment); an item RustCall refuses fails the scan.
+/// A fragment that does not parse is not a fragment of items — an
+/// `include!("table.rs")` holding `[1, 2, 3]` is an expression — so it is left
+/// to the compiler whatever `--skip-unparsable` says about the crate's own
+/// files. An `ExtractError::Unsupported` is a different thing entirely: the
+/// fragment *is* items, and one of them is something RustCall refuses (a
+/// `#[julia]` item in an unmarked inline module, a crate-wide duplicate
+/// symbol). Swallowing that would hand back a manifest missing an item the
+/// proc-macro still wraps, so it fails closed exactly as it would in a file of
+/// the module tree (#343 review).
+fn skip_fragment_or_fail(e: ExtractError, file: &Path) -> Result<(), String> {
+    match e {
+        ExtractError::Parse(e) => {
+            eprintln!(
+                "rustcall-extract: {} is not a list of items ({e}); skipping it",
+                file.display()
+            );
+            Ok(())
+        }
+        e => Err(format!("{}: {e}", file.display())),
+    }
+}
+
 fn skip_or_fail(e: ExtractError, file: &Path, skip_unparsable: bool) -> Result<(), String> {
     match e {
         ExtractError::Parse(e) if skip_unparsable => {
@@ -437,10 +461,7 @@ fn scan_crate_tree(
             Ok(v) => v,
             Err(e) => {
                 if fragment {
-                    eprintln!(
-                        "rustcall-extract: {} is not a list of items ({e}); skipping it",
-                        file.display()
-                    );
+                    skip_fragment_or_fail(e, &file)?;
                 } else {
                     skip_or_fail(e, &file, skip_unparsable)?;
                 }

--- a/docs/src/crate_bindings.md
+++ b/docs/src/crate_bindings.md
@@ -179,9 +179,20 @@ elsewhere: annotate that struct, or spell the intended one
 (`impl crate::Counter`).
 
 A file reached only by a literal `include!("api.rs")` is scanned too: its items
-are compiled into the including module, so that is where they bind. An include
-whose path is not a literal (`include!(concat!(env!("OUT_DIR"), "/api.rs"))`)
-names a file the build writes later and is left to the compiler.
+are compiled into the including module, so that is where they bind — the
+`#[julia] mod` chain included — so a fragment included inside
+`#[julia] pub mod ops` gets `ops`-qualified symbols. An include whose path is
+not a literal (`include!(concat!(env!("OUT_DIR"), "/api.rs"))`) names a file the
+build writes later and is left to the compiler, as is a fragment that is not a
+list of items (`include!("table.rs")` holding `[1, 2, 3]`).
+
+A fragment may declare out-of-line modules of its own, and those are followed
+(#343). Their files are resolved against the **fragment's** directory, which is
+what rustc does: with `include!("frag/api.rs")` in `src/lib.rs` and
+`pub mod nested;` inside `api.rs`, the module's file is `src/frag/nested.rs` —
+not `src/nested.rs` — even though `nested` is a child of the *including*
+module. A declaration whose file does not exist is noted and skipped, exactly
+as a missing `mod` target elsewhere in the tree.
 
 !!! note "Inline blocks: the wrapper is emitted where the block is"
     A `rust"""` block follows the same rule (#342): the wrappers of a method

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -754,8 +754,10 @@ in another file (#315) — instead of treating every file as a root. The tree *i
 the file list then: `files` is not passed on, because a file no `mod` reaches is
 not compiled by rustc and exports nothing. The walk follows a literal
 `include!("api.rs")` as well, since that file's items are compiled into the
-including module (#315 review); an include whose path is not a literal, or that
-holds a fragment rather than items, is left to the compiler.
+including module (#315 review) — and the out-of-line `mod` declarations *inside*
+such a fragment, resolved against the fragment's own directory the way rustc
+resolves them (#343). An include whose path is not a literal, or that holds a
+fragment rather than items, is left to the compiler.
 """
 function extract_manifest(files::Vector{String}; mode::String, skip_unparsable::Bool = false,
                           cfg = :strict, cfg_text::Union{Nothing, AbstractString} = nothing,

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -449,6 +449,9 @@ end
         @test gauge_exports("CmiInlineGauge_free_rust_string")
         @test gauge_exports("CmiInlineGauge_cmi_cross_label_free_rust_string")
         @test gauge_exports("CmiInlineGauge_cmi_cross_split_free_rust_string")
+    end
+end
+
 # rustc resolves a `mod` written inside an `include!`d fragment against the
 # **fragment's own** directory, not the including file's module directory:
 # `include!("frag/api.rs")` in `src/lib.rs` with `mod nested;` in `api.rs`

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -588,3 +588,44 @@ end
         end
     end
 end
+
+# The no-crate-root walk does not follow a listed file's own `mod` declarations
+# — the caller lists the files it wants — but a fragment's are not the caller's
+# to list: nothing outside the crate names them, and rustc compiles them. So
+# they are followed, resolved against the fragment's own directory (#343
+# review).
+@testset "A mod declared inside a fragment is followed without a crate root (#343 review)" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping the no-root fragment-module test"
+    else
+        mktempdir() do dir
+            mkpath(joinpath(dir, "frag"))
+            write(joinpath(dir, "frag", "api.rs"), """
+                pub mod nested;
+                #[julia]
+                pub fn from_api() -> i32 { 1 }
+                """)
+            write(joinpath(dir, "frag", "nested.rs"), """
+                use juliacall_macros::julia;
+                #[julia]
+                pub fn deep() -> i32 { 2 }
+                """)
+            lib = joinpath(dir, "lib.rs")
+            write(lib, """
+                use juliacall_macros::julia;
+                include!("frag/api.rs");
+                """)
+
+            manifest = RustCall.extract_manifest([lib]; mode = "crate")
+            names = sort([f["name"] for f in manifest["functions"]])
+            @test names == ["deep", "from_api"]
+
+            # A listed file's own `mod` is still the caller's to list: this
+            # walk has no module tree to place it in.
+            plain = joinpath(dir, "plain.rs")
+            write(plain, "pub mod nested;\n")
+            plain_manifest = RustCall.extract_manifest([plain]; mode = "crate")
+            @test isempty(plain_manifest["functions"])
+        end
+    end
+end

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -626,6 +626,16 @@ end
             write(plain, "pub mod nested;\n")
             plain_manifest = RustCall.extract_manifest([plain]; mode = "crate")
             @test isempty(plain_manifest["functions"])
+
+            # And a caller that lists *both* the including file and the
+            # fragment's module file gets one scan of it, not two: scanning it
+            # as a root and again under `nested` would claim `rustcall_deep`
+            # twice and fail the run (#343 review).
+            both = RustCall.extract_manifest([lib, joinpath(dir, "frag", "nested.rs")];
+                                             mode = "crate")
+            @test sort([f["name"] for f in both["functions"]]) == ["deep", "from_api"]
+            @test sort([f["symbol"] for f in both["functions"]]) ==
+                  ["rustcall_deep", "rustcall_from_api"]
         end
     end
 end

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -449,5 +449,106 @@ end
         @test gauge_exports("CmiInlineGauge_free_rust_string")
         @test gauge_exports("CmiInlineGauge_cmi_cross_label_free_rust_string")
         @test gauge_exports("CmiInlineGauge_cmi_cross_split_free_rust_string")
+# rustc resolves a `mod` written inside an `include!`d fragment against the
+# **fragment's own** directory, not the including file's module directory:
+# `include!("frag/api.rs")` in `src/lib.rs` with `mod nested;` in `api.rs`
+# compiles `src/frag/nested.rs`. (Verified against rustc: with the file only at
+# `src/nested.rs` the build fails with "create file src/frag/nested.rs".) The
+# fragment's items still belong to the *including* module — `nested` is a child
+# of the crate root here, not of anything called `frag`.
+@testset "A mod declared inside an include! fragment is followed (#343)" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping the include!-plus-mod scan test"
+    else
+        mktempdir() do dir
+            mkpath(joinpath(dir, "src", "frag"))
+            macros = replace(CMI_MACROS_PATH, "\\" => "/")
+            write(joinpath(dir, "Cargo.toml"), """
+                [package]
+                name = "included_mod"
+                version = "0.1.0"
+                edition = "2021"
+
+                [lib]
+                crate-type = ["cdylib"]
+
+                [dependencies]
+                juliacall_macros = { path = "$macros" }
+                """)
+            write(joinpath(dir, "src", "frag", "api.rs"), """
+                pub mod nested;
+                #[julia]
+                pub fn from_api() -> i32 { nested::deep() }
+                """)
+            # Next to the fragment, which is where rustc looks. It is a
+            # module of its own, so it brings its own `use` — the fragment
+            # above inherits the crate root's, because it is compiled into it.
+            write(joinpath(dir, "src", "frag", "nested.rs"), """
+                use juliacall_macros::julia;
+                #[julia]
+                pub fn deep() -> i32 { 7 }
+                """)
+            write(joinpath(dir, "src", "lib.rs"), """
+                use juliacall_macros::julia;
+                include!("frag/api.rs");
+                #[julia]
+                pub fn root_one() -> i32 { 1 }
+                """)
+
+            info = RustCall.scan_crate(dir)
+            names = sort([f.name for f in info.julia_functions])
+            @test names == ["deep", "from_api", "root_one"]
+            symbols = Dict(f.name => f.symbol for f in info.julia_functions)
+            # A file module is transparent to the `#[julia]` symbol scheme
+            # (#300), so `deep` keeps the crate-root symbol; what #343 fixes is
+            # that it is in the manifest at all.
+            @test symbols["deep"] == "rustcall_deep"
+
+            # And the crate really does compile with this layout, so the
+            # manifest describes what rustc builds.
+            bindings = RustCall.@rust_crate dir
+            @test bindings.deep() == 7
+            @test bindings.from_api() == 7
+            @test bindings.root_one() == 1
+        end
+    end
+end
+
+# A `mod` inside a fragment whose file does not exist is noted and skipped, the
+# way a missing `mod` target has always been: the scan describes what it can
+# see rather than failing (#343).
+@testset "A mod inside a fragment that names no file is skipped (#343)" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping the missing-mod-in-fragment test"
+    else
+        mktempdir() do dir
+            mkpath(joinpath(dir, "src"))
+            macros = replace(CMI_MACROS_PATH, "\\" => "/")
+            write(joinpath(dir, "Cargo.toml"), """
+                [package]
+                name = "missing_mod_in_fragment"
+                version = "0.1.0"
+                edition = "2021"
+
+                [lib]
+                crate-type = ["cdylib"]
+
+                [dependencies]
+                juliacall_macros = { path = "$macros" }
+                """)
+            write(joinpath(dir, "src", "api.rs"), """
+                #[cfg(feature = "never")]
+                pub mod absent;
+                #[julia]
+                pub fn present() -> i32 { 3 }
+                """)
+            write(joinpath(dir, "src", "lib.rs"), """
+                use juliacall_macros::julia;
+                include!("api.rs");
+                """)
+
+            info = RustCall.scan_crate(dir)
+            @test [f.name for f in info.julia_functions] == ["present"]
+        end
     end
 end

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -552,3 +552,39 @@ end
         end
     end
 end
+
+# One fragment `include!`d under two different modules is compiled twice by
+# rustc and belongs in the manifest twice, under each module's own path. The
+# walk that has no crate root keyed the files it had seen by path alone, so the
+# second position was dropped and one module's binding went missing (#343
+# review).
+@testset "A fragment included under two modules is scanned twice (#343 review)" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping the twice-included fragment test"
+    else
+        mktempdir() do dir
+            write(joinpath(dir, "frag.rs"), """
+                #[julia]
+                pub fn run() -> i32 { 1 }
+                """)
+            lib = joinpath(dir, "lib.rs")
+            write(lib, """
+                use juliacall_macros::julia;
+                #[julia]
+                pub mod a { include!("frag.rs"); }
+                #[julia]
+                pub mod b { include!("frag.rs"); }
+                """)
+
+            # The no-crate-root walk: every file argument is its own root.
+            manifest = RustCall.extract_manifest([lib]; mode = "crate")
+            symbols = sort([f["symbol"] for f in manifest["functions"]])
+            @test symbols == ["rustcall_a__run", "rustcall_b__run"]
+
+            # And the same through the crate-root walk, which keyed correctly
+            # already — the two paths must agree.
+            rooted = RustCall.extract_manifest(String[]; mode = "crate", crate_root = lib)
+            @test sort([f["symbol"] for f in rooted["functions"]]) == symbols
+        end
+    end
+end


### PR DESCRIPTION
## Summary

A `mod` declaration written inside an `include!`d file was followed by nobody, and a fragment's items were invisible to the PyO3 scan. Both come from the same place: since #315 the `#[julia]` walk followed a literal `include!("api.rs")` *itself*, inside `rustcall_core` — the layer that is not supposed to touch the filesystem, and the one that only half the scan runs through.

So a crate like

```rust
// src/lib.rs
include!("api.rs");

// src/api.rs
pub mod nested;

// src/nested.rs
#[julia] pub fn deep() -> i32 { 7 }
```

compiled fine and exported `rustcall_deep`, but `deep` was missing from the manifest, so Julia never bound it. And a `#[pyfunction]` in `api.rs` was missing too, because `Pyo3Scan` was never handed the fragment.

## What changed

`TreeScan::file` now takes a `FilePosition` and returns a `PullIns`: the out-of-line `mod` declarations **and** the `include!` fragments. `rustcall-extract` — the only layer that reads files — follows both, so both scans see every file exactly once.

A fragment is scanned as a file of its own, at the **including item's** position:

| carried from the `include!` site | why |
|---|---|
| module path | the fragment's items are compiled into the including module |
| `#[julia] mod` chain | a fragment inside `#[julia] pub mod ops` must still get `ops`-qualified symbols (#300); one inside an *unmarked* module must still refuse `#[julia]` items |
| `#[cfg]` | the items exist only under the enclosing predicates |
| reachability | whether a PyO3 item is reachable from outside the crate |

Only the **directory** is the fragment's own — and that is rustc's rule, not a choice we made:

```
src/lib.rs        include!("frag/api.rs");
src/frag/api.rs   pub mod nested;
src/frag/nested.rs   ← this is the file rustc compiles
```

I checked this against rustc rather than assuming: with the file only at `src/nested.rs`, the build fails with `help: to create the module `nested`, create file "src/frag/nested.rs"`. It holds whether or not the `include!` sits in an inline module. **Issue #343 states the opposite rule** ("relative to the *including* file's directory"); rustc's rule is what is implemented, and the issue text is wrong on that point.

A fragment that does not exist, or that is not a list of items (`include!("table.rs")` holding `[1, 2, 3]`), is noted on stderr and skipped exactly as a missing `mod` target already was — regardless of `--skip-unparsable`, which governs the crate's own files. A data fragment is not a scan failure.

## Acceptance criteria

| criterion (from #343) | test |
|---|---|
| `lib.rs` with `include!`, `api.rs` with `mod nested;`, a `#[julia]` item in the module's file: in the manifest with the right module path | `test/test_cross_module_impl.jl`, "A mod declared inside an include! fragment is followed (#343)" — end to end through the real CLI, and it builds the crate and calls `deep()`, `from_api()`, `root_one()`; `deps/rustcall_core/tests/include_walk.rs::a_mod_declared_inside_a_fragment_is_reported` |
| the same for a `#[pyclass]` item | `include_walk.rs::a_pyo3_item_in_a_fragment_reaches_the_manifest` (a `#[pyfunction]` and a `#[pyclass]`, both under the including module's path) |
| a `mod` inside a fragment whose target does not exist fails the scan the way a missing `mod` target does today — i.e. a note and a skip | `test/test_cross_module_impl.jl`, "A mod inside a fragment that names no file is skipped (#343)" |
| both scans share one "what does this file pull in" step | `PullIns`, and the PyO3 test above, which could not pass without it |

Note on the module path: a **file** module is transparent to the `#[julia]` symbol scheme — the proc-macro that expands `nested.rs` cannot see the `mod nested;` that reaches it (#300) — so `deep` keeps the crate-root symbol `rustcall_deep`. What #343 changes is that it is in the manifest at all. The PyO3 side does qualify by file module, and the test asserts that.

Also in `include_walk.rs`: the `#[julia] mod` chain is carried into a fragment; an unmarked module's refusal is inherited; a fragment inside a fragment is followed; a non-literal `include!(concat!(env!("OUT_DIR"), …))` reports nothing.

## Verification

`cargo test` / `cargo clippy -D warnings` / `cargo fmt --check` in `deps/rustcall_core`, all five `scripts/lint_*.sh`, and the full Julia suite: **9285 tests, 0 failures, 2 known broken**.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
