### PR TITLE
Key a visited file by its full position, not only its module path (#357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Two cfg-exclusive modules including one fragment are both scanned**
+  ([#357](https://github.com/AtelierArith/RustCall.jl/issues/357)). Since #343
+  the crate walk keyed the files it had seen by (file, module path), so
+  `#[cfg(feature = "x")] mod api { include!("frag.rs"); }` beside
+  `#[cfg(not(feature = "x"))] mod api { include!("frag.rs"); }` scanned the
+  fragment once and recorded its items under whichever predicate the walk
+  reached last — the *off* branch for a build that enables the feature, so
+  the binding was dropped while the library exported the symbol. The key is
+  now the file and its full position (module path, `#[cfg]`, reachability,
+  `#[julia] mod` chain), so a lenient scan reports both entries; one fragment
+  included twice at the same position is still one scan.
 - **A panic inside an `@irust` snippet is a catchable exception, not an abort**
   ([#346](https://github.com/AtelierArith/RustCall.jl/issues/346)). `@irust`
   hand-wrote a bare `#[no_mangle] pub extern "C"` entry point with no

--- a/deps/rustcall_core/src/cfg.rs
+++ b/deps/rustcall_core/src/cfg.rs
@@ -792,6 +792,51 @@ fn item_attrs(item: &Item) -> &[Attribute] {
     }
 }
 
+/// The conjuncts of a predicate string as [`predicate_string`] renders it: the
+/// arguments of a top-level `all(...)`, else the predicate itself.
+fn cfg_conjuncts(p: &str) -> Vec<&str> {
+    let Some(inner) = p.strip_prefix("all(").and_then(|r| r.strip_suffix(')')) else {
+        return vec![p];
+    };
+    let mut out = Vec::new();
+    let (mut depth, mut start) = (0usize, 0usize);
+    for (i, ch) in inner.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                out.push(inner[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    out.push(inner[start..].trim());
+    out
+}
+
+/// Whether two predicate strings are **provably** mutually exclusive: one
+/// conjunct of the first is the exact negation of one conjunct of the second.
+///
+/// That is the shape of cfg-exclusive copies of one fragment — `feature = "x"`
+/// against `not(feature = "x")`, or `all(feature = "x", feature = "y")`
+/// against `all(not(feature = "x"), feature = "y")` — and nothing else:
+/// `feature = "x"` and `feature = "y"` may both be on and are *not* exclusive,
+/// and neither is anything against the empty predicate. Two items whose
+/// symbols coincide clash unless this says otherwise, on the `#[julia]` side
+/// (`CrateScan::claim`, `Manifest::duplicate_symbols`) and on the PyO3 side
+/// (`mark_symbol_collisions`) alike (#357 review).
+pub fn cfg_exclusive(a: &str, b: &str) -> bool {
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    let (ca, cb) = (cfg_conjuncts(a), cfg_conjuncts(b));
+    ca.iter().any(|x| {
+        cb.iter()
+            .any(|y| format!("not({x})") == *y || format!("not({y})") == *x)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -1008,9 +1008,9 @@ impl CrateScan {
     /// `cfg` is the block's *enclosing* predicate, not its effective one — a
     /// block that adds `#[cfg(feature = "y")]` of its own still sits beside
     /// exactly one copy, and its own predicate is carried by its methods.
-    /// A block written *outside* every copy — an unconditional
-    /// `#[julia] impl api::Gauge` at the crate root, empty `cfg` — applies to
-    /// whichever copy rustc compiles, so it attaches to every one.
+    /// A block written *outside* every copy — at the crate root, or in a
+    /// module gated on something else — applies to whichever copy rustc
+    /// compiles, so it attaches to every copy its predicate can coexist with.
     fn cfg_variants_for(&self, index: usize, cfg: &[syn::Attribute]) -> Vec<usize> {
         let want = predicate_string(cfg);
         let here = &self.structs[index];
@@ -1025,17 +1025,24 @@ impl CrateScan {
         {
             return vec![exact];
         }
-        if want.is_empty() {
-            let all: Vec<usize> = self
-                .structs
-                .iter()
-                .enumerate()
-                .filter(|(_, s)| same(s))
-                .map(|(i, _)| i)
-                .collect();
-            if !all.is_empty() {
-                return all;
-            }
+        // No copy sits under exactly this predicate: the block was written
+        // outside them all — at the crate root, or in a module gated on
+        // something else (`#[cfg(feature = "y")] mod ops { impl
+        // crate::api::Gauge }`). rustc applies it to whichever copy it
+        // compiles, so it attaches to every copy whose predicate can hold
+        // together with the block's; only a copy *provably* exclusive with it
+        // is left out (#357 review).
+        let overlapping: Vec<usize> = self
+            .structs
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| {
+                same(s) && !crate::pyo3::cfg_exclusive(&predicate_string(&s.cfg), &want)
+            })
+            .map(|(i, _)| i)
+            .collect();
+        if !overlapping.is_empty() {
+            return overlapping;
         }
         vec![index]
     }

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -980,14 +980,15 @@ impl CrateScan {
             // scanned since #357. `locate` sees one name and lands on the
             // first; the block belongs to the variant under its own predicate,
             // or the other one ends up without the method (#357 review).
-            let index = self.cfg_variant_for(index, &imp.enclosing_cfg);
-            self.check_symbol_path(imp, index)?;
-            self.structs[index].model.attach_impl(
-                &imp.item,
-                Mode::Crate,
-                &imp.cfg,
-                Some(&imp.header.module_path),
-            );
+            for index in self.cfg_variants_for(index, &imp.enclosing_cfg) {
+                self.check_symbol_path(imp, index)?;
+                self.structs[index].model.attach_impl(
+                    &imp.item,
+                    Mode::Crate,
+                    &imp.cfg,
+                    Some(&imp.header.module_path),
+                );
+            }
         }
 
         for scanned in std::mem::take(&mut self.structs) {
@@ -1000,27 +1001,43 @@ impl CrateScan {
         Ok(())
     }
 
-    /// The `#[julia]` struct at `index`, or the same-named struct at the same
+    /// The `#[julia]` structs at `index` — or the same-named struct at the same
     /// module path whose enclosing `#[cfg]` is `cfg` when there is one:
     /// cfg-exclusive copies of one declaration are distinct structs to the
     /// scan, and an impl block written beside one copy attaches to that copy.
     /// `cfg` is the block's *enclosing* predicate, not its effective one — a
     /// block that adds `#[cfg(feature = "y")]` of its own still sits beside
     /// exactly one copy, and its own predicate is carried by its methods.
-    fn cfg_variant_for(&self, index: usize, cfg: &[syn::Attribute]) -> usize {
+    /// A block written *outside* every copy — an unconditional
+    /// `#[julia] impl api::Gauge` at the crate root, empty `cfg` — applies to
+    /// whichever copy rustc compiles, so it attaches to every one.
+    fn cfg_variants_for(&self, index: usize, cfg: &[syn::Attribute]) -> Vec<usize> {
         let want = predicate_string(cfg);
         let here = &self.structs[index];
+        let same = |s: &ScannedStruct| s.name == here.name && s.module_path == here.module_path;
         if predicate_string(&here.cfg) == want {
-            return index;
+            return vec![index];
         }
-        self.structs
+        if let Some(exact) = self
+            .structs
             .iter()
-            .position(|s| {
-                s.name == here.name
-                    && s.module_path == here.module_path
-                    && predicate_string(&s.cfg) == want
-            })
-            .unwrap_or(index)
+            .position(|s| same(s) && predicate_string(&s.cfg) == want)
+        {
+            return vec![exact];
+        }
+        if want.is_empty() {
+            let all: Vec<usize> = self
+                .structs
+                .iter()
+                .enumerate()
+                .filter(|(_, s)| same(s))
+                .map(|(i, _)| i)
+                .collect();
+            if !all.is_empty() {
+                return all;
+            }
+        }
+        vec![index]
     }
 
     fn unresolved_impl(&self, imp: &ScannedImpl, why: Unresolved) -> ExtractError {

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -968,6 +968,13 @@ impl CrateScan {
                 },
                 Err(why) => return Err(self.unresolved_impl(imp, why)),
             };
+            // Two `#[julia]` structs of one name at one module path are cfg
+            // variants of each other — a fragment included under
+            // `#[cfg(feature = "x")]` and `#[cfg(not(feature = "x"))]`, both
+            // scanned since #357. `locate` sees one name and lands on the
+            // first; the block belongs to the variant under its own predicate,
+            // or the other one ends up without the method (#357 review).
+            let index = self.cfg_variant_for(index, &imp.cfg);
             self.check_symbol_path(imp, index)?;
             self.structs[index].model.attach_impl(
                 &imp.item,
@@ -985,6 +992,26 @@ impl CrateScan {
             manifest.structs.push(entry);
         }
         Ok(())
+    }
+
+    /// The `#[julia]` struct at `index`, or the same-named struct at the same
+    /// module path whose `#[cfg]` is `cfg` when there is one: cfg-exclusive
+    /// copies of one declaration are distinct structs to the scan, and an
+    /// impl block written under one predicate attaches to that copy.
+    fn cfg_variant_for(&self, index: usize, cfg: &[syn::Attribute]) -> usize {
+        let want = predicate_string(cfg);
+        let here = &self.structs[index];
+        if predicate_string(&here.cfg) == want {
+            return index;
+        }
+        self.structs
+            .iter()
+            .position(|s| {
+                s.name == here.name
+                    && s.module_path == here.module_path
+                    && predicate_string(&s.cfg) == want
+            })
+            .unwrap_or(index)
     }
 
     fn unresolved_impl(&self, imp: &ScannedImpl, why: Unresolved) -> ExtractError {

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -652,6 +652,11 @@ struct ScannedImpl {
     /// block may sit in a gated module far from its struct, and its methods
     /// exist only under that predicate (#300 review).
     cfg: Vec<syn::Attribute>,
+    /// The `#[cfg]` of the enclosing modules alone — the block's own
+    /// predicate left out. This is the provenance a block shares with the
+    /// struct copy it was written beside, and what tells cfg-exclusive copies
+    /// of one fragment apart (#357 review).
+    enclosing_cfg: Vec<syn::Attribute>,
     line: usize,
     file: String,
 }
@@ -805,6 +810,7 @@ impl CrateScan {
                         header,
                         symbol_path: symbol_path.to_vec(),
                         cfg: crate::cfg::effective_cfg_attrs(enclosing_cfg, &imp.attrs),
+                        enclosing_cfg: enclosing_cfg.to_vec(),
                         line: imp.span().start().line,
                         file: file.to_string(),
                     });
@@ -974,7 +980,7 @@ impl CrateScan {
             // scanned since #357. `locate` sees one name and lands on the
             // first; the block belongs to the variant under its own predicate,
             // or the other one ends up without the method (#357 review).
-            let index = self.cfg_variant_for(index, &imp.cfg);
+            let index = self.cfg_variant_for(index, &imp.enclosing_cfg);
             self.check_symbol_path(imp, index)?;
             self.structs[index].model.attach_impl(
                 &imp.item,
@@ -995,9 +1001,12 @@ impl CrateScan {
     }
 
     /// The `#[julia]` struct at `index`, or the same-named struct at the same
-    /// module path whose `#[cfg]` is `cfg` when there is one: cfg-exclusive
-    /// copies of one declaration are distinct structs to the scan, and an
-    /// impl block written under one predicate attaches to that copy.
+    /// module path whose enclosing `#[cfg]` is `cfg` when there is one:
+    /// cfg-exclusive copies of one declaration are distinct structs to the
+    /// scan, and an impl block written beside one copy attaches to that copy.
+    /// `cfg` is the block's *enclosing* predicate, not its effective one — a
+    /// block that adds `#[cfg(feature = "y")]` of its own still sits beside
+    /// exactly one copy, and its own predicate is carried by its methods.
     fn cfg_variant_for(&self, index: usize, cfg: &[syn::Attribute]) -> usize {
         let want = predicate_string(cfg);
         let here = &self.structs[index];

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -501,45 +501,7 @@ fn mark_julia_surface_collisions(manifest: &mut Manifest) {
 ///
 /// The first entry in manifest order keeps the symbol so the outcome does not
 /// depend on which file was visited first.
-/// The conjuncts of a predicate string: the arguments of a top-level
-/// `all(...)`, else the predicate itself.
-fn cfg_conjuncts(p: &str) -> Vec<&str> {
-    let Some(inner) = p.strip_prefix("all(").and_then(|r| r.strip_suffix(')')) else {
-        return vec![p];
-    };
-    let mut out = Vec::new();
-    let (mut depth, mut start) = (0usize, 0usize);
-    for (i, ch) in inner.char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                out.push(inner[start..i].trim());
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    out.push(inner[start..].trim());
-    out
-}
-
-/// Whether two predicates are **provably** mutually exclusive: one conjunct
-/// of the first is the exact negation of one conjunct of the second. That is
-/// the shape of cfg-exclusive copies of one fragment (`feature = "x"` against
-/// `not(feature = "x")`, or `all(feature = "x", feature = "y")` against
-/// `all(not(feature = "x"), feature = "y")`), and nothing else: `feature = "x"`
-/// and `feature = "y"` may both be on, and are *not* exclusive (#357 review).
-pub(crate) fn cfg_exclusive(a: &str, b: &str) -> bool {
-    if a.is_empty() || b.is_empty() {
-        return false;
-    }
-    let (ca, cb) = (cfg_conjuncts(a), cfg_conjuncts(b));
-    ca.iter().any(|x| {
-        cb.iter()
-            .any(|y| format!("not({x})") == *y || format!("not({y})") == *x)
-    })
-}
+pub(crate) use crate::cfg::cfg_exclusive;
 
 /// Whether two items whose symbols coincide really clash: they do unless their
 /// predicates are provably exclusive — copies rustc never compiles together.

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -135,6 +135,43 @@ struct ScannedImpl {
     enclosing_cfg: Vec<syn::Attribute>,
 }
 
+/// The classes a `#[pymethods]` block resolved to `index` attaches to, among
+/// the cfg-exclusive copies of that class at that module path: the copy whose
+/// enclosing `#[cfg]` is `enclosing` when there is one; every copy when the
+/// block is unconditional (empty `enclosing`) — it applies to whichever copy
+/// rustc compiles; else the located one (#357 review).
+fn cfg_variants_of(
+    classes: &[ScannedClass],
+    index: usize,
+    enclosing: &[syn::Attribute],
+) -> Vec<usize> {
+    let want = crate::cfg::predicate_string(enclosing);
+    let here = &classes[index];
+    let same =
+        |c: &ScannedClass| c.entry.name == here.entry.name && c.module_path == here.module_path;
+    if crate::cfg::predicate_string(&here.cfg) == want {
+        return vec![index];
+    }
+    if let Some(exact) = classes
+        .iter()
+        .position(|c| same(c) && crate::cfg::predicate_string(&c.cfg) == want)
+    {
+        return vec![exact];
+    }
+    if want.is_empty() {
+        let all: Vec<usize> = classes
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| same(c))
+            .map(|(i, _)| i)
+            .collect();
+        if !all.is_empty() {
+            return all;
+        }
+    }
+    vec![index]
+}
+
 impl Located for ScannedClass {
     fn name(&self) -> &str {
         &self.entry.name
@@ -328,32 +365,22 @@ impl Pyo3Scan {
                 continue;
             };
             // Cfg-exclusive copies of one class: the block written beside one
-            // copy belongs to that copy, not to the first `locate` saw (#357
-            // review). Same rule as `CrateScan::cfg_variant_for`.
-            let index = {
-                let want = crate::cfg::predicate_string(&imp.enclosing_cfg);
-                let here = &self.classes[index];
-                if crate::cfg::predicate_string(&here.cfg) == want {
-                    index
-                } else {
-                    self.classes
-                        .iter()
-                        .position(|c| {
-                            c.entry.name == here.entry.name
-                                && c.module_path == here.module_path
-                                && crate::cfg::predicate_string(&c.cfg) == want
-                        })
-                        .unwrap_or(index)
+            // copy belongs to that copy, not to the first `locate` saw; a block
+            // written *outside* both — an unconditional `impl api::Gauge` at
+            // the root — applies to whichever copy rustc compiles, so it
+            // attaches to every one (#357 review). Same rule as
+            // `CrateScan::cfg_variants_for`.
+            let targets = cfg_variants_of(&self.classes, index, &imp.enclosing_cfg);
+            for index in targets {
+                let owner_skip = self.classes[index].entry.skip_reason.clone();
+                // The symbol is the *class's*: an `impl a::C` written elsewhere
+                // still wraps `a::C`'s methods (#300).
+                let class_path = self.classes[index].module_path.clone();
+                for func in &imp.funcs {
+                    let entry =
+                        method_entry(&imp.header.target, &class_path, func, &owner_skip, &imp.cfg);
+                    self.classes[index].entry.methods.push(entry);
                 }
-            };
-            let owner_skip = self.classes[index].entry.skip_reason.clone();
-            // The symbol is the *class's*: an `impl a::C` written elsewhere
-            // still wraps `a::C`'s methods (#300).
-            let class_path = self.classes[index].module_path.clone();
-            for func in &imp.funcs {
-                let entry =
-                    method_entry(&imp.header.target, &class_path, func, &owner_skip, &imp.cfg);
-                self.classes[index].entry.methods.push(entry);
             }
         }
 
@@ -394,9 +421,12 @@ fn mark_julia_surface_collisions(manifest: &mut Manifest) {
     // below carries the module path: `a::parse` and `b::parse` live in
     // `bindings.a` and `bindings.b` and never meet.
     // (module path, name) -> qualified owner; (module path, name, arity) -> owner.
+    // Every key also carries the claimant's `#[cfg]`: cfg-exclusive copies of
+    // one fragment name the same things and rustc never compiles them
+    // together, so they do not take the name from each other (#357 review).
     type Scoped = (Vec<String>, String);
     type ScopedArity = (Vec<String>, String, usize);
-    let class_names: Vec<(Scoped, String)> = manifest
+    let class_names: Vec<(Scoped, String, String)> = manifest
         .structs
         .iter()
         .filter(|s| s.attribute.is_pyo3_scan() && s.skip_reason.is_empty())
@@ -404,27 +434,29 @@ fn mark_julia_surface_collisions(manifest: &mut Manifest) {
             (
                 (s.module_path.clone(), s.name.clone()),
                 qualified(&s.module_path, &s.name),
+                s.cfg.clone(),
             )
         })
         .collect();
-    let class_named = |path: &[String], name: &str| {
+    let class_named = |path: &[String], name: &str, cfg: &str| {
         class_names
             .iter()
-            .find(|((p, n), _)| p == path && n == name)
+            .find(|((p, n), _, c)| p == path && n == name && cfg_clash(c, cfg))
     };
 
-    let mut taken: Vec<(ScopedArity, String)> = Vec::new();
+    let mut taken: Vec<(ScopedArity, String, String)> = Vec::new();
     for f in &mut manifest.functions {
         if !f.attribute.is_pyo3_scan() || !f.skip_reason.is_empty() {
             continue;
         }
-        if let Some((_, class)) = class_named(&f.module_path, &f.name) {
+        if let Some((_, class, _)) = class_named(&f.module_path, &f.name, &f.cfg) {
             f.skip_reason = skip_reason::detailed(skip_reason::JULIA_NAME_COLLISION, class);
             continue;
         }
         taken.push((
             (f.module_path.clone(), f.name.clone(), f.args.len()),
             qualified(&f.module_path, &f.name),
+            f.cfg.clone(),
         ));
     }
     for s in &mut manifest.structs {
@@ -432,20 +464,24 @@ fn mark_julia_surface_collisions(manifest: &mut Manifest) {
             continue;
         }
         let owner = qualified(&s.module_path, &s.name);
+        let s_cfg = s.cfg.clone();
         for m in &mut s.methods {
             if !m.skip_reason.is_empty() || !m.is_static || m.is_constructor {
                 continue;
             }
-            if let Some((_, class)) = class_named(&s.module_path, &m.name) {
+            if let Some((_, class, _)) = class_named(&s.module_path, &m.name, &s_cfg) {
                 m.skip_reason = skip_reason::detailed(skip_reason::JULIA_NAME_COLLISION, class);
                 continue;
             }
             let key = (s.module_path.clone(), m.name.clone(), m.args.len());
-            match taken.iter().find(|(k, _)| *k == key) {
-                Some((_, other)) => {
+            match taken
+                .iter()
+                .find(|(k, _, c)| *k == key && cfg_clash(c, &s_cfg))
+            {
+                Some((_, other, _)) => {
                     m.skip_reason = skip_reason::detailed(skip_reason::JULIA_NAME_COLLISION, other);
                 }
-                None => taken.push((key, format!("{owner}::{}", m.name))),
+                None => taken.push((key, format!("{owner}::{}", m.name), s_cfg.clone())),
             }
         }
     }
@@ -463,12 +499,51 @@ fn mark_julia_surface_collisions(manifest: &mut Manifest) {
 ///
 /// The first entry in manifest order keeps the symbol so the outcome does not
 /// depend on which file was visited first.
-/// Whether two items whose symbols coincide really clash: they do unless both
-/// are gated and gated *differently* — cfg-exclusive copies of one fragment
-/// under a lenient scan, which rustc never compiles together. The same
-/// exemption `claimed_symbols` applies on the `#[julia]` side (#357 review).
+/// The conjuncts of a predicate string: the arguments of a top-level
+/// `all(...)`, else the predicate itself.
+fn cfg_conjuncts(p: &str) -> Vec<&str> {
+    let Some(inner) = p.strip_prefix("all(").and_then(|r| r.strip_suffix(')')) else {
+        return vec![p];
+    };
+    let mut out = Vec::new();
+    let (mut depth, mut start) = (0usize, 0usize);
+    for (i, ch) in inner.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                out.push(inner[start..i].trim());
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    out.push(inner[start..].trim());
+    out
+}
+
+/// Whether two predicates are **provably** mutually exclusive: one conjunct
+/// of the first is the exact negation of one conjunct of the second. That is
+/// the shape of cfg-exclusive copies of one fragment (`feature = "x"` against
+/// `not(feature = "x")`, or `all(feature = "x", feature = "y")` against
+/// `all(not(feature = "x"), feature = "y")`), and nothing else: `feature = "x"`
+/// and `feature = "y"` may both be on, and are *not* exclusive (#357 review).
+pub(crate) fn cfg_exclusive(a: &str, b: &str) -> bool {
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    let (ca, cb) = (cfg_conjuncts(a), cfg_conjuncts(b));
+    ca.iter().any(|x| {
+        cb.iter()
+            .any(|y| format!("not({x})") == *y || format!("not({y})") == *x)
+    })
+}
+
+/// Whether two items whose symbols coincide really clash: they do unless their
+/// predicates are provably exclusive — copies rustc never compiles together.
+/// The same exemption `claimed_symbols` applies on the `#[julia]` side.
 fn cfg_clash(a: &str, b: &str) -> bool {
-    a.is_empty() || b.is_empty() || a == b
+    !cfg_exclusive(a, b)
 }
 
 fn mark_symbol_collisions(manifest: &mut Manifest) {

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -137,9 +137,10 @@ struct ScannedImpl {
 
 /// The classes a `#[pymethods]` block resolved to `index` attaches to, among
 /// the cfg-exclusive copies of that class at that module path: the copy whose
-/// enclosing `#[cfg]` is `enclosing` when there is one; every copy when the
-/// block is unconditional (empty `enclosing`) — it applies to whichever copy
-/// rustc compiles; else the located one (#357 review).
+/// enclosing `#[cfg]` is `enclosing` when there is one; else every copy whose
+/// predicate can coexist with `enclosing` — a block written outside the
+/// copies applies to whichever one rustc compiles; else the located one
+/// (#357 review).
 fn cfg_variants_of(
     classes: &[ScannedClass],
     index: usize,
@@ -158,16 +159,17 @@ fn cfg_variants_of(
     {
         return vec![exact];
     }
-    if want.is_empty() {
-        let all: Vec<usize> = classes
-            .iter()
-            .enumerate()
-            .filter(|(_, c)| same(c))
-            .map(|(i, _)| i)
-            .collect();
-        if !all.is_empty() {
-            return all;
-        }
+    // Written outside every copy — at the root, or in a module gated on
+    // something else: every copy whose predicate can hold together with the
+    // block's, i.e. all but the provably exclusive ones (#357 review).
+    let overlapping: Vec<usize> = classes
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| same(c) && !cfg_exclusive(&crate::cfg::predicate_string(&c.cfg), &want))
+        .map(|(i, _)| i)
+        .collect();
+    if !overlapping.is_empty() {
+        return overlapping;
     }
     vec![index]
 }

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -112,6 +112,10 @@ pub struct Pyo3Scan {
 struct ScannedClass {
     module_path: Vec<String>,
     entry: Struct,
+    /// The `#[cfg]` of the enclosing modules: what tells cfg-exclusive copies
+    /// of one fragment apart, and what a `#[pymethods]` block written beside
+    /// one copy shares with it (#357 review).
+    cfg: Vec<syn::Attribute>,
 }
 
 #[derive(Debug)]
@@ -127,6 +131,8 @@ struct ScannedImpl {
     /// `#[pymethods]` block may sit in a gated module far from its class, and
     /// its methods exist only under that predicate (#300 review).
     cfg: Vec<syn::Attribute>,
+    /// The enclosing modules' `#[cfg]` alone; see [`ScannedClass::cfg`].
+    enclosing_cfg: Vec<syn::Attribute>,
 }
 
 impl Located for ScannedClass {
@@ -228,6 +234,7 @@ impl Pyo3Scan {
                         self.classes.push(ScannedClass {
                             module_path: module_path.clone(),
                             entry: class_entry(s, reachable, module_path, enclosing_cfg),
+                            cfg: enclosing_cfg.to_vec(),
                         });
                     }
                 }
@@ -242,6 +249,7 @@ impl Pyo3Scan {
                         header,
                         line: imp.span().start().line,
                         cfg: crate::cfg::effective_cfg_attrs(enclosing_cfg, &imp.attrs),
+                        enclosing_cfg: enclosing_cfg.to_vec(),
                         funcs: imp
                             .items
                             .iter()
@@ -318,6 +326,25 @@ impl Pyo3Scan {
             // `Struct::method` would not compile in Phase 2.
             let Ok(index) = locate(&self.classes, &imp.header, &self.imports) else {
                 continue;
+            };
+            // Cfg-exclusive copies of one class: the block written beside one
+            // copy belongs to that copy, not to the first `locate` saw (#357
+            // review). Same rule as `CrateScan::cfg_variant_for`.
+            let index = {
+                let want = crate::cfg::predicate_string(&imp.enclosing_cfg);
+                let here = &self.classes[index];
+                if crate::cfg::predicate_string(&here.cfg) == want {
+                    index
+                } else {
+                    self.classes
+                        .iter()
+                        .position(|c| {
+                            c.entry.name == here.entry.name
+                                && c.module_path == here.module_path
+                                && crate::cfg::predicate_string(&c.cfg) == want
+                        })
+                        .unwrap_or(index)
+                }
             };
             let owner_skip = self.classes[index].entry.skip_reason.clone();
             // The symbol is the *class's*: an `impl a::C` written elsewhere
@@ -436,6 +463,14 @@ fn mark_julia_surface_collisions(manifest: &mut Manifest) {
 ///
 /// The first entry in manifest order keeps the symbol so the outcome does not
 /// depend on which file was visited first.
+/// Whether two items whose symbols coincide really clash: they do unless both
+/// are gated and gated *differently* — cfg-exclusive copies of one fragment
+/// under a lenient scan, which rustc never compiles together. The same
+/// exemption `claimed_symbols` applies on the `#[julia]` side (#357 review).
+fn cfg_clash(a: &str, b: &str) -> bool {
+    a.is_empty() || b.is_empty() || a == b
+}
+
 fn mark_symbol_collisions(manifest: &mut Manifest) {
     // One table for every exported symbol of the whole manifest, whatever
     // produces it: a `#[julia]` function's wrapper, a `#[julia]` struct's
@@ -443,7 +478,7 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
     // They all live in one `cdylib`, so `rustcall_C_f` from a `#[julia]`
     // `impl C { fn f }` and from a `#[pyclass] C` with `#[pymethods] fn f`
     // are the same symbol even though nothing else about them matches.
-    let mut taken: Vec<(String, String)> = Vec::new();
+    let mut taken: Vec<(String, String, String)> = Vec::new();
 
     // Items already exported by a RustCall attribute own their symbols
     // outright: a PyO3 entry that wants one is the loser whatever the order.
@@ -454,11 +489,11 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
     {
         if f.exported && !f.symbol.is_empty() {
             for symbol in wrapper_symbols(&f.symbol) {
-                taken.push((symbol, qualified(&f.module_path, &f.name)));
+                taken.push((symbol, qualified(&f.module_path, &f.name), f.cfg.clone()));
             }
             if declares_string_helpers(&f.return_type, &f.ok_type, &f.err_type, &f.inner_type) {
                 for symbol in string_helper_symbols(&f.ffi_name) {
-                    taken.push((symbol, qualified(&f.module_path, &f.name)));
+                    taken.push((symbol, qualified(&f.module_path, &f.name), f.cfg.clone()));
                 }
             }
         }
@@ -469,7 +504,7 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
         .filter(|s| !s.attribute.is_pyo3_scan())
     {
         for symbol in struct_symbols(s) {
-            taken.push((symbol, qualified(&s.module_path, &s.name)));
+            taken.push((symbol, qualified(&s.module_path, &s.name), s.cfg.clone()));
         }
     }
 
@@ -491,14 +526,18 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
         if declares_string_helpers(&f.return_type, &f.ok_type, &f.err_type, &f.inner_type) {
             symbols.extend(string_helper_symbols(&f.ffi_name));
         }
-        if let Some((_, owner)) = taken.iter().find(|(s, _)| symbols.contains(s)) {
+        let f_cfg = f.cfg.clone();
+        if let Some((_, owner, _)) = taken
+            .iter()
+            .find(|(s, _, c)| symbols.contains(s) && cfg_clash(c, &f_cfg))
+        {
             let owner = owner.clone();
             manifest.functions[i].skip_reason =
                 skip_reason::detailed(skip_reason::SYMBOL_COLLISION, &owner);
         } else {
             let owner = qualified(&f.module_path, &f.name);
             for symbol in symbols {
-                taken.push((symbol, owner.clone()));
+                taken.push((symbol, owner.clone(), f_cfg.clone()));
             }
         }
     }
@@ -510,11 +549,17 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
     // with a free function, or between a class's own method and one of its
     // field accessors — is reported on the individual entry, which leaves the
     // rest of the class wrappable.
-    let mut class_names: Vec<(String, String)> = manifest
+    let mut class_names: Vec<(String, String, String)> = manifest
         .structs
         .iter()
         .filter(|s| !s.attribute.is_pyo3_scan())
-        .map(|s| (s.ffi_name.clone(), qualified(&s.module_path, &s.name)))
+        .map(|s| {
+            (
+                s.ffi_name.clone(),
+                qualified(&s.module_path, &s.name),
+                s.cfg.clone(),
+            )
+        })
         .collect();
 
     let mut struct_order: Vec<usize> = (0..manifest.structs.len()).collect();
@@ -531,8 +576,12 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
             continue;
         }
         let name = s.ffi_name.clone();
+        let s_cfg = s.cfg.clone();
 
-        if let Some((_, owner)) = class_names.iter().find(|(n, _)| *n == name) {
+        if let Some((_, owner, _)) = class_names
+            .iter()
+            .find(|(n, _, c)| *n == name && cfg_clash(c, &s_cfg))
+        {
             let reason = skip_reason::detailed(skip_reason::SYMBOL_COLLISION, &owner.clone());
             let s = &mut manifest.structs[i];
             s.skip_reason = reason.clone();
@@ -564,13 +613,16 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
             if declares_string_helpers(&m.return_type, &m.ok_type, &m.err_type, &m.inner_type) {
                 symbols.extend(string_helper_symbols(&format!("{}_{}", class_name, m.name)));
             }
-            match taken.iter().find(|(t, _)| symbols.contains(t)) {
-                Some((_, other)) => {
+            match taken
+                .iter()
+                .find(|(t, _, c)| symbols.contains(t) && cfg_clash(c, &s_cfg))
+            {
+                Some((_, other, _)) => {
                     m.skip_reason = skip_reason::detailed(skip_reason::SYMBOL_COLLISION, other);
                 }
                 None => {
                     for symbol in symbols {
-                        taken.push((symbol, owner.clone()));
+                        taken.push((symbol, owner.clone(), s_cfg.clone()));
                     }
                 }
             }
@@ -588,7 +640,10 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
             .any(|f| !f.getter.is_empty() && is_string_spelling(&f.rust_type))
         {
             let helpers = string_helper_symbols(&class_name);
-            if taken.iter().any(|(t, _)| helpers.contains(t)) {
+            if taken
+                .iter()
+                .any(|(t, _, c)| helpers.contains(t) && cfg_clash(c, &s_cfg))
+            {
                 for f in &mut s.fields {
                     if is_string_spelling(&f.rust_type) {
                         f.ffi_compatible = false;
@@ -598,7 +653,7 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
                 }
             } else {
                 for symbol in helpers {
-                    taken.push((symbol, owner.clone()));
+                    taken.push((symbol, owner.clone(), s_cfg.clone()));
                 }
             }
         }
@@ -607,16 +662,19 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
                 if accessor.is_empty() {
                     continue;
                 }
-                match taken.iter().find(|(t, _)| t == accessor) {
+                match taken
+                    .iter()
+                    .find(|(t, _, c)| t == accessor && cfg_clash(c, &s_cfg))
+                {
                     Some(_) => accessor.clear(),
-                    None => taken.push((accessor.clone(), owner.clone())),
+                    None => taken.push((accessor.clone(), owner.clone(), s_cfg.clone())),
                 }
             }
             if f.getter.is_empty() && f.setter.is_empty() {
                 f.ffi_compatible = false;
             }
         }
-        class_names.push((name, owner));
+        class_names.push((name, owner, s_cfg));
     }
 }
 

--- a/deps/rustcall_extract/src/main.rs
+++ b/deps/rustcall_extract/src/main.rs
@@ -191,6 +191,7 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
                     dir: f.parent().unwrap_or(Path::new(".")).to_path_buf(),
                     file: f.clone(),
                     position: rustcall_core::extract::FilePosition::module(&[], true, &[]),
+                    ancestry: Vec::new(),
                     follow_modules: false,
                     fragment: false,
                 })
@@ -215,6 +216,7 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
                 file,
                 dir,
                 position,
+                ancestry,
                 follow_modules,
                 fragment,
             }) = queue.pop()
@@ -244,7 +246,7 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
                         continue;
                     }
                 };
-                for next in pulled_in(&file, &dir, pending, follow_modules) {
+                for next in pulled_in(&file, &dir, pending, follow_modules, &ancestry) {
                     let canonical =
                         fs::canonicalize(&next.file).unwrap_or_else(|_| next.file.clone());
                     if listed.contains(&canonical) {
@@ -421,6 +423,13 @@ struct QueuedFile {
     /// file reached through an `include!`, because a listed file's modules are
     /// the caller's to list and a fragment's are not (#343 review).
     follow_modules: bool,
+    /// The fragments this file was reached through, innermost last. An
+    /// `include!` whose target is already on it is a cycle — `#[cfg(feature =
+    /// "optional")] include!("lib.rs")` in `lib.rs`, followed under a lenient
+    /// scan because the predicate is undecided — and is not followed again.
+    /// Ancestry, not a visited set: two *sibling* positions of one fragment
+    /// are both scanned, but a fragment never includes itself (#357 review).
+    ancestry: Vec<PathBuf>,
     /// An `include!`d fragment rather than a file of the module tree. A
     /// fragment need not be a list of items at all — `include!("table.rs")`
     /// holding `[1, 2, 3]` is an expression — so one that does not parse as a
@@ -448,8 +457,13 @@ fn pulled_in(
     dir: &Path,
     pending: rustcall_core::extract::PullIns,
     follow_modules: bool,
+    ancestry: &[PathBuf],
 ) -> Vec<QueuedFile> {
     let mut out = Vec::new();
+    // What everything below this file descends from: its own ancestry plus
+    // itself, so a fragment that includes its includer is caught too.
+    let mut lineage = ancestry.to_vec();
+    lineage.push(fs::canonicalize(file).unwrap_or_else(|_| file.to_path_buf()));
     if follow_modules {
         for m in pending.modules {
             let Some((child_file, child_dir)) = resolve_module_file(dir, &m) else {
@@ -469,6 +483,7 @@ fn pulled_in(
                     m.reachable,
                     &m.cfg,
                 ),
+                ancestry: lineage.clone(),
                 follow_modules: true,
                 fragment: false,
             });
@@ -486,10 +501,21 @@ fn pulled_in(
             );
             continue;
         }
+        let canonical = fs::canonicalize(&fragment).unwrap_or_else(|_| fragment.clone());
+        if lineage.contains(&canonical) {
+            eprintln!(
+                "rustcall-extract: `include!(\"{}\")` in {} includes a file it is part of; \
+                 skipping the cycle",
+                inc.path,
+                file.display()
+            );
+            continue;
+        }
         out.push(QueuedFile {
             dir: fragment.parent().unwrap_or(Path::new(".")).to_path_buf(),
             file: fragment,
             position: inc.position,
+            ancestry: lineage.clone(),
             follow_modules: true,
             fragment: true,
         });
@@ -519,6 +545,7 @@ fn scan_crate_tree(
         file: root.to_path_buf(),
         dir: root_dir,
         position: rustcall_core::extract::FilePosition::module(&[], true, &[]),
+        ancestry: Vec::new(),
         follow_modules: true,
         fragment: false,
     }];
@@ -539,6 +566,7 @@ fn scan_crate_tree(
         file,
         dir,
         position,
+        ancestry,
         follow_modules,
         fragment,
     }) = queue.pop()
@@ -564,7 +592,7 @@ fn scan_crate_tree(
             }
         };
 
-        queue.extend(pulled_in(&file, &dir, pending, follow_modules));
+        queue.extend(pulled_in(&file, &dir, pending, follow_modules, &ancestry));
     }
     // Structs and their impl blocks — `#[julia]` and PyO3 alike — may live in
     // different files, so the structs are only emitted once every file of the

--- a/deps/rustcall_extract/src/main.rs
+++ b/deps/rustcall_extract/src/main.rs
@@ -199,7 +199,7 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
             // fragment `include!`d under two different modules is compiled
             // twice by rustc and belongs in the manifest twice, under each
             // module's own path (#343 review).
-            let mut seen: Vec<(PathBuf, Vec<String>)> = Vec::new();
+            let mut seen: Vec<(PathBuf, rustcall_core::extract::FilePosition)> = Vec::new();
             // What the caller listed. A file it named is scanned as its own
             // root, and following a fragment into it as well would scan it
             // twice under two module paths — a `#[julia]` item would then
@@ -220,7 +220,7 @@ fn scan(opts: &ScanOptions) -> Result<Manifest, String> {
             }) = queue.pop()
             {
                 let canonical = fs::canonicalize(&file).unwrap_or_else(|_| file.clone());
-                let key = (canonical, position.module_path.clone());
+                let key = (canonical, position.clone());
                 if seen.contains(&key) {
                     continue;
                 }
@@ -522,12 +522,17 @@ fn scan_crate_tree(
         follow_modules: true,
         fragment: false,
     }];
-    // Keyed by (file, module path): `#[path = "shared.rs"] pub mod a;` and the
+    // Keyed by (file, **position**): `#[path = "shared.rs"] pub mod a;` and the
     // same for `b` compile one file as two distinct modules, and both belong in
     // the manifest — under their own module paths, and colliding with each
-    // other on the wrapper symbols. An `include!`d fragment is keyed the same
-    // way, under the module that includes it.
-    let mut visited: Vec<(PathBuf, Vec<String>)> = Vec::new();
+    // other on the wrapper symbols. The position, not only the module path:
+    // `#[cfg(feature = "x")] mod api { include!("frag.rs"); }` beside
+    // `#[cfg(not(feature = "x"))] mod api { include!("frag.rs"); }` is one file
+    // at one module path under two predicates, and a lenient scan must report
+    // both — keyed by module path alone the second was dropped and the item
+    // kept whichever predicate the walk reached last (#357). One fragment
+    // included twice at the *same* position is still one scan.
+    let mut visited: Vec<(PathBuf, rustcall_core::extract::FilePosition)> = Vec::new();
     let mut scan = rustcall_core::extract::TreeScan::new();
 
     while let Some(QueuedFile {
@@ -539,7 +544,7 @@ fn scan_crate_tree(
     }) = queue.pop()
     {
         let canonical = fs::canonicalize(&file).unwrap_or_else(|_| file.clone());
-        let key = (canonical, position.module_path.clone());
+        let key = (canonical, position.clone());
         if visited.contains(&key) {
             continue;
         }

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -750,6 +750,89 @@ end
                 @test [m["name"] for m in methods] == ["read"]
                 @test all(m -> m["skip_reason"] == "" && m["cfg"] == c["cfg"], methods)
             end
+            lenient() = RustCall.extract_manifest(String[]; mode = "crate", crate_root = lib,
+                                                  cfg = :lenient, cfg_text = RustCall._cargo_cfg_text())
+
+            # A `#[staticmethod]` is a module-level Julia function, and the
+            # Julia-surface check used to key it by (module, name, arity)
+            # alone — the second copy's was refused as a name collision with
+            # the first's (#357 review).
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[pyclass]
+                pub struct Gauge { pub value: i32 }
+                #[pymethods]
+                impl Gauge {
+                    #[staticmethod]
+                    pub fn zero() -> i32 { 0 }
+                }
+                """)
+            statics = filter(s -> s["name"] == "Gauge", lenient()["structs"])
+            @test length(statics) == 2
+            for c in statics
+                zs = filter(m -> m["name"] == "zero", get(c, "methods", Any[]))
+                @test length(zs) == 1 && zs[1]["skip_reason"] == ""
+            end
+
+            # Only *provably* exclusive predicates are exempt from collision:
+            # `feature = "x"` and `feature = "y"` may both be on, so two
+            # `#[pyfunction] run`s gated that way still clash on one symbol
+            # (#357 review).
+            write(lib, """
+                #[cfg(feature = "x")]
+                pub mod api { include!("frag.rs"); }
+                #[cfg(feature = "y")]
+                pub mod api { include!("frag.rs"); }
+                """)
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[pyfunction]
+                pub fn run() -> i32 { 1 }
+                """)
+            overlapping = filter(f -> f["name"] == "run", lenient()["functions"])
+            @test length(overlapping) == 2
+            @test count(f -> startswith(f["skip_reason"], "symbol_collision"), overlapping) == 1
+
+            # A block written *outside* both copies — an unconditional
+            # `impl api::Gauge` at the root — applies to whichever copy rustc
+            # compiles, so it attaches to every one, in both scans (#357
+            # review).
+            write(lib, """
+                use juliacall_macros::julia;
+                #[cfg(feature = "x")]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                #[cfg(not(feature = "x"))]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                #[julia]
+                impl api::Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }
+                """)
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[julia]
+                pub struct Gauge { pub value: i32 }
+                """)
+            external = filter(s -> s["name"] == "Gauge", lenient()["structs"])
+            @test length(external) == 2
+            @test all(g -> [m["name"] for m in get(g, "methods", Any[])] == ["read"], external)
+            write(lib, """
+                #[cfg(feature = "x")]
+                pub mod api { include!("frag.rs"); }
+                #[cfg(not(feature = "x"))]
+                pub mod api { include!("frag.rs"); }
+                #[pymethods]
+                impl api::Gauge { pub fn read(&self) -> i32 { self.value } }
+                """)
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[pyclass]
+                pub struct Gauge { pub value: i32 }
+                """)
+            external_py = filter(s -> s["name"] == "Gauge", lenient()["structs"])
+            @test length(external_py) == 2
+            @test all(external_py) do g
+                ms = get(g, "methods", Any[])
+                g["skip_reason"] == "" && [m["name"] for m in ms] == ["read"] &&
+                    all(m -> m["skip_reason"] == "", ms)
+            end
+
             write(lib, """
                 use juliacall_macros::julia;
                 #[cfg(feature = "x")]

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -833,6 +833,74 @@ end
                     all(m -> m["skip_reason"] == "", ms)
             end
 
+            # A block gated on something *else* (`feature = "y"`) is outside
+            # both copies too: with `y` on, rustc applies it to whichever
+            # `Gauge` the `x` state compiles, so it attaches to every copy its
+            # predicate can coexist with — in both scans (#357 review).
+            write(lib, """
+                use juliacall_macros::julia;
+                #[cfg(feature = "x")]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                #[cfg(not(feature = "x"))]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                #[cfg(feature = "y")]
+                mod ops {
+                    use juliacall_macros::julia;
+                    #[julia]
+                    impl crate::api::Gauge { #[julia] pub fn read(&self) -> i32 { self.value } }
+                }
+                """)
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[julia]
+                pub struct Gauge { pub value: i32 }
+                """)
+            gated = filter(s -> s["name"] == "Gauge", lenient()["structs"])
+            @test length(gated) == 2
+            @test all(g -> [m["name"] for m in get(g, "methods", Any[])] == ["read"], gated)
+            write(lib, """
+                #[cfg(feature = "x")]
+                pub mod api { include!("frag.rs"); }
+                #[cfg(not(feature = "x"))]
+                pub mod api { include!("frag.rs"); }
+                #[cfg(feature = "y")]
+                mod ops {
+                    #[pymethods]
+                    impl crate::api::Gauge { pub fn read(&self) -> i32 { self.value } }
+                }
+                """)
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[pyclass]
+                pub struct Gauge { pub value: i32 }
+                """)
+            gated_py = filter(s -> s["name"] == "Gauge", lenient()["structs"])
+            @test length(gated_py) == 2
+            @test all(g -> [m["name"] for m in get(g, "methods", Any[])] == ["read"], gated_py)
+
+            # A recursive `include!` behind an undecided feature is followed by
+            # a lenient scan; keying visited files by their full position let
+            # it grow the queue forever, since each pass added the predicate
+            # again. An include-ancestry guard stops the cycle and still lets
+            # two sibling positions of one fragment both be scanned (#357
+            # review). Bounded, so a regression fails instead of hanging.
+            write(lib, """
+                #[cfg(feature = "optional")]
+                include!("lib.rs");
+                #[pyfunction]
+                pub fn f() -> i32 { 1 }
+                """)
+            let cfg = RustCall._cfg_file_args(:lenient; cfg_text = RustCall._cargo_cfg_text()),
+                out = IOBuffer(),
+                proc = run(pipeline(`$(RustCall.extractor_path()) manifest --mode crate --skip-unparsable $cfg --crate-root $lib`;
+                                    stdout = out, stderr = devnull); wait = false)
+                finished = timedwait(() -> process_exited(proc), 120.0) === :ok
+                finished || kill(proc)
+                @test finished
+                @test finished && success(proc)
+                @test finished && occursin("name = \"f\"", String(take!(out)))
+            end
+
             write(lib, """
                 use juliacall_macros::julia;
                 #[cfg(feature = "x")]

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -642,3 +642,51 @@ end
         end
     end
 end
+
+# Two mutually exclusive `#[cfg]` modules of one name, each including the same
+# fragment, are one file at one module path under two predicates. The walk
+# keyed the files it had seen by (file, module path), so the second was
+# dropped and the surviving entry carried whichever predicate the walk reached
+# last — the *off* branch, for a build that enables the feature (#357).
+@testset "cfg-exclusive modules including one fragment are both scanned (#357)" begin
+    if !RustCall.check_rustc_available()
+        @warn "rustc not found, skipping the cfg-exclusive fragment test"
+    else
+        mktempdir() do dir
+            mkpath(joinpath(dir, "src"))
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[julia]
+                pub fn run() -> i32 { 1 }
+                """)
+            lib = joinpath(dir, "src", "lib.rs")
+            write(lib, """
+                use juliacall_macros::julia;
+                #[cfg(feature = "x")]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                #[cfg(not(feature = "x"))]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                """)
+            # A lenient scan, as `scan_crate` runs for an external crate: the
+            # host's cfg decides target predicates, feature predicates are
+            # left undecided and their items kept.
+            manifest = RustCall.extract_manifest(String[]; mode = "crate", crate_root = lib,
+                                                 cfg = :lenient, cfg_text = RustCall._cargo_cfg_text())
+            runs = filter(f -> f["name"] == "run", manifest["functions"])
+            @test length(runs) == 2
+            @test sort([f["cfg"] for f in runs]) == ["feature = \"x\"", "not(feature = \"x\")"]
+            @test all(f -> f["symbol"] == "rustcall_api__run", runs)
+
+            # One fragment included twice at the *same* position is still one
+            # scan — the duplicate-symbol case of #343.
+            write(lib, """
+                use juliacall_macros::julia;
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                """)
+            once = RustCall.extract_manifest(String[]; mode = "crate", crate_root = lib)
+            @test count(f -> f["name"] == "run", once["functions"]) == 1
+        end
+    end
+end

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -678,6 +678,34 @@ end
             @test sort([f["cfg"] for f in runs]) == ["feature = \"x\"", "not(feature = \"x\")"]
             @test all(f -> f["symbol"] == "rustcall_api__run", runs)
 
+            # A struct and its impl block inside the fragment: both copies are
+            # distinct structs to the scan, and the block written under one
+            # predicate attaches to that copy — not to whichever `locate` saw
+            # first, leaving the other without the method (#357 review).
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[julia]
+                pub struct Gauge { pub value: i32 }
+                #[julia]
+                impl Gauge {
+                    #[julia]
+                    pub fn read(&self) -> i32 { self.value }
+                }
+                """)
+            with_struct = RustCall.extract_manifest(String[]; mode = "crate", crate_root = lib,
+                                                    cfg = :lenient, cfg_text = RustCall._cargo_cfg_text())
+            gauges = filter(s -> s["name"] == "Gauge", with_struct["structs"])
+            @test length(gauges) == 2
+            @test sort([g["cfg"] for g in gauges]) == ["feature = \"x\"", "not(feature = \"x\")"]
+            for g in gauges
+                methods = get(g, "methods", Any[])
+                @test [m["name"] for m in methods] == ["read"]
+                @test all(m -> m["cfg"] == g["cfg"], methods)
+            end
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[julia]
+                pub fn run() -> i32 { 1 }
+                """)
+
             # One fragment included twice at the *same* position is still one
             # scan — the duplicate-symbol case of #343.
             write(lib, """

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -701,6 +701,64 @@ end
                 @test [m["name"] for m in methods] == ["read"]
                 @test all(m -> m["cfg"] == g["cfg"], methods)
             end
+            # A block that adds a predicate of its own still sits beside
+            # exactly one copy: the match is on the *enclosing* cfg, and the
+            # block's own predicate travels with its methods (#357 review).
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[julia]
+                pub struct Gauge { pub value: i32 }
+                #[cfg(feature = "y")]
+                #[julia]
+                impl Gauge {
+                    #[julia]
+                    pub fn read(&self) -> i32 { self.value }
+                }
+                """)
+            own_cfg = RustCall.extract_manifest(String[]; mode = "crate", crate_root = lib,
+                                                cfg = :lenient, cfg_text = RustCall._cargo_cfg_text())
+            gauges_y = filter(s -> s["name"] == "Gauge", own_cfg["structs"])
+            @test length(gauges_y) == 2
+            for g in gauges_y
+                methods = get(g, "methods", Any[])
+                @test [m["name"] for m in methods] == ["read"]
+                @test all(m -> occursin("feature = \"y\"", m["cfg"]) && occursin(g["cfg"], m["cfg"]),
+                          methods)
+            end
+
+            # The PyO3 scan follows the same rule, and cfg-exclusive copies of
+            # one class are not a symbol collision with each other — rustc
+            # never compiles them together (#357 review).
+            write(joinpath(dir, "src", "frag.rs"), """
+                #[pyclass]
+                pub struct Gauge { pub value: i32 }
+                #[pymethods]
+                impl Gauge { pub fn read(&self) -> i32 { self.value } }
+                """)
+            write(lib, """
+                #[cfg(feature = "x")]
+                pub mod api { include!("frag.rs"); }
+                #[cfg(not(feature = "x"))]
+                pub mod api { include!("frag.rs"); }
+                """)
+            py = RustCall.extract_manifest(String[]; mode = "crate", crate_root = lib,
+                                           cfg = :lenient, cfg_text = RustCall._cargo_cfg_text())
+            classes = filter(s -> s["name"] == "Gauge", py["structs"])
+            @test length(classes) == 2
+            @test all(c -> c["skip_reason"] == "", classes)
+            for c in classes
+                methods = get(c, "methods", Any[])
+                @test [m["name"] for m in methods] == ["read"]
+                @test all(m -> m["skip_reason"] == "" && m["cfg"] == c["cfg"], methods)
+            end
+            write(lib, """
+                use juliacall_macros::julia;
+                #[cfg(feature = "x")]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                #[cfg(not(feature = "x"))]
+                #[julia]
+                pub mod api { use juliacall_macros::julia; include!("frag.rs"); }
+                """)
             write(joinpath(dir, "src", "frag.rs"), """
                 #[julia]
                 pub fn run() -> i32 { 1 }


### PR DESCRIPTION
## Summary

Two mutually exclusive `#[cfg]` modules of one name, each including the same fragment, collapsed to a single manifest entry carrying whichever predicate the walk reached last — the *off* branch for a build that enables the feature. The binding was then dropped while the library exported the symbol. Found while writing the MWE for #356; it reaches the **crate-root walk**, the one RustCall uses, so it is a bug rather than a rootless-mode corner.

```rust
#[cfg(feature = "x")]      #[julia] pub mod api { include!("frag.rs"); }
#[cfg(not(feature = "x"))] #[julia] pub mod api { include!("frag.rs"); }
```

Before (lenient scan, `--crate-root`): one entry, `cfg = 'not(feature = "x")'`. After: two entries, one per predicate.

## Cause and fix

Since #343 the walk keyed visited files by `(canonical path, module_path)`; both branches queue `frag.rs` at `api`, so the second was dropped. Before #343 the `#[julia]` walk followed `include!` with no visited set, and both branches reached the manifest — a regression from that change. The key is now `(canonical path, FilePosition)` — module path, `#[cfg]`, reachability, `#[julia] mod` chain — in both walks. One fragment included twice at the *same* position is still one scan (the duplicate-symbol case #343 fixed).

## Acceptance

| criterion | test |
|---|---|
| the MWE yields two entries for `run`, one per predicate | `test/test_cross_module_impl.jl`, "cfg-exclusive modules including one fragment are both scanned (#357)" — through `extract_manifest` with `cfg = :lenient`, both `cfg` strings asserted |
| one fragment included twice at the same position is still one scan | same testset, second half |
| `#[path = "shared.rs"]` under two module paths still yields two entries | the position includes the module path, so the existing behaviour is unchanged; existing tests cover it |

Verified against the issue's CLI MWE with the built extractor. `cargo fmt` / `clippy -D warnings` / `cargo test` clean; all five `scripts/lint_*.sh`; full Julia suite green (9492 tests, 3 known broken).

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iJ1dZ7KEebWDjdY7fhPbw
