### PR TITLE
Contain generated helper panics and stress generic reloads

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           julia --threads=4 --check-bounds=yes --project test/test_state.jl
           julia --threads=4 --check-bounds=yes --project test/test_hot_reload_transaction.jl
+          julia --threads=4 --check-bounds=yes --project test/test_generic_reload.jl
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: ${{ matrix.threads }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,17 @@ A replaced image is **retired, not closed**, so a call already inside one stays 
 
 ## Testing
 
+Generated struct destructors use the shared Rust panic boundary. Constructor
+snapshots and generated objects capture the destructor's `free_channel` along
+with `free_ptr` and liveness from the same image. The finalizer calls free and
+then consumes that captured channel with `(out = C_NULL, cap = typemax(Csize_t))`
+before anything can yield, counting a failure without allocating a Julia
+message buffer. This reserved read discards the message; normal null/zero
+queries retain it for the usual message-reading path. Do not resolve a channel
+or take STATE inside a finalizer. `test_destructor_panics.jl` runs real panicking
+destructors in child processes, so a missing boundary fails instead of aborting
+the entire test worker.
+
 - Entry point: `test/runtests.jl` (includes 30+ test files)
 - Tests are organized by feature: ownership, arrays, generics, cargo, crate bindings, hot reload, etc.
 - `test/test_regressions.jl` holds regression tests for fixed issues

--- a/benchmark/benchmarks_cfg_probe.jl
+++ b/benchmark/benchmarks_cfg_probe.jl
@@ -1,0 +1,32 @@
+# Cost of always asking Cargo for current cfg (#291).
+# Run: julia --project benchmark/benchmarks_cfg_probe.jl
+# An isolated, dependency-free crate: not a prediction for large workspaces.
+using RustCall, Statistics
+
+mktempdir() do root
+    mkpath(joinpath(root, "src"))
+    write(joinpath(root, "Cargo.toml"), """
+        [package]
+        name = "cfg_probe_cost291"
+        version = "0.1.0"
+        edition = "2021"
+        """)
+    write(joinpath(root, "src", "lib.rs"), "pub fn value() -> i32 { 1 }\n")
+    write(joinpath(root, "build.rs"), raw"""
+        fn main() {
+            println!("cargo:rerun-if-changed=cfg.flag");
+            let flag = std::fs::read_to_string("cfg.flag").unwrap();
+            println!("cargo:rustc-cfg={}", flag.trim());
+        }
+        """)
+    write(joinpath(root, "cfg.flag"), "first_cfg")
+    cold = @elapsed result = RustCall._crate_build_cfg_text(root)
+    @assert occursin("first_cfg", result)
+    times = [@elapsed(RustCall._crate_build_cfg_text(root)) for _ in 1:10]
+    write(joinpath(root, "cfg.flag"), "second_cfg")
+    changed = @elapsed result = RustCall._crate_build_cfg_text(root)
+    @assert occursin("second_cfg", result) && !occursin("first_cfg", result)
+    println((cold_seconds=cold, warm_median_seconds=median(times),
+             warm_min_seconds=minimum(times), warm_max_seconds=maximum(times),
+             changed_seconds=changed, warm_samples=length(times)))
+end

--- a/deps/rustcall_core/src/codegen.rs
+++ b/deps/rustcall_core/src/codegen.rs
@@ -560,6 +560,13 @@ fn panic_channel(cfg_attrs: &[Attribute], slot: &Ident, reader: &Ident) -> Token
         pub extern "C" fn #reader(out: *mut u8, cap: usize) -> usize {
             #slot.with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                // Finalizers only need a failure count, not its text. This
+                // reserved request consumes the channel without allocating a
+                // Julia message buffer or leaving a stale panic for a later
+                // call. Ordinary null/zero length queries still retain it.
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -1395,15 +1402,40 @@ fn crate_field_accessors(
     ffi_functions
 }
 
-fn crate_free_fn(struct_name: &Ident, stem: &Ident, cfgs: &[Attribute]) -> TokenStream2 {
+pub(crate) fn struct_free_wrapper(
+    struct_type: &syn::Path,
+    stem: &Ident,
+    cfgs: &[Attribute],
+) -> TokenStream2 {
     let free_fn_name = format_ident!("{}_free", stem);
-    quote! {
-        #(#cfgs)*
-        #[no_mangle]
-        pub extern "C" fn #free_fn_name(ptr: *mut #struct_name) {
+    // Unlike case folding, byte encoding keeps distinct struct names such as
+    // `C` and `c` distinct in the private TLS namespace as well.
+    let slot_suffix: String = free_fn_name
+        .to_string()
+        .bytes()
+        .map(|byte| format!("{byte:02X}"))
+        .collect();
+    let slot = format_ident!("__RUSTCALL_DROP_PANIC_{}", slot_suffix);
+    let reader = format_ident!("{}", panic_symbol(&free_fn_name.to_string()));
+    let channel = panic_channel(cfgs, &slot, &reader);
+    let body = guarded_body(
+        &format!("{}::drop", path_tail(struct_type)),
+        &slot,
+        &quote! {},
+        quote! {
             if !ptr.is_null() {
                 unsafe { drop(Box::from_raw(ptr)); }
             }
+        },
+        quote! {},
+        true,
+    );
+    quote! {
+        #channel
+        #(#cfgs)*
+        #[no_mangle]
+        pub extern "C" fn #free_fn_name(ptr: *mut #struct_type) {
+            #body
         }
     }
 }
@@ -1422,7 +1454,8 @@ pub fn transform_struct_crate(mut item_struct: ItemStruct, module_path: &[String
     let stem = struct_stem(module_path, &item_struct.ident);
     // The struct's `#[cfg]` gates its helpers too (#300 review).
     let cfgs = cfg_attrs(&item_struct.attrs);
-    let free = crate_free_fn(&item_struct.ident, &stem, &cfgs);
+    let struct_name = &item_struct.ident;
+    let free = struct_free_wrapper(&syn::parse_quote!(#struct_name), &stem, &cfgs);
     let accessors = crate_field_accessors(&item_struct, &stem, &cfgs);
 
     quote! {
@@ -1778,15 +1811,11 @@ pub fn inline_struct_wrappers(
     let mut out = TokenStream2::new();
     let mut meta = InlineStructMeta::default();
 
-    let free_name = format_ident!("{}_free", stem);
-    out.extend(quote! {
-        #[no_mangle]
-        pub extern "C" fn #free_name(ptr: *mut #struct_name) {
-            if !ptr.is_null() {
-                unsafe { drop(Box::from_raw(ptr)); }
-            }
-        }
-    });
+    out.extend(struct_free_wrapper(
+        &syn::parse_quote!(#struct_name),
+        &stem,
+        &[],
+    ));
 
     let fields = model.named_fields();
     let accessible: Vec<&(Ident, Type)> = fields

--- a/deps/rustcall_core/src/codegen.rs
+++ b/deps/rustcall_core/src/codegen.rs
@@ -1326,11 +1326,43 @@ pub fn crate_struct_needs_owned_string_helper(item_struct: &ItemStruct) -> bool 
     })
 }
 
-/// `cfgs` is the struct's own `#[cfg]` set, copied onto every generated
-/// helper: inside a `#[julia] mod` the module macro expands a
-/// `#[cfg(feature = "x")] #[julia] pub struct C` before rustc evaluates the
-/// predicate, and a helper without it would refer to a struct that is gone
-/// when `x` is off (#300 review).
+/// Apply the common boundary to generated field/clone helpers. These helpers
+/// return only unit, primitives, raw pointers, owned-string buffers or Vec.
+/// In particular, Vec must use an empty vector, not an invalid zeroed value.
+pub(crate) fn guard_struct_helper(tokens: TokenStream2) -> TokenStream2 {
+    let mut function: ItemFn = syn::parse2(tokens).expect("generated struct helper is a function");
+    let symbol = &function.sig.ident;
+    let suffix: String = symbol
+        .to_string()
+        .bytes()
+        .map(|b| format!("{b:02X}"))
+        .collect();
+    let slot = format_ident!("__RUSTCALL_HELPER_PANIC_{}", suffix);
+    let reader = format_ident!("{}", panic_symbol(&symbol.to_string()));
+    let channel = panic_channel(&cfg_attrs(&function.attrs), &slot, &reader);
+    let (sentinel, unit) = match &function.sig.output {
+        ReturnType::Default => (quote! {}, true),
+        ReturnType::Type(_, ty) if matches!(unparen(ty), Type::Tuple(t) if t.elems.is_empty()) => {
+            (quote! {}, true)
+        }
+        ReturnType::Type(_, ty) if is_vec_type(ty) => (quote! { ::std::vec::Vec::new() }, false),
+        ReturnType::Type(_, ty) => (quote! { unsafe { ::std::mem::zeroed::<#ty>() } }, false),
+    };
+    let original = &function.block;
+    let body = guarded_body(
+        &symbol.to_string(),
+        &slot,
+        &quote! {},
+        quote! { #original },
+        sentinel,
+        unit,
+    );
+    function.block = syn::parse_quote!({ #body });
+    quote! { #channel #function }
+}
+
+/// Copy the struct's cfg onto every accessor and its channel, including when
+/// a module macro expands the struct before rustc evaluates the predicate.
 fn crate_field_accessors(
     item_struct: &ItemStruct,
     stem: &Ident,
@@ -1358,7 +1390,7 @@ fn crate_field_accessors(
                 // owned `(ptr, len, cap)` buffer the caller hands back to
                 // `<Struct>_free_rust_string`, exactly as the inline flavour
                 // and the string-returning method wrappers do (#246).
-                ffi_functions.extend(quote! {
+                ffi_functions.extend(guard_struct_helper(quote! {
                     #(#cfgs)*
                     #[no_mangle]
                     pub extern "C" fn #getter_name(ptr: *const #struct_name) -> #owned_helper {
@@ -1371,32 +1403,32 @@ fn crate_field_accessors(
                         std::mem::forget(rustcall_bytes);
                         rustcall_ret
                     }
-                });
+                }));
             } else if needs_clone_for_getter(field_ty) {
-                ffi_functions.extend(quote! {
+                ffi_functions.extend(guard_struct_helper(quote! {
                     #(#cfgs)*
                     #[no_mangle]
                     pub extern "C" fn #getter_name(ptr: *const #struct_name) -> #field_ty {
                         unsafe { (*ptr).#field_name.clone() }
                     }
-                });
+                }));
             } else {
-                ffi_functions.extend(quote! {
+                ffi_functions.extend(guard_struct_helper(quote! {
                     #(#cfgs)*
                     #[no_mangle]
                     pub extern "C" fn #getter_name(ptr: *const #struct_name) -> #field_ty {
                         unsafe { (*ptr).#field_name }
                     }
-                });
+                }));
             }
             let setter_name = format_ident!("{}_set_{}", stem, field_name);
-            ffi_functions.extend(quote! {
+            ffi_functions.extend(guard_struct_helper(quote! {
                 #(#cfgs)*
                 #[no_mangle]
                 pub extern "C" fn #setter_name(ptr: *mut #struct_name, value: #field_ty) {
                     unsafe { (*ptr).#field_name = value; }
                 }
-            });
+            }));
         }
     }
     ffi_functions
@@ -1877,7 +1909,7 @@ pub fn inline_struct_wrappers(
             setter.to_string(),
         ));
         if is_string_type(field_ty) {
-            out.extend(quote! {
+            out.extend(guard_struct_helper(quote! {
                 #[no_mangle]
                 pub extern "C" fn #getter(ptr: *const #struct_name) -> #owned_helper {
                     let mut rustcall_bytes = unsafe { (*ptr).#field_name.clone().into_bytes() };
@@ -1889,39 +1921,39 @@ pub fn inline_struct_wrappers(
                     std::mem::forget(rustcall_bytes);
                     rustcall_ret
                 }
-            });
+            }));
         } else if is_vec_type(field_ty) {
-            out.extend(quote! {
+            out.extend(guard_struct_helper(quote! {
                 #[no_mangle]
                 pub extern "C" fn #getter(ptr: *const #struct_name) -> #field_ty {
                     unsafe { (*ptr).#field_name.clone() }
                 }
-            });
+            }));
         } else {
-            out.extend(quote! {
+            out.extend(guard_struct_helper(quote! {
                 #[no_mangle]
                 pub extern "C" fn #getter(ptr: *const #struct_name) -> #field_ty {
                     unsafe { (*ptr).#field_name }
                 }
-            });
+            }));
         }
-        out.extend(quote! {
+        out.extend(guard_struct_helper(quote! {
             #[no_mangle]
             pub extern "C" fn #setter(ptr: *mut #struct_name, value: #field_ty) {
                 unsafe { (*ptr).#field_name = value; }
             }
-        });
+        }));
     }
 
     if model.derives.iter().any(|d| d == "Clone") {
         meta.has_clone = true;
         let clone_name = format_ident!("{}_clone", stem);
-        out.extend(quote! {
+        out.extend(guard_struct_helper(quote! {
             #[no_mangle]
             pub extern "C" fn #clone_name(ptr: *const #struct_name) -> *mut #struct_name {
                 unsafe { Box::into_raw(Box::new((*ptr).clone())) }
             }
-        });
+        }));
     }
 
     for m in &local {

--- a/deps/rustcall_core/src/codegen.rs
+++ b/deps/rustcall_core/src/codegen.rs
@@ -1422,16 +1422,39 @@ fn crate_field_accessors(
                 }));
             }
             let setter_name = format_ident!("{}_set_{}", stem, field_name);
-            ffi_functions.extend(guard_struct_helper(quote! {
-                #(#cfgs)*
-                #[no_mangle]
-                pub extern "C" fn #setter_name(ptr: *mut #struct_name, value: #field_ty) {
-                    unsafe { (*ptr).#field_name = value; }
-                }
-            }));
+            ffi_functions.extend(struct_field_setter(
+                struct_name,
+                field_name,
+                field_ty,
+                &setter_name,
+                cfgs,
+            ));
         }
     }
     ffi_functions
+}
+
+fn struct_field_setter(
+    owner: &Ident,
+    field: &Ident,
+    ty: &Type,
+    setter: &Ident,
+    cfgs: &[Attribute],
+) -> TokenStream2 {
+    let value = format_ident!("value");
+    let (args, conversion) = if is_string_type(ty) {
+        string_arg_conversion(&value, ty, &["ptr".into()])
+    } else {
+        (vec![quote! { value: #ty }], None)
+    };
+    guard_struct_helper(quote! {
+        #(#cfgs)*
+        #[no_mangle]
+        pub extern "C" fn #setter(ptr: *mut #owner, #(#args),*) {
+            #conversion
+            unsafe { (*ptr).#field = value; }
+        }
+    })
 }
 
 pub(crate) fn struct_free_wrapper(
@@ -1937,12 +1960,13 @@ pub fn inline_struct_wrappers(
                 }
             }));
         }
-        out.extend(guard_struct_helper(quote! {
-            #[no_mangle]
-            pub extern "C" fn #setter(ptr: *mut #struct_name, value: #field_ty) {
-                unsafe { (*ptr).#field_name = value; }
-            }
-        }));
+        out.extend(struct_field_setter(
+            struct_name,
+            field_name,
+            field_ty,
+            &setter,
+            &[],
+        ));
     }
 
     if model.derives.iter().any(|d| d == "Clone") {

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -728,7 +728,9 @@ impl Struct {
         let mut out = Vec::new();
         // A generic struct exports nothing itself.
         if self.type_params.is_empty() {
-            out.push((format!("{}_free", self.ffi_name), who.clone()));
+            let free = crate::codegen::struct_free_symbol(&self.ffi_name);
+            out.push((crate::codegen::panic_symbol(&free), who.clone()));
+            out.push((free, who.clone()));
         }
         for field in &self.fields {
             for accessor in [&field.getter, &field.setter] {

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -736,8 +736,14 @@ impl Struct {
             for accessor in [&field.getter, &field.setter] {
                 if !accessor.is_empty() {
                     out.push((accessor.clone(), who.clone()));
+                    out.push((crate::codegen::panic_symbol(accessor), who.clone()));
                 }
             }
+        }
+        if self.has_clone {
+            let clone = format!("{}_clone", self.ffi_name);
+            out.push((crate::codegen::panic_symbol(&clone), who.clone()));
+            out.push((clone, who.clone()));
         }
         let mut buffers: Vec<String> = Vec::new();
         if self.has_owned_string_helper {

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -864,12 +864,17 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
                 if accessor.is_empty() {
                     continue;
                 }
+                let symbols = [accessor.clone(), crate::codegen::panic_symbol(accessor)];
                 match taken
                     .iter()
-                    .find(|(t, _, c)| t == accessor && cfg_clash(c, &s_cfg))
+                    .find(|(t, _, c)| symbols.contains(t) && cfg_clash(c, &s_cfg))
                 {
                     Some(_) => accessor.clear(),
-                    None => taken.push((accessor.clone(), owner.clone(), s_cfg.clone())),
+                    None => {
+                        for symbol in symbols {
+                            taken.push((symbol, owner.clone(), s_cfg.clone()));
+                        }
+                    }
                 }
             }
             if f.getter.is_empty() && f.setter.is_empty() {
@@ -956,9 +961,11 @@ fn struct_symbols(s: &Struct) -> Vec<String> {
     for f in &s.fields {
         if !f.getter.is_empty() {
             out.push(f.getter.clone());
+            out.push(crate::codegen::panic_symbol(&f.getter));
         }
         if !f.setter.is_empty() {
             out.push(f.setter.clone());
+            out.push(crate::codegen::panic_symbol(&f.setter));
         }
     }
     out

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -769,12 +769,19 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
         }
         let name = s.ffi_name.clone();
         let s_cfg = s.cfg.clone();
+        let free = crate::codegen::struct_free_symbol(&s.ffi_name);
+        let free_symbols = [crate::codegen::panic_symbol(&free), free];
 
-        if let Some((_, owner, _)) = class_names
+        let class_conflict = class_names
             .iter()
             .find(|(n, _, c)| *n == name && cfg_clash(c, &s_cfg))
-        {
-            let reason = skip_reason::detailed(skip_reason::SYMBOL_COLLISION, &owner.clone());
+            .or_else(|| {
+                taken.iter().find(|(symbol, _, cfg)| {
+                    free_symbols.contains(symbol) && cfg_clash(cfg, &s_cfg)
+                })
+            });
+        if let Some((_, owner, _)) = class_conflict {
+            let reason = skip_reason::detailed(skip_reason::SYMBOL_COLLISION, owner);
             let s = &mut manifest.structs[i];
             s.skip_reason = reason.clone();
             for m in &mut s.methods {
@@ -795,6 +802,9 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
         // `rustcall_C_set_x` — leave the method wrappable and drop the
         // accessor, rather than taking the whole class down.
         let owner = qualified(&s.module_path, &s.name);
+        for symbol in free_symbols {
+            taken.push((symbol, owner.clone(), s_cfg.clone()));
+        }
         let s = &mut manifest.structs[i];
         let class_name = s.ffi_name.clone();
         for m in &mut s.methods {
@@ -927,6 +937,11 @@ fn wrapper_symbols(symbol: &str) -> [String; 3] {
 /// struct-level owned-string helper its `String` getters share.
 fn struct_symbols(s: &Struct) -> Vec<String> {
     let mut out = Vec::new();
+    if s.type_params.is_empty() {
+        let free = crate::codegen::struct_free_symbol(&s.ffi_name);
+        out.push(crate::codegen::panic_symbol(&free));
+        out.push(free);
+    }
     for m in &s.methods {
         if m.skip_reason.is_empty() && !m.symbol.is_empty() {
             out.extend(wrapper_symbols(&m.symbol));

--- a/deps/rustcall_core/src/wrap.rs
+++ b/deps/rustcall_core/src/wrap.rs
@@ -293,15 +293,11 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
 
     // `<Struct>_free`, the destructor `RustCall.ffi_struct_free_symbol` names
     // from the manifest's `ffi_name` (#300).
-    let free = format_ident!("{}_free", s.ffi_name);
-    out.extend(quote! {
-        #[no_mangle]
-        pub extern "C" fn #free(ptr: *mut #class) {
-            if !ptr.is_null() {
-                unsafe { drop(Box::from_raw(ptr)); }
-            }
-        }
-    });
+    out.extend(crate::codegen::struct_free_wrapper(
+        &class,
+        &format_ident!("{}", s.ffi_name),
+        &[],
+    ));
 
     // The struct-level owned-string buffer, shared by every `String` field
     // getter (`RustCall._ffi_field_return` names it after the struct).

--- a/deps/rustcall_core/src/wrap.rs
+++ b/deps/rustcall_core/src/wrap.rs
@@ -343,7 +343,7 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
         if is_string_type(&ty) {
             if !f.getter.is_empty() {
                 let getter = format_ident!("{}", f.getter);
-                out.extend(quote! {
+                out.extend(crate::codegen::guard_struct_helper(quote! {
                     #[no_mangle]
                     pub extern "C" fn #getter(ptr: *const #class) -> #owned_helper {
                         let mut rustcall_bytes = unsafe { (*ptr).#field.clone().into_bytes() };
@@ -355,7 +355,7 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
                         ::std::mem::forget(rustcall_bytes);
                         rustcall_ret
                     }
-                });
+                }));
             }
             // A `String` field is read by copying it out; writing one would
             // need the byte-pair ABI on a setter, which no accessor shape
@@ -371,21 +371,21 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
                 // Only `Copy` FFI types reach here: `String` has its own
                 // branch above and the scan gives a `Vec<T>` no accessor
                 // (no ABI for it on the Julia side yet, #303).
-                out.extend(quote! {
+                out.extend(crate::codegen::guard_struct_helper(quote! {
                     #[no_mangle]
                     pub extern "C" fn #getter(ptr: *const #class) -> #ty {
                         unsafe { (*ptr).#field }
                     }
-                });
+                }));
             }
             if !f.setter.is_empty() {
                 let setter = format_ident!("{}", f.setter);
-                out.extend(quote! {
+                out.extend(crate::codegen::guard_struct_helper(quote! {
                     #[no_mangle]
                     pub extern "C" fn #setter(ptr: *mut #class, value: #ty) {
                         unsafe { (*ptr).#field = value; }
                     }
-                });
+                }));
             }
         }
     }

--- a/deps/rustcall_core/tests/accessor_panics.rs
+++ b/deps/rustcall_core/tests/accessor_panics.rs
@@ -5,6 +5,66 @@ use rustcall_core::{
 };
 
 #[test]
+fn string_setters_copy_byte_pairs_in_both_flavours() {
+    for flavour in ["inline", "crate"] {
+        let declaration = if flavour == "inline" {
+            expand("#[julia] pub struct Text { pub value: String }")
+                .unwrap()
+                .source
+        } else {
+            transform_struct_crate(
+                syn::parse_quote! {
+                    pub struct Text { pub value: String }
+                },
+                &[],
+            )
+            .to_string()
+        };
+        let source = format!(
+            r#"
+            #![allow(non_snake_case)]
+            {declaration}
+            fn main() {{
+                let mut object = Text {{ value: String::new() }};
+                for value in ["日本語\0末尾", "", "replacement"] {{
+                    Text_set_value(&mut object, value.as_ptr(), value.len());
+                    assert_eq!(object.value, value);
+                    assert_eq!(Text_set_value_take_panic(std::ptr::null_mut(), 0), 0);
+                }}
+            }}
+        "#
+        );
+        let dir = std::env::temp_dir().join(format!(
+            "rustcall_string_setter_{}_{flavour}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("probe.rs");
+        let binary = dir.join(format!("probe{}", std::env::consts::EXE_SUFFIX));
+        fs::write(&input, source).unwrap();
+        let compile = Command::new("rustc")
+            .args(["--edition=2021", "-C", "panic=unwind"])
+            .arg(&input)
+            .arg("-o")
+            .arg(&binary)
+            .output()
+            .unwrap();
+        assert!(
+            compile.status.success(),
+            "{flavour}: {}",
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = Command::new(&binary).output().unwrap();
+        assert!(
+            run.status.success(),
+            "{flavour}: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+        fs::remove_dir_all(dir).unwrap();
+    }
+}
+
+#[test]
 fn accessor_channels_are_reserved() {
     let source = r#"
         #[julia] pub struct rustcall_Fields { pub value: i32 }

--- a/deps/rustcall_core/tests/accessor_panics.rs
+++ b/deps/rustcall_core/tests/accessor_panics.rs
@@ -1,0 +1,120 @@
+use std::{fs, process::Command};
+
+use rustcall_core::{
+    codegen::transform_struct_crate, expand::expand, extract::extract, manifest::Mode,
+};
+
+#[test]
+fn accessor_channels_are_reserved() {
+    let source = r#"
+        #[julia] pub struct rustcall_Fields { pub value: i32 }
+        #[julia] pub fn Fields_get_value_take_panic() {}
+    "#;
+    assert!(extract(source, Mode::Crate).is_err());
+    let mixed = source.replace("#[julia] pub fn", "#[pyfunction] pub fn");
+    assert!(extract(&mixed, Mode::Crate).unwrap().functions[0]
+        .skip_reason
+        .starts_with("symbol_collision:"));
+    let python = mixed.replace(
+        "#[julia] pub struct rustcall_Fields",
+        "#[pyclass(get_all)] pub struct Fields",
+    );
+    let manifest = extract(&python, Mode::Crate).unwrap();
+    assert!(manifest.structs[0].fields[0].getter.is_empty());
+}
+
+#[test]
+fn generated_accessors_contain_clone_and_drop_panics() {
+    for flavour in ["inline", "crate"] {
+        let declaration = if flavour == "inline" {
+            expand("#[julia] #[derive(Clone)] pub struct Fields { pub values: Vec<Explode> }")
+                .unwrap()
+                .source
+        } else {
+            transform_struct_crate(
+                syn::parse_quote! {
+                    pub struct Fields { pub values: Vec<Explode> }
+                },
+                &[],
+            )
+            .to_string()
+        };
+        let clone_probe = if flavour == "inline" {
+            r#"
+                assert!(Fields_clone(&*object).is_null());
+                let n = Fields_clone_take_panic(bytes.as_mut_ptr(), bytes.len());
+                assert!(std::str::from_utf8(&bytes[..n]).unwrap().contains("accessor clone panic"));
+                assert_eq!(Fields_clone_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+            "#
+        } else {
+            ""
+        };
+        let source = format!(
+            r#"
+            #![allow(non_snake_case, improper_ctypes_definitions)]
+            {declaration}
+            pub struct Explode {{ fail: bool }}
+            impl Clone for Explode {{
+                fn clone(&self) -> Self {{
+                    if self.fail {{ panic!("accessor clone panic"); }}
+                    Self {{ fail: false }}
+                }}
+            }}
+            impl Drop for Explode {{
+                fn drop(&mut self) {{
+                    if self.fail {{ panic!("accessor drop panic"); }}
+                }}
+            }}
+            fn main() {{
+                let mut object = std::mem::ManuallyDrop::new(Fields {{ values: vec![Explode {{ fail: true }}] }});
+                // The unwind result must be a VALID empty Vec, not zeroed Vec.
+                let sentinel = Fields_get_values(&*object);
+                assert!(sentinel.is_empty());
+                drop(sentinel);
+                let mut bytes = [0u8; 512];
+                let n = Fields_get_values_take_panic(bytes.as_mut_ptr(), bytes.len());
+                assert!(std::str::from_utf8(&bytes[..n]).unwrap().contains("accessor clone panic"));
+                assert_eq!(Fields_get_values_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+                {clone_probe}
+                Fields_set_values(&mut *object, Vec::new());
+                let n = Fields_set_values_take_panic(bytes.as_mut_ptr(), bytes.len());
+                assert!(std::str::from_utf8(&bytes[..n]).unwrap().contains("accessor drop panic"));
+                assert_eq!(Fields_set_values_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+                // Do not rely on the panicking setter's post-panic object state.
+                let mut quiet = Fields {{ values: vec![Explode {{ fail: false }}] }};
+                assert_eq!(Fields_get_values(&quiet).len(), 1);
+                assert_eq!(Fields_get_values_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+                Fields_set_values(&mut quiet, Vec::new());
+                assert_eq!(Fields_set_values_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+            }}
+        "#
+        );
+        let dir = std::env::temp_dir().join(format!(
+            "rustcall_accessor_{}_{flavour}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("probe.rs");
+        let binary = dir.join(format!("probe{}", std::env::consts::EXE_SUFFIX));
+        fs::write(&input, source).unwrap();
+        let compile = Command::new("rustc")
+            .args(["--edition=2021", "-C", "panic=unwind"])
+            .arg(&input)
+            .arg("-o")
+            .arg(&binary)
+            .output()
+            .unwrap();
+        assert!(
+            compile.status.success(),
+            "{flavour}: {}",
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = Command::new(&binary).output().unwrap();
+        assert!(
+            run.status.success(),
+            "{flavour}: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+        fs::remove_dir_all(dir).unwrap();
+    }
+}

--- a/deps/rustcall_core/tests/cfg_pruning.rs
+++ b/deps/rustcall_core/tests/cfg_pruning.rs
@@ -699,13 +699,13 @@ fn generated_struct_helpers_carry_the_struct_cfg() {
             }
             syn::Item::Struct(s) => assert!(has_cfg(&s.attrs), "`{}` lost its cfg", s.ident),
             syn::Item::Macro(m) if m.mac.path.is_ident("thread_local") => {
-                assert!(has_cfg(&m.attrs), "the destructor panic slot lost its cfg");
+                assert!(has_cfg(&m.attrs), "a helper panic slot lost its cfg");
             }
             _ => {}
         }
     }
-    // free + its panic reader, get_v, set_v, get_label, set_label, free_rust_string
-    assert_eq!(fns, 7);
+    // free + four accessors, each with a reader, plus free_rust_string
+    assert_eq!(fns, 11);
 
     let imp: syn::ItemImpl = syn::parse_str(
         "#[cfg(feature = \"x\")] impl C { #[julia] pub fn get(&self) -> i32 { self.v } }",

--- a/deps/rustcall_core/tests/cfg_pruning.rs
+++ b/deps/rustcall_core/tests/cfg_pruning.rs
@@ -698,11 +698,14 @@ fn generated_struct_helpers_carry_the_struct_cfg() {
                 );
             }
             syn::Item::Struct(s) => assert!(has_cfg(&s.attrs), "`{}` lost its cfg", s.ident),
+            syn::Item::Macro(m) if m.mac.path.is_ident("thread_local") => {
+                assert!(has_cfg(&m.attrs), "the destructor panic slot lost its cfg");
+            }
             _ => {}
         }
     }
-    // free, get_v, set_v, get_label, set_label, free_rust_string
-    assert_eq!(fns, 6);
+    // free + its panic reader, get_v, set_v, get_label, set_label, free_rust_string
+    assert_eq!(fns, 7);
 
     let imp: syn::ItemImpl = syn::parse_str(
         "#[cfg(feature = \"x\")] impl C { #[julia] pub fn get(&self) -> i32 { self.v } }",

--- a/deps/rustcall_core/tests/corpus/cfg_items.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/cfg_items.expanded.rs
@@ -17,6 +17,9 @@ pub extern "C" fn rustcall_unix_only_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_UNIX_ONLY
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -93,6 +96,9 @@ pub extern "C" fn rustcall_windows_wide_take_panic(out: *mut u8, cap: usize) -> 
     __RUSTCALL_PANIC_RUSTCALL_WINDOWS_WIDE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -234,6 +240,9 @@ pub extern "C" fn rustcall_maybe_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_MAYBE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -348,11 +357,80 @@ pub struct Handle {
     #[cfg(target_os = "linux")]
     pub epoll: i32,
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_48616E646C655F66726565 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Handle_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_48616E646C655F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Handle_free(ptr: *mut Handle) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Handle::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_48616E646C655F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -386,6 +464,9 @@ pub extern "C" fn rustcall_Handle_fd_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_HANDLE_FD
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -460,6 +541,9 @@ pub extern "C" fn rustcall_Handle_epoll_take_panic(out: *mut u8, cap: usize) -> 
     __RUSTCALL_PANIC_RUSTCALL_HANDLE_EPOLL
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -550,6 +634,9 @@ mod extra {
         __RUSTCALL_PANIC_RUSTCALL_EXTRA__BONUS
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/cfg_items.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/cfg_items.expanded.rs
@@ -434,24 +434,302 @@ pub extern "C" fn Handle_free(ptr: *mut Handle) {
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_48616E646C655F6765745F6664 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Handle_get_fd_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_48616E646C655F6765745F6664
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Handle_get_fd(ptr: *const Handle) -> i32 {
-    unsafe { (*ptr).fd }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).fd } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Handle_get_fd", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_48616E646C655F6765745F6664
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<i32>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_48616E646C655F7365745F6664 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Handle_set_fd_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_48616E646C655F7365745F6664
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Handle_set_fd(ptr: *mut Handle, value: i32) {
-    unsafe {
-        (*ptr).fd = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).fd = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Handle_set_fd", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_48616E646C655F7365745F6664
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_48616E646C655F6765745F65706F6C6C :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Handle_get_epoll_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_48616E646C655F6765745F65706F6C6C
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Handle_get_epoll(ptr: *const Handle) -> i32 {
-    unsafe { (*ptr).epoll }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).epoll } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Handle_get_epoll", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_48616E646C655F6765745F65706F6C6C
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<i32>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_48616E646C655F7365745F65706F6C6C :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Handle_set_epoll_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_48616E646C655F7365745F65706F6C6C
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Handle_set_epoll(ptr: *mut Handle, value: i32) {
-    unsafe {
-        (*ptr).epoll = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).epoll = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Handle_set_epoll", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_48616E646C655F7365745F65706F6C6C
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
 }
 thread_local! {

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.expanded.rs
@@ -93,14 +93,153 @@ pub extern "C" fn Gauge_free(ptr: *mut Gauge) {
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_47617567655F6765745F76616C7565 : ::std::cell::RefCell
+    < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Gauge_get_value_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_47617567655F6765745F76616C7565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Gauge_get_value(ptr: *const Gauge) -> i32 {
-    unsafe { (*ptr).value }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).value } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge_get_value", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_47617567655F6765745F76616C7565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<i32>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_47617567655F7365745F76616C7565 : ::std::cell::RefCell
+    < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Gauge_set_value_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_47617567655F7365745F76616C7565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Gauge_set_value(ptr: *mut Gauge, value: i32) {
-    unsafe {
-        (*ptr).value = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).value = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge_set_value", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_47617567655F7365745F76616C7565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
 }
 thread_local! {
@@ -817,14 +956,153 @@ pub mod a {
             }
         }
     }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_615F5F435F6765745F76 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_get_v_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_615F5F435F6765745F76
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
     #[no_mangle]
     pub extern "C" fn a__C_get_v(ptr: *const C) -> i32 {
-        unsafe { (*ptr).v }
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).v } } }),
+        ) {
+            ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "a__C_get_v", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_615F5F435F6765745F76
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+                unsafe { ::std::mem::zeroed::<i32>() }
+            }
+        }
+    }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_615F5F435F7365745F76 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_set_v_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_615F5F435F7365745F76
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
     }
     #[no_mangle]
     pub extern "C" fn a__C_set_v(ptr: *mut C, value: i32) {
-        unsafe {
-            (*ptr).v = value;
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                {
+                    unsafe {
+                        (*ptr).v = value;
+                    }
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(_) => {}
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "a__C_set_v", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_615F5F435F7365745F76
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+            }
         }
     }
     thread_local! {

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.expanded.rs
@@ -16,11 +16,80 @@
 pub struct Gauge {
     pub value: i32,
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_47617567655F66726565 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Gauge_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_47617567655F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Gauge_free(ptr: *mut Gauge) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Gauge::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_47617567655F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -44,6 +113,9 @@ pub extern "C" fn rustcall_Gauge_new_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_GAUGE_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -131,6 +203,9 @@ pub mod ops {
         __RUSTCALL_PANIC_RUSTCALL_GAUGE_READ
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -203,6 +278,9 @@ pub mod ops {
         __RUSTCALL_PANIC_RUSTCALL_GAUGE_BUMP
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -287,6 +365,9 @@ pub mod more {
         __RUSTCALL_PANIC_RUSTCALL_GAUGE_LABEL
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -395,6 +476,9 @@ pub mod more {
         __RUSTCALL_PANIC_RUSTCALL_GAUGE_SCALED
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -485,6 +569,9 @@ pub mod plain {
         __RUSTCALL_PANIC_RUSTCALL_GAUGE_HALVED
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -653,11 +740,80 @@ pub mod a {
     pub struct C {
         pub v: i32,
     }
+    thread_local! {
+        static __RUSTCALL_DROP_PANIC_615F5F435F66726565 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_free_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_DROP_PANIC_615F5F435F66726565
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
     #[no_mangle]
     pub extern "C" fn a__C_free(ptr: *mut C) {
-        if !ptr.is_null() {
-            unsafe {
-                drop(Box::from_raw(ptr));
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                if !ptr.is_null() {
+                    unsafe {
+                        drop(Box::from_raw(ptr));
+                    }
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(_) => {}
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "C::drop", rustcall_message
+                );
+                __RUSTCALL_DROP_PANIC_615F5F435F66726565
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
             }
         }
     }
@@ -681,6 +837,9 @@ pub mod a {
         __RUSTCALL_PANIC_RUSTCALL_A__C_NEW
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -765,6 +924,9 @@ pub mod b {
         __RUSTCALL_PANIC_RUSTCALL_A__C_GET
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/modules.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/modules.expanded.rs
@@ -447,10 +447,18 @@ pub mod a {
             })
     }
     #[no_mangle]
-    pub extern "C" fn a__C_set_label(ptr: *mut C, value: String) {
+    pub extern "C" fn a__C_set_label(
+        ptr: *mut C,
+        value_ptr: *const u8,
+        value_len: usize,
+    ) {
         match ::std::panic::catch_unwind(
             ::std::panic::AssertUnwindSafe(|| {
                 {
+                    let value = unsafe {
+                        let slice = std::slice::from_raw_parts(value_ptr, value_len);
+                        String::from_utf8_lossy(slice).into_owned()
+                    };
                     unsafe {
                         (*ptr).label = value;
                     }

--- a/deps/rustcall_core/tests/corpus/modules.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/modules.expanded.rs
@@ -172,31 +172,315 @@ pub mod a {
             }
         }
     }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_615F5F435F6765745F76 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_get_v_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_615F5F435F6765745F76
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
     #[no_mangle]
     pub extern "C" fn a__C_get_v(ptr: *const C) -> i32 {
-        unsafe { (*ptr).v }
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).v } } }),
+        ) {
+            ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "a__C_get_v", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_615F5F435F6765745F76
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+                unsafe { ::std::mem::zeroed::<i32>() }
+            }
+        }
+    }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_615F5F435F7365745F76 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_set_v_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_615F5F435F7365745F76
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
     }
     #[no_mangle]
     pub extern "C" fn a__C_set_v(ptr: *mut C, value: i32) {
-        unsafe {
-            (*ptr).v = value;
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                {
+                    unsafe {
+                        (*ptr).v = value;
+                    }
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(_) => {}
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "a__C_set_v", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_615F5F435F7365745F76
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+            }
         }
+    }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_615F5F435F6765745F6C6162656C :
+        ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_get_label_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_615F5F435F6765745F6C6162656C
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
     }
     #[no_mangle]
     pub extern "C" fn a__C_get_label(ptr: *const C) -> a__C_RustCallOwnedString {
-        let mut rustcall_bytes = unsafe { (*ptr).label.clone().into_bytes() };
-        let rustcall_ret = a__C_RustCallOwnedString {
-            ptr: rustcall_bytes.as_mut_ptr(),
-            len: rustcall_bytes.len(),
-            cap: rustcall_bytes.capacity(),
-        };
-        std::mem::forget(rustcall_bytes);
-        rustcall_ret
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                {
+                    let mut rustcall_bytes = unsafe {
+                        (*ptr).label.clone().into_bytes()
+                    };
+                    let rustcall_ret = a__C_RustCallOwnedString {
+                        ptr: rustcall_bytes.as_mut_ptr(),
+                        len: rustcall_bytes.len(),
+                        cap: rustcall_bytes.capacity(),
+                    };
+                    std::mem::forget(rustcall_bytes);
+                    rustcall_ret
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "a__C_get_label", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_615F5F435F6765745F6C6162656C
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+                unsafe { ::std::mem::zeroed::<a__C_RustCallOwnedString>() }
+            }
+        }
+    }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_615F5F435F7365745F6C6162656C :
+        ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_set_label_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_615F5F435F7365745F6C6162656C
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
     }
     #[no_mangle]
     pub extern "C" fn a__C_set_label(ptr: *mut C, value: String) {
-        unsafe {
-            (*ptr).label = value;
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                {
+                    unsafe {
+                        (*ptr).label = value;
+                    }
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(_) => {}
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "a__C_set_label", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_615F5F435F7365745F6C6162656C
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+            }
         }
     }
     thread_local! {
@@ -928,14 +1212,153 @@ pub mod b {
             }
         }
     }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_625F5F435F6765745F76 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn b__C_get_v_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_625F5F435F6765745F76
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
     #[no_mangle]
     pub extern "C" fn b__C_get_v(ptr: *const C) -> i32 {
-        unsafe { (*ptr).v }
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).v } } }),
+        ) {
+            ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "b__C_get_v", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_625F5F435F6765745F76
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+                unsafe { ::std::mem::zeroed::<i32>() }
+            }
+        }
+    }
+    thread_local! {
+        static __RUSTCALL_HELPER_PANIC_625F5F435F7365745F76 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn b__C_set_v_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_HELPER_PANIC_625F5F435F7365745F76
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
     }
     #[no_mangle]
     pub extern "C" fn b__C_set_v(ptr: *mut C, value: i32) {
-        unsafe {
-            (*ptr).v = value;
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                {
+                    unsafe {
+                        (*ptr).v = value;
+                    }
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(_) => {}
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "b__C_set_v", rustcall_message
+                );
+                __RUSTCALL_HELPER_PANIC_625F5F435F7365745F76
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
+            }
         }
     }
     thread_local! {

--- a/deps/rustcall_core/tests/corpus/modules.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/modules.expanded.rs
@@ -17,6 +17,9 @@ pub mod a {
         __RUSTCALL_PANIC_RUSTCALL_A__RUN
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -78,11 +81,80 @@ pub mod a {
         pub v: i32,
         pub label: String,
     }
+    thread_local! {
+        static __RUSTCALL_DROP_PANIC_615F5F435F66726565 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn a__C_free_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_DROP_PANIC_615F5F435F66726565
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
     #[no_mangle]
     pub extern "C" fn a__C_free(ptr: *mut C) {
-        if !ptr.is_null() {
-            unsafe {
-                drop(Box::from_raw(ptr));
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                if !ptr.is_null() {
+                    unsafe {
+                        drop(Box::from_raw(ptr));
+                    }
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(_) => {}
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "C::drop", rustcall_message
+                );
+                __RUSTCALL_DROP_PANIC_615F5F435F66726565
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
             }
         }
     }
@@ -137,6 +209,9 @@ pub mod a {
         __RUSTCALL_PANIC_RUSTCALL_A__C_NEW
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -209,6 +284,9 @@ pub mod a {
         __RUSTCALL_PANIC_RUSTCALL_A__C_GET
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -284,6 +362,9 @@ pub mod a {
         __RUSTCALL_PANIC_RUSTCALL_A__C_DESCRIBE
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -372,6 +453,9 @@ pub mod a {
         __RUSTCALL_PANIC_RUSTCALL_A__C_CHECKED
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -548,6 +632,9 @@ pub mod a {
             __RUSTCALL_PANIC_RUSTCALL_A__DEEP_0ER__RUN
                 .with(|rustcall_slot| {
                     let mut rustcall_slot = rustcall_slot.borrow_mut();
+                    if out.is_null() && cap == usize::MAX {
+                        return rustcall_slot.take().map_or(0, |message| message.len());
+                    }
                     let rustcall_len = match rustcall_slot.as_ref() {
                         ::std::option::Option::Some(message) => {
                             let bytes = message.as_bytes();
@@ -623,6 +710,9 @@ pub mod a {
             __RUSTCALL_PANIC_RUSTCALL_A__DEEP_0ER__SNAKE_0CASE_0FN
                 .with(|rustcall_slot| {
                     let mut rustcall_slot = rustcall_slot.borrow_mut();
+                    if out.is_null() && cap == usize::MAX {
+                        return rustcall_slot.take().map_or(0, |message| message.len());
+                    }
                     let rustcall_len = match rustcall_slot.as_ref() {
                         ::std::option::Option::Some(message) => {
                             let bytes = message.as_bytes();
@@ -698,6 +788,9 @@ pub mod b {
         __RUSTCALL_PANIC_RUSTCALL_B__RUN
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -758,11 +851,80 @@ pub mod b {
     pub struct C {
         pub v: i32,
     }
+    thread_local! {
+        static __RUSTCALL_DROP_PANIC_625F5F435F66726565 : ::std::cell::RefCell <
+        ::std::option::Option < ::std::string::String >> =
+        ::std::cell::RefCell::new(::std::option::Option::None);
+    }
+    #[no_mangle]
+    pub extern "C" fn b__C_free_take_panic(out: *mut u8, cap: usize) -> usize {
+        __RUSTCALL_DROP_PANIC_625F5F435F66726565
+            .with(|rustcall_slot| {
+                let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
+                let rustcall_len = match rustcall_slot.as_ref() {
+                    ::std::option::Option::Some(message) => {
+                        let bytes = message.as_bytes();
+                        if bytes.len() <= cap && !out.is_null() {
+                            unsafe {
+                                ::std::ptr::copy_nonoverlapping(
+                                    bytes.as_ptr(),
+                                    out,
+                                    bytes.len(),
+                                );
+                            }
+                            Some(bytes.len())
+                        } else {
+                            return bytes.len();
+                        }
+                    }
+                    ::std::option::Option::None => ::std::option::Option::None,
+                };
+                match rustcall_len {
+                    ::std::option::Option::Some(n) => {
+                        *rustcall_slot = ::std::option::Option::None;
+                        n
+                    }
+                    ::std::option::Option::None => 0,
+                }
+            })
+    }
     #[no_mangle]
     pub extern "C" fn b__C_free(ptr: *mut C) {
-        if !ptr.is_null() {
-            unsafe {
-                drop(Box::from_raw(ptr));
+        match ::std::panic::catch_unwind(
+            ::std::panic::AssertUnwindSafe(|| {
+                if !ptr.is_null() {
+                    unsafe {
+                        drop(Box::from_raw(ptr));
+                    }
+                }
+            }),
+        ) {
+            ::std::result::Result::Ok(_) => {}
+            ::std::result::Result::Err(rustcall_payload) => {
+                let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                    s,
+                ) = rustcall_payload.downcast_ref::<&'static str>()
+                {
+                    ::std::string::ToString::to_string(s)
+                } else if let ::std::option::Option::Some(s) = rustcall_payload
+                    .downcast_ref::<::std::string::String>()
+                {
+                    s.clone()
+                } else {
+                    ::std::string::ToString::to_string("Box<dyn Any>")
+                };
+                let rustcall_message = ::std::format!(
+                    "{} panicked: {}", "C::drop", rustcall_message
+                );
+                __RUSTCALL_DROP_PANIC_625F5F435F66726565
+                    .with(|rustcall_slot| {
+                        *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                            rustcall_message,
+                        );
+                    });
             }
         }
     }
@@ -786,6 +948,9 @@ pub mod b {
         __RUSTCALL_PANIC_RUSTCALL_B__C_NEW
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -858,6 +1023,9 @@ pub mod b {
         __RUSTCALL_PANIC_RUSTCALL_B__C_GET
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -941,6 +1109,9 @@ pub extern "C" fn rustcall_run_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_RUN
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1012,6 +1183,9 @@ pub mod a_b {
         __RUSTCALL_PANIC_RUSTCALL_A_0B__C
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();
@@ -1084,6 +1258,9 @@ pub mod a {
         __RUSTCALL_PANIC_RUSTCALL_A__B_0C
             .with(|rustcall_slot| {
                 let mut rustcall_slot = rustcall_slot.borrow_mut();
+                if out.is_null() && cap == usize::MAX {
+                    return rustcall_slot.take().map_or(0, |message| message.len());
+                }
                 let rustcall_len = match rustcall_slot.as_ref() {
                     ::std::option::Option::Some(message) => {
                         let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.expanded.rs
@@ -145,6 +145,9 @@ pub extern "C" fn rustcall_dual_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_DUAL
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.rs
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.rs
@@ -639,26 +639,234 @@ pub extern "C" fn Point_free_rust_string(ptr: *mut u8, len: usize, cap: usize) {
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F78 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Point_get_x_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F78
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn rustcall_Point_get_x(ptr: *const user_crate::Point) -> f64 {
-    unsafe { (*ptr).x }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).x } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_Point_get_x", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F78
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<f64>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F79 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Point_get_y_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F79
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn rustcall_Point_get_y(ptr: *const user_crate::Point) -> f64 {
-    unsafe { (*ptr).y }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).y } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_Point_get_y", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F79
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<f64>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F746167 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_Point_get_tag_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F746167
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn rustcall_Point_get_tag(
     ptr: *const user_crate::Point,
 ) -> Point_RustCallOwnedString {
-    let mut rustcall_bytes = unsafe { (*ptr).tag.clone().into_bytes() };
-    let rustcall_ret = Point_RustCallOwnedString {
-        ptr: rustcall_bytes.as_mut_ptr(),
-        len: rustcall_bytes.len(),
-        cap: rustcall_bytes.capacity(),
-    };
-    ::std::mem::forget(rustcall_bytes);
-    rustcall_ret
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                let mut rustcall_bytes = unsafe { (*ptr).tag.clone().into_bytes() };
+                let rustcall_ret = Point_RustCallOwnedString {
+                    ptr: rustcall_bytes.as_mut_ptr(),
+                    len: rustcall_bytes.len(),
+                    cap: rustcall_bytes.capacity(),
+                };
+                ::std::mem::forget(rustcall_bytes);
+                rustcall_ret
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_Point_get_tag", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F506F696E745F6765745F746167
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<Point_RustCallOwnedString>() }
+        }
+    }
 }
 thread_local! {
     static __RUSTCALL_PANIC_RUSTCALL_POINT_NEW : ::std::cell::RefCell <
@@ -1194,11 +1402,83 @@ pub extern "C" fn shapes__Circle_free(ptr: *mut user_crate::shapes::Circle) {
         }
     }
 }
+thread_local! {
+    static
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F7368617065735F5F436972636C655F6765745F72 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_shapes__Circle_get_r_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F7368617065735F5F436972636C655F6765745F72
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn rustcall_shapes__Circle_get_r(
     ptr: *const user_crate::shapes::Circle,
 ) -> f64 {
-    unsafe { (*ptr).r }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).r } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_shapes__Circle_get_r", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F7368617065735F5F436972636C655F6765745F72
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<f64>() }
+        }
+    }
 }
 thread_local! {
     static __RUSTCALL_PANIC_RUSTCALL_SHAPES__CIRCLE_NEW : ::std::cell::RefCell <
@@ -1437,17 +1717,162 @@ pub extern "C" fn GatedPoint_free(ptr: *mut user_crate::GatedPoint) {
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_7275737463616C6C5F4761746564506F696E745F6765745F78 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_GatedPoint_get_x_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F4761746564506F696E745F6765745F78
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn rustcall_GatedPoint_get_x(ptr: *const user_crate::GatedPoint) -> f64 {
-    unsafe { (*ptr).x }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).x } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_GatedPoint_get_x", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F4761746564506F696E745F6765745F78
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<f64>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_7275737463616C6C5F4761746564506F696E745F7365745F78 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_GatedPoint_set_x_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F4761746564506F696E745F7365745F78
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn rustcall_GatedPoint_set_x(
     ptr: *mut user_crate::GatedPoint,
     value: f64,
 ) {
-    unsafe {
-        (*ptr).x = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).x = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_GatedPoint_set_x", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F4761746564506F696E745F7365745F78
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
 }
 thread_local! {

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.rs
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.rs
@@ -18,6 +18,9 @@ pub extern "C" fn rustcall_add_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_ADD
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -86,6 +89,9 @@ pub extern "C" fn rustcall_shout_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_SHOUT
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -190,6 +196,9 @@ pub extern "C" fn rustcall_double_take_panic(out: *mut u8, cap: usize) -> usize 
     __RUSTCALL_PANIC_RUSTCALL_DOUBLE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -258,6 +267,9 @@ pub extern "C" fn rustcall_parse_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_PARSE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -402,6 +414,9 @@ pub extern "C" fn rustcall_nested__deep_take_panic(out: *mut u8, cap: usize) -> 
     __RUSTCALL_PANIC_RUSTCALL_NESTED__DEEP
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -471,6 +486,9 @@ pub extern "C" fn rustcall_gated_add_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_GATED_ADD
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -530,11 +548,80 @@ pub extern "C" fn rustcall_gated_add(a: i32, b: i32) -> i32 {
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_506F696E745F66726565 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Point_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_506F696E745F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Point_free(ptr: *mut user_crate::Point) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Point::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_506F696E745F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -583,6 +670,9 @@ pub extern "C" fn rustcall_Point_new_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_POINT_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -664,6 +754,9 @@ pub extern "C" fn rustcall_Point_norm_take_panic(out: *mut u8, cap: usize) -> us
     __RUSTCALL_PANIC_RUSTCALL_POINT_NORM
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -736,6 +829,9 @@ pub extern "C" fn rustcall_Point_scale_take_panic(out: *mut u8, cap: usize) -> u
     __RUSTCALL_PANIC_RUSTCALL_POINT_SCALE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -807,6 +903,9 @@ pub extern "C" fn rustcall_Point_origin_take_panic(out: *mut u8, cap: usize) -> 
     __RUSTCALL_PANIC_RUSTCALL_POINT_ORIGIN
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -879,6 +978,9 @@ pub extern "C" fn rustcall_Point_sum_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_POINT_SUM
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -951,6 +1053,9 @@ pub extern "C" fn rustcall_Point_set_x_take_panic(out: *mut u8, cap: usize) -> u
     __RUSTCALL_PANIC_RUSTCALL_POINT_SET_X
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1012,11 +1117,80 @@ pub extern "C" fn rustcall_Point_set_x(ptr: *mut user_crate::Point, value: f64) 
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_7368617065735F5F436972636C655F66726565 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn shapes__Circle_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_7368617065735F5F436972636C655F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn shapes__Circle_free(ptr: *mut user_crate::shapes::Circle) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Circle::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_7368617065735F5F436972636C655F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -1039,6 +1213,9 @@ pub extern "C" fn rustcall_shapes__Circle_new_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_SHAPES__CIRCLE_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1116,6 +1293,9 @@ pub extern "C" fn rustcall_shapes__Circle_area_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_SHAPES__CIRCLE_AREA
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1180,11 +1360,80 @@ pub extern "C" fn rustcall_shapes__Circle_area(
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_4761746564506F696E745F66726565 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn GatedPoint_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_4761746564506F696E745F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn GatedPoint_free(ptr: *mut user_crate::GatedPoint) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "GatedPoint::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_4761746564506F696E745F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -1211,6 +1460,9 @@ pub extern "C" fn rustcall_GatedPoint_new_take_panic(out: *mut u8, cap: usize) -
     __RUSTCALL_PANIC_RUSTCALL_GATEDPOINT_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1286,6 +1538,9 @@ pub extern "C" fn rustcall_GatedPoint_checked_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GATEDPOINT_CHECKED
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.rs
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.rs
@@ -1152,42 +1152,340 @@ pub extern "C" fn geometry__Rect_free_rust_string(ptr: *mut u8, len: usize, cap:
         }
     }
 }
+thread_local! {
+    static
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F77 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_geometry__Rect_get_w_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F77
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn rustcall_geometry__Rect_get_w(
     ptr: *const user_crate::geometry::Rect,
 ) -> f64 {
-    unsafe { (*ptr).w }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).w } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_geometry__Rect_get_w", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F77
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<f64>() }
+        }
+    }
+}
+thread_local! {
+    static
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F7365745F77 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_geometry__Rect_set_w_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F7365745F77
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn rustcall_geometry__Rect_set_w(
     ptr: *mut user_crate::geometry::Rect,
     value: f64,
 ) {
-    unsafe {
-        (*ptr).w = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).w = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_geometry__Rect_set_w", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F7365745F77
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
+}
+thread_local! {
+    static
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F7365745F6465707468
+    : ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_geometry__Rect_set_depth_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F7365745F6465707468
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn rustcall_geometry__Rect_set_depth(
     ptr: *mut user_crate::geometry::Rect,
     value: f64,
 ) {
-    unsafe {
-        (*ptr).depth = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).depth = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_geometry__Rect_set_depth", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F7365745F6465707468
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
+}
+thread_local! {
+    static
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F6E616D65
+    : ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_geometry__Rect_get_name_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F6E616D65
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn rustcall_geometry__Rect_get_name(
     ptr: *const user_crate::geometry::Rect,
 ) -> geometry__Rect_RustCallOwnedString {
-    let mut rustcall_bytes = unsafe { (*ptr).name.clone().into_bytes() };
-    let rustcall_ret = geometry__Rect_RustCallOwnedString {
-        ptr: rustcall_bytes.as_mut_ptr(),
-        len: rustcall_bytes.len(),
-        cap: rustcall_bytes.capacity(),
-    };
-    ::std::mem::forget(rustcall_bytes);
-    rustcall_ret
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                let mut rustcall_bytes = unsafe { (*ptr).name.clone().into_bytes() };
+                let rustcall_ret = geometry__Rect_RustCallOwnedString {
+                    ptr: rustcall_bytes.as_mut_ptr(),
+                    len: rustcall_bytes.len(),
+                    cap: rustcall_bytes.capacity(),
+                };
+                ::std::mem::forget(rustcall_bytes);
+                rustcall_ret
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_geometry__Rect_get_name", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F6E616D65
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<geometry__Rect_RustCallOwnedString>() }
+        }
+    }
 }
 thread_local! {
     static __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_NEW : ::std::cell::RefCell <

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.rs
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.rs
@@ -16,6 +16,9 @@ pub extern "C" fn rustcall_add_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_ADD
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -84,6 +87,9 @@ pub extern "C" fn rustcall_shout_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_SHOUT
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -187,6 +193,9 @@ pub extern "C" fn rustcall_tag_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_TAG
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -269,6 +278,9 @@ pub extern "C" fn rustcall_echo_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_ECHO
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -371,6 +383,9 @@ pub extern "C" fn rustcall_parse_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_PARSE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -514,6 +529,9 @@ pub extern "C" fn rustcall_check_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_CHECK
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -656,6 +674,9 @@ pub extern "C" fn rustcall_divide_take_panic(out: *mut u8, cap: usize) -> usize 
     __RUSTCALL_PANIC_RUSTCALL_DIVIDE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -790,6 +811,9 @@ pub extern "C" fn rustcall_maybe_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_MAYBE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -904,6 +928,9 @@ pub extern "C" fn rustcall_note_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_NOTE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -972,6 +999,9 @@ pub extern "C" fn rustcall_geometry__area_take_panic(out: *mut u8, cap: usize) -
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__AREA
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1031,11 +1061,80 @@ pub extern "C" fn rustcall_geometry__area(w: f64, h: f64) -> f64 {
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_67656F6D657472795F5F526563745F66726565 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn geometry__Rect_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_67656F6D657472795F5F526563745F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn geometry__Rect_free(ptr: *mut user_crate::geometry::Rect) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Rect::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_67656F6D657472795F5F526563745F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -1103,6 +1202,9 @@ pub extern "C" fn rustcall_geometry__Rect_new_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1180,6 +1282,9 @@ pub extern "C" fn rustcall_geometry__Rect_unit_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_UNIT
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1255,6 +1360,9 @@ pub extern "C" fn rustcall_geometry__Rect_area_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_AREA
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1332,6 +1440,9 @@ pub extern "C" fn rustcall_geometry__Rect_scale_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_SCALE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1409,6 +1520,9 @@ pub extern "C" fn rustcall_geometry__Rect_label_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_LABEL
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1516,6 +1630,9 @@ pub extern "C" fn rustcall_geometry__Rect_scaled_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_SCALED
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1652,11 +1769,80 @@ pub extern "C" fn rustcall_geometry__Rect_scaled(
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_67656F6D657472795F5F436F756E7465725F66726565 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn geometry__Counter_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_67656F6D657472795F5F436F756E7465725F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn geometry__Counter_free(ptr: *mut user_crate::geometry::Counter) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Counter::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_67656F6D657472795F5F436F756E7465725F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -1673,6 +1859,9 @@ pub extern "C" fn rustcall_geometry__Counter_new_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__COUNTER_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1745,6 +1934,9 @@ pub extern "C" fn rustcall_geometry__Counter_describe_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__COUNTER_DESCRIBE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/strings.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/strings.expanded.rs
@@ -858,14 +858,153 @@ pub struct Greeter_RustCallBorrowedString {
     pub ptr: *const u8,
     pub len: usize,
 }
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_477265657465725F6765745F636F756E74 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_get_count_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_477265657465725F6765745F636F756E74
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Greeter_get_count(ptr: *const Greeter) -> u32 {
-    unsafe { (*ptr).count }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).count } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter_get_count", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_477265657465725F6765745F636F756E74
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<u32>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_477265657465725F7365745F636F756E74 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_set_count_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_477265657465725F7365745F636F756E74
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Greeter_set_count(ptr: *mut Greeter, value: u32) {
-    unsafe {
-        (*ptr).count = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).count = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter_set_count", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_477265657465725F7365745F636F756E74
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
 }
 thread_local! {

--- a/deps/rustcall_core/tests/corpus/strings.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/strings.expanded.rs
@@ -11,6 +11,9 @@ pub extern "C" fn rustcall_shout_take_panic(out: *mut u8, cap: usize) -> usize {
     __RUSTCALL_PANIC_RUSTCALL_SHOUT
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -123,6 +126,9 @@ pub extern "C" fn rustcall_concat_take_panic(out: *mut u8, cap: usize) -> usize 
     __RUSTCALL_PANIC_RUSTCALL_CONCAT
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -235,6 +241,9 @@ pub extern "C" fn rustcall_byte_len_take_panic(out: *mut u8, cap: usize) -> usiz
     __RUSTCALL_PANIC_RUSTCALL_BYTE_LEN
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -312,6 +321,9 @@ pub extern "C" fn rustcall_greeting_take_panic(out: *mut u8, cap: usize) -> usiz
     __RUSTCALL_PANIC_RUSTCALL_GREETING
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -401,6 +413,9 @@ pub extern "C" fn rustcall_unix_name_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_UNIX_NAME
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -511,6 +526,9 @@ pub extern "C" fn rustcall_consume_take_panic(out: *mut u8, cap: usize) -> usize
     __RUSTCALL_PANIC_RUSTCALL_CONSUME
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -589,6 +607,9 @@ pub extern "C" fn rustcall_paren_ref_take_panic(out: *mut u8, cap: usize) -> usi
     __RUSTCALL_PANIC_RUSTCALL_PAREN_REF
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -666,6 +687,9 @@ pub extern "C" fn rustcall_collide_take_panic(out: *mut u8, cap: usize) -> usize
     __RUSTCALL_PANIC_RUSTCALL_COLLIDE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -738,11 +762,80 @@ pub extern "C" fn rustcall_collide(
 pub struct Greeter {
     pub count: u32,
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_477265657465725F66726565 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_477265657465725F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Greeter_free(ptr: *mut Greeter) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_477265657465725F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -785,6 +878,9 @@ pub extern "C" fn rustcall_Greeter_new_take_panic(out: *mut u8, cap: usize) -> u
     __RUSTCALL_PANIC_RUSTCALL_GREETER_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -857,6 +953,9 @@ pub extern "C" fn rustcall_Greeter_shout_take_panic(out: *mut u8, cap: usize) ->
     __RUSTCALL_PANIC_RUSTCALL_GREETER_SHOUT
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -950,6 +1049,9 @@ pub extern "C" fn rustcall_Greeter_label_take_panic(out: *mut u8, cap: usize) ->
     __RUSTCALL_PANIC_RUSTCALL_GREETER_LABEL
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1031,6 +1133,9 @@ pub extern "C" fn rustcall_Greeter_take_take_panic(out: *mut u8, cap: usize) -> 
     __RUSTCALL_PANIC_RUSTCALL_GREETER_TAKE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
@@ -99,36 +99,388 @@ pub struct Greeter_RustCallBorrowedString {
     pub ptr: *const u8,
     pub len: usize,
 }
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_477265657465725F6765745F6E616D65 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_get_name_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_477265657465725F6765745F6E616D65
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Greeter_get_name(ptr: *const Greeter) -> Greeter_RustCallOwnedString {
-    let mut rustcall_bytes = unsafe { (*ptr).name.clone().into_bytes() };
-    let rustcall_ret = Greeter_RustCallOwnedString {
-        ptr: rustcall_bytes.as_mut_ptr(),
-        len: rustcall_bytes.len(),
-        cap: rustcall_bytes.capacity(),
-    };
-    std::mem::forget(rustcall_bytes);
-    rustcall_ret
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                let mut rustcall_bytes = unsafe { (*ptr).name.clone().into_bytes() };
+                let rustcall_ret = Greeter_RustCallOwnedString {
+                    ptr: rustcall_bytes.as_mut_ptr(),
+                    len: rustcall_bytes.len(),
+                    cap: rustcall_bytes.capacity(),
+                };
+                std::mem::forget(rustcall_bytes);
+                rustcall_ret
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter_get_name", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_477265657465725F6765745F6E616D65
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<Greeter_RustCallOwnedString>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_477265657465725F7365745F6E616D65 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_set_name_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_477265657465725F7365745F6E616D65
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Greeter_set_name(ptr: *mut Greeter, value: String) {
-    unsafe {
-        (*ptr).name = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).name = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter_set_name", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_477265657465725F7365745F6E616D65
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_477265657465725F6765745F766973697473 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_get_visits_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_477265657465725F6765745F766973697473
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Greeter_get_visits(ptr: *const Greeter) -> u32 {
-    unsafe { (*ptr).visits }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).visits } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter_get_visits", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_477265657465725F6765745F766973697473
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<u32>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_477265657465725F7365745F766973697473 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_set_visits_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_477265657465725F7365745F766973697473
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Greeter_set_visits(ptr: *mut Greeter, value: u32) {
-    unsafe {
-        (*ptr).visits = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).visits = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter_set_visits", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_477265657465725F7365745F766973697473
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_477265657465725F636C6F6E65 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_clone_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_477265657465725F636C6F6E65
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Greeter_clone(ptr: *const Greeter) -> *mut Greeter {
-    unsafe { Box::into_raw(Box::new((*ptr).clone())) }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            { unsafe { Box::into_raw(Box::new((*ptr).clone())) } }
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter_clone", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_477265657465725F636C6F6E65
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<*mut Greeter>() }
+        }
+    }
 }
 thread_local! {
     static __RUSTCALL_PANIC_RUSTCALL_GREETER_NEW : ::std::cell::RefCell <
@@ -844,14 +1196,153 @@ pub extern "C" fn Divider_free_rust_string(ptr: *mut u8, len: usize, cap: usize)
         }
     }
 }
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_446976696465725F6765745F7363616C65 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Divider_get_scale_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_446976696465725F6765745F7363616C65
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Divider_get_scale(ptr: *const Divider) -> i32 {
-    unsafe { (*ptr).scale }
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| { { unsafe { (*ptr).scale } } }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Divider_get_scale", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_446976696465725F6765745F7363616C65
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe { ::std::mem::zeroed::<i32>() }
+        }
+    }
+}
+thread_local! {
+    static __RUSTCALL_HELPER_PANIC_446976696465725F7365745F7363616C65 :
+    ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Divider_set_scale_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_HELPER_PANIC_446976696465725F7365745F7363616C65
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
 }
 #[no_mangle]
 pub extern "C" fn Divider_set_scale(ptr: *mut Divider, value: i32) {
-    unsafe {
-        (*ptr).scale = value;
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                unsafe {
+                    (*ptr).scale = value;
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Divider_set_scale", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_446976696465725F7365745F7363616C65
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+        }
     }
 }
 thread_local! {

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
@@ -223,10 +223,18 @@ pub extern "C" fn Greeter_set_name_take_panic(out: *mut u8, cap: usize) -> usize
         })
 }
 #[no_mangle]
-pub extern "C" fn Greeter_set_name(ptr: *mut Greeter, value: String) {
+pub extern "C" fn Greeter_set_name(
+    ptr: *mut Greeter,
+    value_ptr: *const u8,
+    value_len: usize,
+) {
     match ::std::panic::catch_unwind(
         ::std::panic::AssertUnwindSafe(|| {
             {
+                let value = unsafe {
+                    let slice = std::slice::from_raw_parts(value_ptr, value_len);
+                    String::from_utf8_lossy(slice).into_owned()
+                };
                 unsafe {
                     (*ptr).name = value;
                 }

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.expanded.rs
@@ -3,11 +3,80 @@ pub struct Greeter {
     pub name: String,
     pub visits: u32,
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_477265657465725F66726565 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Greeter_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_477265657465725F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Greeter_free(ptr: *mut Greeter) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Greeter::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_477265657465725F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -71,6 +140,9 @@ pub extern "C" fn rustcall_Greeter_new_take_panic(out: *mut u8, cap: usize) -> u
     __RUSTCALL_PANIC_RUSTCALL_GREETER_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -150,6 +222,9 @@ pub extern "C" fn rustcall_Greeter_rename_take_panic(out: *mut u8, cap: usize) -
     __RUSTCALL_PANIC_RUSTCALL_GREETER_RENAME
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -229,6 +304,9 @@ pub extern "C" fn rustcall_Greeter_greet_take_panic(out: *mut u8, cap: usize) ->
     __RUSTCALL_PANIC_RUSTCALL_GREETER_GREET
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -322,6 +400,9 @@ pub extern "C" fn rustcall_Greeter_name_take_panic(out: *mut u8, cap: usize) -> 
     __RUSTCALL_PANIC_RUSTCALL_GREETER_NAME
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -420,6 +501,9 @@ pub extern "C" fn rustcall_checked_double_take_panic(out: *mut u8, cap: usize) -
     __RUSTCALL_PANIC_RUSTCALL_CHECKED_DOUBLE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -558,6 +642,9 @@ pub extern "C" fn rustcall_positive_take_panic(out: *mut u8, cap: usize) -> usiz
     __RUSTCALL_PANIC_RUSTCALL_POSITIVE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -666,11 +753,80 @@ pub extern "C" fn rustcall_positive(value: i32) -> COption_positive {
 pub struct Divider {
     pub scale: i32,
 }
+thread_local! {
+    static __RUSTCALL_DROP_PANIC_446976696465725F66726565 : ::std::cell::RefCell <
+    ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn Divider_free_take_panic(out: *mut u8, cap: usize) -> usize {
+    __RUSTCALL_DROP_PANIC_446976696465725F66726565
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
 #[no_mangle]
 pub extern "C" fn Divider_free(ptr: *mut Divider) {
-    if !ptr.is_null() {
-        unsafe {
-            drop(Box::from_raw(ptr));
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            if !ptr.is_null() {
+                unsafe {
+                    drop(Box::from_raw(ptr));
+                }
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(_) => {}
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "Divider::drop", rustcall_message
+            );
+            __RUSTCALL_DROP_PANIC_446976696465725F66726565
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
         }
     }
 }
@@ -708,6 +864,9 @@ pub extern "C" fn rustcall_Divider_new_take_panic(out: *mut u8, cap: usize) -> u
     __RUSTCALL_PANIC_RUSTCALL_DIVIDER_NEW
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -783,6 +942,9 @@ pub extern "C" fn rustcall_Divider_checked_div_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_DIVIDER_CHECKED_DIV
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -941,6 +1103,9 @@ pub extern "C" fn rustcall_Divider_ratio_take_panic(out: *mut u8, cap: usize) ->
     __RUSTCALL_PANIC_RUSTCALL_DIVIDER_RATIO
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1065,6 +1230,9 @@ pub extern "C" fn rustcall_Divider_describe_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_DIVIDER_DESCRIBE
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -1240,6 +1408,9 @@ pub extern "C" fn rustcall_Divider_label_take_panic(out: *mut u8, cap: usize) ->
     __RUSTCALL_PANIC_RUSTCALL_DIVIDER_LABEL
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/corpus/syntax_stress.expanded.rs
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.expanded.rs
@@ -23,6 +23,9 @@ pub extern "C" fn rustcall_const_expression_take_panic(
     __RUSTCALL_PANIC_RUSTCALL_CONST_EXPRESSION
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -98,6 +101,9 @@ pub extern "C" fn rustcall_raw_braces_take_panic(out: *mut u8, cap: usize) -> us
     __RUSTCALL_PANIC_RUSTCALL_RAW_BRACES
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();
@@ -194,6 +200,9 @@ pub extern "C" fn rustcall_cfg_disabled_take_panic(out: *mut u8, cap: usize) -> 
     __RUSTCALL_PANIC_RUSTCALL_CFG_DISABLED
         .with(|rustcall_slot| {
             let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
             let rustcall_len = match rustcall_slot.as_ref() {
                 ::std::option::Option::Some(message) => {
                     let bytes = message.as_bytes();

--- a/deps/rustcall_core/tests/destructor_panics.rs
+++ b/deps/rustcall_core/tests/destructor_panics.rs
@@ -1,0 +1,108 @@
+use std::fs;
+use std::process::Command;
+
+use rustcall_core::codegen::transform_struct_crate;
+use rustcall_core::expand::expand;
+use rustcall_core::extract::extract;
+use rustcall_core::manifest::Mode;
+
+#[test]
+fn destructor_channels_participate_in_symbol_collisions() {
+    let source = r#"
+        #[julia] pub struct rustcall_Bomb;
+        #[julia] pub fn Bomb_free_take_panic() {}
+    "#;
+    assert!(extract(source, Mode::Crate).is_err());
+
+    let mixed = source.replace("#[julia] pub fn", "#[pyfunction] pub fn");
+    let manifest = extract(&mixed, Mode::Crate).unwrap();
+    assert!(manifest.functions[0]
+        .skip_reason
+        .starts_with("symbol_collision:"));
+
+    let pyo3 = mixed.replace("#[julia] pub struct", "#[pyclass] pub struct");
+    let manifest = extract(&pyo3, Mode::Crate).unwrap();
+    assert!(manifest.structs[0]
+        .skip_reason
+        .starts_with("symbol_collision:"));
+}
+
+#[test]
+fn generated_destructors_contain_panics_in_both_flavours() {
+    for flavour in ["inline", "crate"] {
+        let declarations = if flavour == "inline" {
+            expand("#[julia] pub struct Bomb; #[julia] pub struct bomb;")
+                .unwrap()
+                .source
+        } else {
+            let upper = transform_struct_crate(
+                syn::parse_quote!(
+                    pub struct Bomb;
+                ),
+                &[],
+            );
+            let lower = transform_struct_crate(
+                syn::parse_quote!(
+                    pub struct bomb;
+                ),
+                &[],
+            );
+            format!("{upper}\n{lower}")
+        };
+        let source = format!(
+            r#"
+            #![allow(non_camel_case_types, non_snake_case)]
+            {declarations}
+            impl Drop for Bomb {{
+                fn drop(&mut self) {{ panic!("destructor sentinel"); }}
+            }}
+            fn main() {{
+                let ptr = Box::into_raw(Box::new(Bomb));
+                Bomb_free(ptr);
+                let mut bytes = [0u8; 512];
+                let needed = Bomb_free_take_panic(std::ptr::null_mut(), 0);
+                assert!(needed > 0);
+                let n = Bomb_free_take_panic(bytes.as_mut_ptr(), bytes.len());
+                assert_eq!(n, needed);
+                let message = std::str::from_utf8(&bytes[..n]).unwrap();
+                assert!(message.contains("destructor sentinel"));
+                assert_eq!(Bomb_free_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+                Bomb_free(Box::into_raw(Box::new(Bomb)));
+                assert_eq!(Bomb_free_take_panic(std::ptr::null_mut(), usize::MAX), n);
+                assert_eq!(Bomb_free_take_panic(std::ptr::null_mut(), usize::MAX), 0);
+                Bomb_free(std::ptr::null_mut());
+                assert_eq!(Bomb_free_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+                bomb_free(Box::into_raw(Box::new(bomb)));
+                assert_eq!(bomb_free_take_panic(bytes.as_mut_ptr(), bytes.len()), 0);
+            }}
+            "#
+        );
+        let dir = std::env::temp_dir().join(format!(
+            "rustcall_destructor_panic_{}_{flavour}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("probe.rs");
+        let binary = dir.join(format!("probe{}", std::env::consts::EXE_SUFFIX));
+        fs::write(&input, source).unwrap();
+        let compile = Command::new("rustc")
+            .args(["--edition=2021", "-C", "panic=unwind"])
+            .arg(&input)
+            .arg("-o")
+            .arg(&binary)
+            .output()
+            .unwrap();
+        assert!(
+            compile.status.success(),
+            "{flavour}: {}",
+            String::from_utf8_lossy(&compile.stderr)
+        );
+        let run = Command::new(&binary).output().unwrap();
+        assert!(
+            run.status.success(),
+            "{flavour}: {}",
+            String::from_utf8_lossy(&run.stderr)
+        );
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/docs/STATE_AUDIT.md
+++ b/docs/STATE_AUDIT.md
@@ -29,6 +29,22 @@ helper must not be moved into a caller's outer transaction. The internal
 
 ## Mechanical and runtime checks
 
+The acceptance criteria of #251 map to the following checks. The snapshot
+extension in #362 also captures destructor panic readers outside STATE; its
+cold-lookup regression checks the old and replacement channels independently.
+
+| Acceptance criterion | Evidence to verify on the PR head |
+| --- | --- |
+| No independent module-level mutable registry | `the mutable runtime registry lives in one Lockable state (#251)` in `test_state.jl`, plus `scripts/lint_state_container.sh` |
+| Four-thread, bounds-checked concurrent compilation, calls, cache hits and reload | CI's `Bounds-checked state and mixed reload stress` step; `inline compile, calls and cache hits overlap reloads (#251)` in `test_hot_reload_transaction.jl` |
+| Documented lock ordering and no FFI/user callbacks under STATE | `RustCallState` docstring, the transaction audit above, AST transaction guard in `test_state.jl`, and the named callback/cold-resolution regressions in the table |
+
+The same CI step additionally runs `test_generic_reload.jl`: real Cargo
+reloads overlap calls and panics on retained generic objects, while new
+specializations and destructor counts are checked against their own images
+(#291). This complements, rather than substitutes for, the mixed compilation
+stress required by #251.
+
 - `test_state.jl` inspects actual module values, including nested containers,
   rather than recognizing only constructor spellings. Runtime registries and
   generated-module tables must be StateViews; immutable lookup tables remain

--- a/docs/src/panics.md
+++ b/docs/src/panics.md
@@ -244,6 +244,22 @@ different costs; this measurement does not rule them out. Automatic reclamation
 would need a complete protocol and workload-level evidence before replacing
 the explicit quiescence contract above.
 
+#### Build configuration probe cost (#291)
+
+The Cargo cfg probe is no longer memoized: `build.rs` can read inputs that a
+RustCall cache key cannot enumerate. `benchmark/benchmarks_cfg_probe.jl` measures
+the cost on an isolated dependency-free crate and checks that changing a file
+read by `build.rs` changes the next probe result without editing the script.
+Run it with `julia --project benchmark/benchmarks_cfg_probe.jl`.
+
+A local Darwin x86_64 / Julia 1.12.7 run on 2026-09-09 measured a 0.725 s first
+probe, a 0.075 s median over ten unchanged probes (range 0.073–0.108 s), and
+1.650 s after changing the build-script input. The first measurement includes
+Julia compilation; the changed-input measurement includes Cargo rebuild work.
+These are illustrative small-crate costs, not bounds for dependency-heavy
+workspaces. The probe happens during loading/building, not on each FFI call;
+the current decision accepts that cost to avoid a stale build configuration.
+
 ### The allocator contract
 
 An allocation made by one library must be released by **that same library**. A

--- a/docs/src/panics.md
+++ b/docs/src/panics.md
@@ -84,7 +84,7 @@ the session outright) and the Cargo path took Cargo's default — the same
 | `#[julia]` item in a `@rust_crate` crate **with** `cdylib` | Cargo, **the user's** manifest | `RustPanicError`, unless their profile pins `panic = "abort"` |
 | raw `#[no_mangle] extern "C" fn` you wrote yourself | either | **abort** — RustCall generates no wrapper, so there is no boundary |
 | a panic inside `Drop`, called by a generated destructor | either, with unwinding enabled | caught; a Julia finalizer increments `finalizer_failure_count()` |
-| a panic in a generated field accessor | either | **abort** (remaining #291 work) |
+| a panic in a generated field accessor or clone helper | either, with unwinding enabled | `RustPanicError` |
 
 Cases that can still abort:
 
@@ -94,8 +94,12 @@ Cases that can still abort:
 * **A crate that pins `panic = "abort"`.** RustCall does not write that crate's
   manifest and will not override the profile of a crate it merely builds. If
   you want the boundary, remove the pin from the crate's `[profile.release]`.
-* **Generated field accessors.** These still have no panic boundary. Completing
-  their coverage is tracked in #291 separately from generated destructors.
+
+Generated field accessors and clone helpers use the same unwind boundary as
+method wrappers. Their channel is captured before the call, and Julia reads it
+before converting an owned or borrowed string result. A caught panic does not
+roll back side effects: if a setter panics while dropping the old field value,
+do not assume the object still contains its previous value.
 
 A second panic during Rust's unwind cleanup can still abort; `catch_unwind`
 does not make double-panicking destructors safe.

--- a/docs/src/panics.md
+++ b/docs/src/panics.md
@@ -34,7 +34,7 @@ checked_div(Int32(9), Int32(3))     # 3 — the library is still usable
 
 ### How it works
 
-Every `extern "C"` wrapper RustCall generates for a `#[julia]` item runs the
+Every function/method wrapper RustCall generates for a `#[julia]` item runs the
 body inside `std::panic::catch_unwind`. On a panic the wrapper:
 
 1. records the message in a **thread-local channel of its own**, and
@@ -83,9 +83,10 @@ the session outright) and the Cargo path took Cargo's default — the same
 | `#[julia]` item in a `@rust_crate` crate **without** `cdylib` | Cargo, RustCall's wrapper manifest | `RustPanicError` |
 | `#[julia]` item in a `@rust_crate` crate **with** `cdylib` | Cargo, **the user's** manifest | `RustPanicError`, unless their profile pins `panic = "abort"` |
 | raw `#[no_mangle] extern "C" fn` you wrote yourself | either | **abort** — RustCall generates no wrapper, so there is no boundary |
-| a panic inside a `Drop` impl, or in a generated field accessor | either | **abort** |
+| a panic inside `Drop`, called by a generated destructor | either, with unwinding enabled | caught; a Julia finalizer increments `finalizer_failure_count()` |
+| a panic in a generated field accessor | either | **abort** (remaining #291 work) |
 
-Two rows abort, and both are visible from the source:
+Cases that can still abort:
 
 * **Raw `extern "C"`.** RustCall does not rewrite functions you export
   yourself; there is nothing between your body and the C ABI. Add `#[julia]` to
@@ -93,6 +94,11 @@ Two rows abort, and both are visible from the source:
 * **A crate that pins `panic = "abort"`.** RustCall does not write that crate's
   manifest and will not override the profile of a crate it merely builds. If
   you want the boundary, remove the pin from the crate's `[profile.release]`.
+* **Generated field accessors.** These still have no panic boundary. Completing
+  their coverage is tracked in #291 separately from generated destructors.
+
+A second panic during Rust's unwind cleanup can still abort; `catch_unwind`
+does not make double-panicking destructors safe.
 
 `RustCall.must_assume_unwind(policy)` answers "could a panic from this door
 reach Julia uncaught?" for any policy.
@@ -130,8 +136,9 @@ disabled to diagnose a segfault.
 
 The rules the finalizer follows, and why:
 
-* **It captures, it does not look up.** The destructor pointer and the
-  library's liveness flag are resolved at construction time and stored on the
+* **It captures, it does not look up.** The destructor pointer, its panic
+  channel and the library's liveness flag are resolved from one image at
+  construction time and stored on the
   object. A finalizer may run while the running thread holds
   `RustCall.REGISTRY_LOCK` — taking it would deadlock — and a `dlsym` plus
   method compilation inside a finalizer is exactly the crash class that made
@@ -143,6 +150,12 @@ The rules the finalizer follows, and why:
   An object outliving its image is inert, not a jump into freed text. Merely
   *unloading* does not flip it — the image is still mapped, so the object still
   frees correctly (see "Libraries are retired, not closed").
+* **A destructor panic is counted, not thrown from the finalizer.** The
+  generated Rust boundary catches it. The finalizer immediately consumes the
+  captured channel without allocating a Julia message buffer, then increments
+  `RustCall.finalizer_failure_count()`. No registry lookup, lock or Julia log
+  occurs between the destructor call and channel read. Rust's panic hook may
+  still write its diagnostic to stderr.
 * **A method call on a freed object raises**, rather than dereferencing a null
   pointer.
 

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -205,6 +205,8 @@ by library name.**
   its result with the replacement's ABI — a scalar read as a struct, which is
   memory corruption rather than a wrong answer.
 - `generation` — which generation of `lib_name` all of the above came from.
+- `free_channel` — the release/destructor's panic channel from that same image,
+  captured before allocation so an object's finalizer never resolves it later.
 """
 struct CallTarget
     func_ptr::Ptr{Cvoid}
@@ -216,7 +218,12 @@ struct CallTarget
     return_type::Union{Type, Nothing}
     func_info::Union{FunctionInfo, Nothing}
     generation::Int
+    free_channel::Ptr{Cvoid}
 end
+
+CallTarget(func_ptr, channel, free_ptr, alive, handle, lib_name, return_type, func_info, generation) =
+    CallTarget(func_ptr, channel, free_ptr, alive, handle, lib_name, return_type, func_info,
+               generation, C_NULL)
 
 """
     ArtifactGeneration
@@ -224,7 +231,7 @@ end
 The per-object half of a snapshot: what a `#[julia]` struct captures at
 construction so its finalizer needs no lookup at all (#249).
 
-`free_ptr` and `alive` must come from **one** generation: taken separately, an
+`free_ptr`, `free_channel` and `alive` must come from **one** generation: taken separately, an
 object could capture the destructor of the image it was allocated by and the
 liveness flag of the image that replaced it, and would then either skip a free
 it should have made or make one into an image that had been closed.
@@ -234,7 +241,11 @@ struct ArtifactGeneration
     free_ptr::Ptr{Cvoid}
     alive::Base.RefValue{Bool}
     generation::Int
+    free_channel::Ptr{Cvoid}
 end
+
+ArtifactGeneration(handle, free_ptr, alive, generation) =
+    ArtifactGeneration(handle, free_ptr, alive, generation, C_NULL)
 
 """
     PANIC_CHANNELS

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1893,21 +1893,31 @@ function _crate_field_read(info::RustStructInfo, field_name::AbstractString,
                            field_type::AbstractString, getter_symbol::AbstractString,
                            self_ptr_expr)
     c = _ffi_field_return(info, field_name, field_type)
-    ptr_expr = :(_get_func_ptr($(String(getter_symbol))))
+    name = String(getter_symbol)
     if ffi_owned_string_return(c)
         # Getter and release function from one snapshot: separately resolved,
         # a reload between them freed the buffer through the wrong image (#277).
         return quote
-            let (fp, _, freep) = _call_target($(String(getter_symbol)), $(c.free_symbol))
-                _call_rust_owned_string_ptr(fp, freep, $self_ptr_expr)
+            let (fp, channel, freep) = _call_target($name, $(c.free_symbol))
+                raw = _guard_panic(call_rust_function(fp, RustCall.CRustString, $self_ptr_expr), channel, $name)
+                RustCall._take_owned_string(raw, freep)
             end
         end
     elseif ffi_borrowed_string_return(c)
-        return :(_call_rust_borrowed_string_ptr($ptr_expr, $self_ptr_expr))
+        return quote
+            let (fp, channel) = _call_target($name)
+                raw = _guard_panic(call_rust_function(fp, RustCall.CRustStr, $self_ptr_expr), channel, $name)
+                RustCall._crust_str_to_julia(raw)
+            end
+        end
     end
     julia_type = ffi_return_symbol_or_throw(field_type, get(info.field_abis, field_name, ""),
                                             _ffi_field_context(info, field_name, field_type))
-    return :(call_rust_function($ptr_expr, $julia_type, $self_ptr_expr))
+    return quote
+        let (fp, channel) = _call_target($name)
+            _guard_panic(call_rust_function(fp, $julia_type, $self_ptr_expr), channel, $name)
+        end
+    end
 end
 
 """
@@ -1925,18 +1935,25 @@ conversion raises on a value that does not fit rather than reinterpreting it.
 function _crate_field_write(info::RustStructInfo, field_name::AbstractString,
                             field_type::AbstractString, setter_symbol::AbstractString,
                             self_ptr_expr, value_expr)
-    ptr_expr = :(_get_func_ptr($(String(setter_symbol))))
+    name = String(setter_symbol)
     c = _ffi_field_return(info, field_name, field_type)
     if ffi_owned_string_return(c) || ffi_borrowed_string_return(c)
         # A `String` field's setter takes the text itself, as a C string the
         # wrapper copies; the contract has no single-slot spelling for it and
         # there is nothing to convert.
-        return :(call_rust_function($ptr_expr, Cvoid, $self_ptr_expr, $value_expr))
+        return quote
+            let (fp, channel) = _call_target($name)
+                _guard_panic(call_rust_function(fp, Cvoid, $self_ptr_expr, $value_expr), channel, $name)
+            end
+        end
     end
     julia_type = ffi_return_symbol_or_throw(field_type, get(info.field_abis, field_name, ""),
                                             _ffi_field_context(info, field_name, field_type))
-    return :(call_rust_function($ptr_expr, Cvoid, $self_ptr_expr,
-                                convert($julia_type, $value_expr)))
+    return quote
+        let value = convert($julia_type, $value_expr), (fp, channel) = _call_target($name)
+            _guard_panic(call_rust_function(fp, Cvoid, $self_ptr_expr, value), channel, $name)
+        end
+    end
 end
 
 """
@@ -1947,16 +1964,17 @@ Source-text counterpart of `_crate_field_write` for the file emitter.
 function _crate_field_write_source(info::RustStructInfo, field_name::AbstractString,
                                    field_type::AbstractString, setter_symbol::AbstractString,
                                    self_ptr::String, value::String; strict::Symbol = FFI_STRICT[])
-    ptr_expr = "_get_func_ptr(\"$setter_symbol\")"
+    target = "(fp, channel) = _call_target(\"$setter_symbol\")"
     c = _ffi_field_return(info, field_name, field_type)
     if ffi_owned_string_return(c) || ffi_borrowed_string_return(c)
         # As in `_crate_field_write`: a string setter takes the text itself.
-        return "call_rust_function($ptr_expr, Cvoid, $self_ptr, $value)"
+        return "let $target; _guard_panic(call_rust_function(fp, Cvoid, $self_ptr, $value), channel, \"$setter_symbol\"); end"
     end
     julia_type = ffi_return_symbol_or_throw(field_type, get(info.field_abis, field_name, ""),
                                             _ffi_field_context(info, field_name, field_type);
                                             strict = strict)
-    return "call_rust_function($ptr_expr, Cvoid, $self_ptr, convert($julia_type, $value))"
+    return "let converted_value = convert($julia_type, $value), $target; " *
+           "_guard_panic(call_rust_function(fp, Cvoid, $self_ptr, converted_value), channel, \"$setter_symbol\"); end"
 end
 
 """
@@ -1968,18 +1986,20 @@ function _crate_field_read_source(info::RustStructInfo, field_name::AbstractStri
                                   field_type::AbstractString, getter_symbol::AbstractString,
                                   self_ptr::String; strict::Symbol = FFI_STRICT[])
     c = _ffi_field_return(info, field_name, field_type)
-    ptr_expr = "_get_func_ptr(\"$getter_symbol\")"
+    target = "(fp, channel) = _call_target(\"$getter_symbol\")"
     if ffi_owned_string_return(c)
         # Getter and release function from one snapshot (#277).
-        return "let (fp, _, freep) = _call_target(\"$getter_symbol\", \"$(c.free_symbol)\"); " *
-               "_call_rust_owned_string_ptr(fp, freep, $self_ptr); end"
+        return "let (fp, channel, freep) = _call_target(\"$getter_symbol\", \"$(c.free_symbol)\"); " *
+               "raw = _guard_panic(call_rust_function(fp, RustCall.CRustString, $self_ptr), channel, \"$getter_symbol\"); " *
+               "RustCall._take_owned_string(raw, freep); end"
     elseif ffi_borrowed_string_return(c)
-        return "_call_rust_borrowed_string_ptr($ptr_expr, $self_ptr)"
+        return "let $target; raw = _guard_panic(call_rust_function(fp, RustCall.CRustStr, $self_ptr), channel, \"$getter_symbol\"); " *
+               "RustCall._crust_str_to_julia(raw); end"
     end
     julia_type = ffi_return_symbol_or_throw(field_type, get(info.field_abis, field_name, ""),
                                             _ffi_field_context(info, field_name, field_type);
                                             strict = strict)
-    return "call_rust_function($ptr_expr, $julia_type, $self_ptr)"
+    return "let $target; _guard_panic(call_rust_function(fp, $julia_type, $self_ptr), channel, \"$getter_symbol\"); end"
 end
 
 """

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1937,10 +1937,18 @@ function _crate_field_write(info::RustStructInfo, field_name::AbstractString,
                             self_ptr_expr, value_expr)
     name = String(setter_symbol)
     c = _ffi_field_return(info, field_name, field_type)
-    if ffi_owned_string_return(c) || ffi_borrowed_string_return(c)
-        # A `String` field's setter takes the text itself, as a C string the
-        # wrapper copies; the contract has no single-slot spelling for it and
-        # there is nothing to convert.
+    if ffi_owned_string_return(c)
+        # Match the wrapper's byte pointer/length input; never pass Rust String
+        # by value or truncate an embedded NUL through a C string.
+        return quote
+            let text = RustCall.ffi_string_argument($value_expr, "value", $name),
+                (fp, channel) = _call_target($name)
+                GC.@preserve text begin
+                    _guard_panic(call_rust_function(fp, Cvoid, $self_ptr_expr, pointer(text), Csize_t(ncodeunits(text))), channel, $name)
+                end
+            end
+        end
+    elseif ffi_borrowed_string_return(c)
         return quote
             let (fp, channel) = _call_target($name)
                 _guard_panic(call_rust_function(fp, Cvoid, $self_ptr_expr, $value_expr), channel, $name)
@@ -1966,8 +1974,10 @@ function _crate_field_write_source(info::RustStructInfo, field_name::AbstractStr
                                    self_ptr::String, value::String; strict::Symbol = FFI_STRICT[])
     target = "(fp, channel) = _call_target(\"$setter_symbol\")"
     c = _ffi_field_return(info, field_name, field_type)
-    if ffi_owned_string_return(c) || ffi_borrowed_string_return(c)
-        # As in `_crate_field_write`: a string setter takes the text itself.
+    if ffi_owned_string_return(c)
+        return "let text = RustCall.ffi_string_argument($value, \"value\", \"$setter_symbol\"), $target; " *
+               "GC.@preserve text begin _guard_panic(call_rust_function(fp, Cvoid, $self_ptr, pointer(text), Csize_t(ncodeunits(text))), channel, \"$setter_symbol\"); end; end"
+    elseif ffi_borrowed_string_return(c)
         return "let $target; _guard_panic(call_rust_function(fp, Cvoid, $self_ptr, $value), channel, \"$setter_symbol\"); end"
     end
     julia_type = ffi_return_symbol_or_throw(field_type, get(info.field_abis, field_name, ""),

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1125,7 +1125,8 @@ function emit_crate_module(info::CrateInfo, lib_path::String;
             (_required_symbol(handle, symbol),
              _symbol(handle, RustCall.ffi_panic_symbol(symbol)),
              _symbol(handle, free_symbol),
-             gen.alive)
+             gen.alive,
+             _symbol(handle, RustCall.ffi_panic_symbol(free_symbol)))
         end
 
         # The per-object half: a struct's destructor and the liveness flag of
@@ -1134,8 +1135,9 @@ function emit_crate_module(info::CrateInfo, lib_path::String;
         # finalizer a no-op: a leak, not a crash (#249).
         function _struct_generation(free_symbol::String)
             gen = _LIB_GEN[]
-            gen.handle == C_NULL && return (C_NULL, gen.alive)
-            (_symbol(gen.handle, free_symbol), gen.alive)
+            gen.handle == C_NULL && return (C_NULL, gen.alive, C_NULL)
+            (_symbol(gen.handle, free_symbol), gen.alive,
+             _symbol(gen.handle, RustCall.ffi_panic_symbol(free_symbol)))
         end
 
         # The channel is resolved by the *caller*, before the wrapper call:
@@ -1822,6 +1824,7 @@ function _generate_crate_struct_wrapper(info::RustStructInfo;
             ptr::Ptr{Cvoid}
             free_ptr::Ptr{Cvoid}
             alive::Base.RefValue{Bool}
+            free_channel::Ptr{Cvoid}
 
             # The destructor and the liveness flag are handed in by the call
             # that allocated `ptr`, from that call's own snapshot: a finalizer
@@ -1829,16 +1832,16 @@ function _generate_crate_struct_wrapper(info::RustStructInfo;
             # them after the constructor returned could pair a pointer from the
             # retired image with the replacement's destructor (#277).
             function $struct_name(ptr::Ptr{Cvoid}, free_ptr::Ptr{Cvoid},
-                                  alive::Base.RefValue{Bool})
-                obj = new(ptr, free_ptr, alive)
+                                  alive::Base.RefValue{Bool}, free_channel::Ptr{Cvoid} = C_NULL)
+                obj = new(ptr, free_ptr, alive, free_channel)
                 finalizer(RustCall.finalize_rust_object!, obj)
                 return obj
             end
 
             # For a pointer that did not come from a call of this module.
             function $struct_name(ptr::Ptr{Cvoid})
-                free_ptr, alive = _struct_generation($(ffi_struct_free_symbol(info.ffi_name)))
-                return $struct_name(ptr, free_ptr, alive)
+                free_ptr, alive, free_channel = _struct_generation($(ffi_struct_free_symbol(info.ffi_name)))
+                return $struct_name(ptr, free_ptr, alive, free_channel)
             end
         end
         export $struct_name
@@ -2110,6 +2113,7 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
 
     channel_sym = _generated_local("panic_channel", method.arg_names)
     free_sym = _generated_local("free_ptr", method.arg_names)
+    free_channel_sym = _generated_local("free_panic_channel", method.arg_names)
     target = :(($ptr_sym, $channel_sym) = _call_target($wrapper_name))
     alive_sym = _generated_local("alive", method.arg_names)
     # A `PyResult` method needs a C struct declared next to the wrapper, so it
@@ -2151,10 +2155,10 @@ function _generate_crate_method_wrapper(info::RustStructInfo, method::RustMethod
     elseif method.returns_boxed_struct
         # Constructors and `Self`-returning methods allocate, so the object is
         # bound to the generation that ran the call (#277).
-        target = :(($ptr_sym, $channel_sym, $free_sym, $alive_sym) =
+        target = :(($ptr_sym, $channel_sym, $free_sym, $alive_sym, $free_channel_sym) =
                        _ctor_target($wrapper_name, $(ffi_struct_free_symbol(info.ffi_name))))
         :($struct_name(call_rust_function($ptr_sym, Ptr{Cvoid}, $(all_args...)),
-                       $free_sym, $alive_sym))
+                       $free_sym, $alive_sym, $free_channel_sym))
     elseif ffi_owned_string_return(c)
         target = :(($ptr_sym, $channel_sym, $free_sym) = _call_target($wrapper_name, $(c.free_symbol)))
         :(_call_rust_owned_string_ptr($ptr_sym, $free_sym, $(all_args...)))
@@ -3658,15 +3662,17 @@ function emit_crate_module_code(info::CrateInfo, lib_path::String;
     push!(lines, "    (_required_symbol(handle, symbol),")
     push!(lines, "     _symbol(handle, RustCall.ffi_panic_symbol(symbol)),")
     push!(lines, "     _symbol(handle, free_symbol),")
-    push!(lines, "     gen.alive)")
+    push!(lines, "     gen.alive,")
+    push!(lines, "     _symbol(handle, RustCall.ffi_panic_symbol(free_symbol)))")
     push!(lines, "end")
     push!(lines, "")
     push!(lines, "# A struct's destructor and the liveness flag of the image that exports it,")
     push!(lines, "# from the same deref (#249, #277).")
     push!(lines, "function _struct_generation(free_symbol::String)")
     push!(lines, "    gen = _LIB_GEN[]")
-    push!(lines, "    gen.handle == C_NULL && return (C_NULL, gen.alive)")
-    push!(lines, "    (_symbol(gen.handle, free_symbol), gen.alive)")
+    push!(lines, "    gen.handle == C_NULL && return (C_NULL, gen.alive, C_NULL)")
+    push!(lines, "    (_symbol(gen.handle, free_symbol), gen.alive,")
+    push!(lines, "     _symbol(gen.handle, RustCall.ffi_panic_symbol(free_symbol)))")
     push!(lines, "end")
     push!(lines, "")
     # The channel is resolved by the caller, before the wrapper call: it is a
@@ -3922,16 +3928,17 @@ function _emit_struct_code(info::RustStructInfo; strict::Symbol = FFI_STRICT[],
     # symbol and log nothing (#249).
     push!(lines, "    free_ptr::Ptr{Cvoid}")
     push!(lines, "    alive::Base.RefValue{Bool}")
+    push!(lines, "    free_channel::Ptr{Cvoid}")
     push!(lines, "")
-    push!(lines, "    function $struct_name(ptr::Ptr{Cvoid}, free_ptr::Ptr{Cvoid}, alive::Base.RefValue{Bool})")
-    push!(lines, "        obj = new(ptr, free_ptr, alive)")
+    push!(lines, "    function $struct_name(ptr::Ptr{Cvoid}, free_ptr::Ptr{Cvoid}, alive::Base.RefValue{Bool}, free_channel::Ptr{Cvoid} = C_NULL)")
+    push!(lines, "        obj = new(ptr, free_ptr, alive, free_channel)")
     push!(lines, "        finalizer(RustCall.finalize_rust_object!, obj)")
     push!(lines, "        return obj")
     push!(lines, "    end")
     push!(lines, "")
     push!(lines, "    function $struct_name(ptr::Ptr{Cvoid})")
-    push!(lines, "        free_ptr, alive = _struct_generation($(repr(ffi_struct_free_symbol(info.ffi_name))))")
-    push!(lines, "        return $struct_name(ptr, free_ptr, alive)")
+    push!(lines, "        free_ptr, alive, free_channel = _struct_generation($(repr(ffi_struct_free_symbol(info.ffi_name))))")
+    push!(lines, "        return $struct_name(ptr, free_ptr, alive, free_channel)")
     push!(lines, "    end")
     push!(lines, "end")
     push!(lines, "export $struct_name")
@@ -4073,6 +4080,7 @@ function _emit_method_code(struct_info::RustStructInfo, method::RustMethod;
 
     free_var = _generated_local("free_ptr", method.arg_names)
     channel_var = _generated_local("panic_channel", method.arg_names)
+    free_channel_var = _generated_local("free_panic_channel", method.arg_names)
     target = "$ptr_var, $channel_var = _call_target(\"$wrapper_name\")"
     alive_var = _generated_local("alive", method.arg_names)
     if method.return_kind === :py_result
@@ -4099,9 +4107,9 @@ $(_emit_payload_decode(plan, c_var, free_expr))"""
                                        predef = plan.source, bare = bare)
     end
     call = if method.returns_boxed_struct
-        target = "$ptr_var, $channel_var, $free_var, $alive_var = " *
+        target = "$ptr_var, $channel_var, $free_var, $alive_var, $free_channel_var = " *
                  "_ctor_target(\"$wrapper_name\", \"$(ffi_struct_free_symbol(struct_info.ffi_name))\")"
-        "$struct_name(call_rust_function($ptr_var, Ptr{Cvoid}, $args_str), $free_var, $alive_var)"
+        "$struct_name(call_rust_function($ptr_var, Ptr{Cvoid}, $args_str), $free_var, $alive_var, $free_channel_var)"
     elseif ffi_owned_string_return(c)
         target = "$ptr_var, $channel_var, $free_var = _call_target(\"$wrapper_name\", \"$(c.free_symbol)\")"
         "_call_rust_owned_string_ptr($ptr_var, $free_var, $args_str)"

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -109,6 +109,7 @@ function resolve_call_target(lib_name::String, func_name::String;
                              free_symbol::AbstractString = "",
                              _lookup = Libdl.dlsym)
     release_symbol = String(free_symbol)
+    release_channel_symbol = isempty(release_symbol) ? "" : ffi_panic_symbol(release_symbol)
     # Capture all generation-dependent metadata together. Cold symbol lookups
     # below use only these captured handles, even if publication retires them
     # before lookup finishes. Explicit close still requires caller quiescence.
@@ -119,6 +120,7 @@ function resolve_call_target(lib_name::String, func_name::String;
             panic_symbol = ffi_panic_symbol(symbol)
             channel = get(PANIC_CHANNELS, (owner, symbol), get(cache, panic_symbol, nothing))
             free_ptr = isempty(release_symbol) ? C_NULL : get(cache, release_symbol, nothing)
+            free_channel = isempty(release_symbol) ? C_NULL : get(cache, release_channel_symbol, nothing)
             return_type = get(FUNCTION_RETURN_TYPES_BY_LIB, (owner, func_name), nothing)
             valid_info(info) = info !== nothing && info.handle == handle &&
                 info.generation == get(ARTIFACT_GENERATIONS, info.lib_name, -1) &&
@@ -127,7 +129,7 @@ function resolve_call_target(lib_name::String, func_name::String;
             func_info = get(FUNCTION_REGISTRY_BY_LIB, (owner, func_name), nothing)
             valid_info(func_info) || (func_info = get(FUNCTION_REGISTRY, func_name, nothing))
             valid_info(func_info) || (func_info = nothing)
-            (; owner, handle, cache, symbol, panic_symbol, channel, free_ptr,
+            (; owner, handle, cache, symbol, panic_symbol, channel, free_ptr, free_channel,
                func_ptr = get(cache, symbol, nothing), return_type, func_info,
                alive = alive_ref_for_handle(handle, owner),
                generation = get(ARTIFACT_GENERATIONS, owner, 0))
@@ -137,10 +139,11 @@ function resolve_call_target(lib_name::String, func_name::String;
         # Keep the warmed preferred-library path independent of registry size.
         if preferred !== nothing && preferred.func_ptr !== nothing &&
            preferred.func_ptr != C_NULL && preferred.channel !== nothing &&
-           preferred.free_ptr !== nothing
+           preferred.free_ptr !== nothing && preferred.free_channel !== nothing
             return CallTarget(preferred.func_ptr, preferred.channel, preferred.free_ptr,
                               preferred.alive, preferred.handle, preferred.owner,
-                              preferred.return_type, preferred.func_info, preferred.generation)
+                              preferred.return_type, preferred.func_info, preferred.generation,
+                              preferred.free_channel)
         end
         others = [capture(owner, entry) for (owner, entry) in RUST_LIBRARIES if owner != lib_name]
         (preferred, others)
@@ -162,8 +165,10 @@ function resolve_call_target(lib_name::String, func_name::String;
     finish(row, ptr) = begin
         channel = resolve_in(row, row.panic_symbol, row.channel)
         free_ptr = isempty(release_symbol) ? C_NULL : resolve_in(row, release_symbol, row.free_ptr)
+        free_channel = isempty(release_symbol) ? C_NULL :
+                       resolve_in(row, release_channel_symbol, row.free_channel)
         CallTarget(ptr, channel, free_ptr, row.alive, row.handle, row.owner,
-                   row.return_type, row.func_info, row.generation)
+                   row.return_type, row.func_info, row.generation, free_channel)
     end
     if preferred !== nothing
         ptr = resolve_in(preferred, preferred.symbol, preferred.func_ptr)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -371,6 +371,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                 # that owns it is still loaded.
                 free_ptr::Ptr{Cvoid}
                 alive::Base.RefValue{Bool}
+                free_channel::Ptr{Cvoid}
 
                 # The destructor and the flag are handed in by the call that
                 # allocated `ptr`, from that call's own snapshot: resolving
@@ -379,8 +380,9 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                 # image with another image's `free` (#249, #277).
                 function $where_clause(ptr::Ptr{Cvoid}, lib::String,
                                        free_ptr::Ptr{Cvoid},
-                                       alive::Base.RefValue{Bool}) where {$(esc_T_params...)}
-                    obj = new{$(esc_T_params...)}(ptr, lib, free_ptr, alive)
+                                       alive::Base.RefValue{Bool},
+                                       free_channel::Ptr{Cvoid} = C_NULL) where {$(esc_T_params...)}
+                    obj = new{$(esc_T_params...)}(ptr, lib, free_ptr, alive, free_channel)
                     finalizer(RustCall.finalize_rust_object!, obj)
                     return obj
                 end
@@ -389,7 +391,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                 function $where_clause(ptr::Ptr{Cvoid}, lib::String) where {$(esc_T_params...)}
                     gen = RustCall.generic_struct_generation_snapshot(
                         $generic_free_name, ($(esc_T_params...),), lib)
-                    return $esc_struct{$(esc_T_params...)}(ptr, lib, gen.free_ptr, gen.alive)
+                    return $esc_struct{$(esc_T_params...)}(ptr, lib, gen.free_ptr, gen.alive, gen.free_channel)
                 end
             end
         end)
@@ -430,7 +432,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                                  $wrapper_name, $struct_name_str,
                                  ($(esc_args...),), ($(esc_T_params...),))
                              return $esc_struct{$(esc_T_params...)}(ptr_val, lib_val,
-                                                                    gen.free_ptr, gen.alive)
+                                                                    gen.free_ptr, gen.alive, gen.free_channel)
                          end
                      end)
                  end
@@ -529,6 +531,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
             lib_name::String
             free_ptr::Ptr{Cvoid}
             alive::Base.RefValue{Bool}
+            free_channel::Ptr{Cvoid}
 
             # The one that matters: the destructor and the liveness flag are
             # handed in by the caller, taken from the *same* snapshot as the
@@ -537,8 +540,9 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
             # between would bind a pointer from the retired image to the
             # replacement's destructor (#249, #277).
             function $esc_struct(ptr::Ptr{Cvoid}, lib::String,
-                                 free_ptr::Ptr{Cvoid}, alive::Base.RefValue{Bool})
-                obj = new(ptr, lib, free_ptr, alive)
+                                 free_ptr::Ptr{Cvoid}, alive::Base.RefValue{Bool},
+                                 free_channel::Ptr{Cvoid} = C_NULL)
+                obj = new(ptr, lib, free_ptr, alive, free_channel)
                 finalizer(RustCall.finalize_rust_object!, obj)
                 return obj
             end
@@ -548,7 +552,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
             # which is the best it can do.
             function $esc_struct(ptr::Ptr{Cvoid}, lib::String)
                 gen = RustCall.artifact_generation_snapshot(lib, $struct_stem)
-                return $esc_struct(ptr, lib, gen.free_ptr, gen.alive)
+                return $esc_struct(ptr, lib, gen.free_ptr, gen.alive, gen.free_channel)
             end
         end
     end)
@@ -582,7 +586,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                         # that allocates, its panic channel, and the destructor
                         # and liveness flag the object will carry (#277).
                         ptr, tgt = GC.@preserve $(preserved...) _call_rust_constructor(lib, $wrapper_name, $struct_stem, $(expanded_call_args...))
-                        return $esc_struct(ptr, tgt.lib_name, tgt.free_ptr, tgt.alive)
+                        return $esc_struct(ptr, tgt.lib_name, tgt.free_ptr, tgt.alive, tgt.free_channel)
                     end
                 end)
             elseif m.return_kind === :result || m.return_kind === :option
@@ -672,7 +676,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                             # is bound to the generation that ran it, exactly
                             # like a constructor (#277).
                             res, tgt = GC.@preserve self $(preserved...) _call_rust_constructor(self.lib_name, $wrapper_name, $struct_stem, self.ptr, $(expanded_call_args...))
-                            return $esc_struct(res, tgt.lib_name, tgt.free_ptr, tgt.alive)
+                            return $esc_struct(res, tgt.lib_name, tgt.free_ptr, tgt.alive, tgt.free_channel)
                         else
                             return GC.@preserve self $(preserved...) _call_rust_method(self.lib_name, $wrapper_name, self.ptr, $jl_ret_type, $(expanded_call_args...))
                         end
@@ -789,7 +793,7 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                     # that cloned it (#277).
                     ptr, tgt = GC.@preserve self _call_rust_constructor(
                         self.lib_name, $clone_name, $struct_stem, self.ptr)
-                    return $esc_struct(ptr, tgt.lib_name, tgt.free_ptr, tgt.alive)
+                    return $esc_struct(ptr, tgt.lib_name, tgt.free_ptr, tgt.alive, tgt.free_channel)
                 end
             end)
         end
@@ -956,14 +960,15 @@ function artifact_generation_snapshot(lib_name::AbstractString,
                                       struct_name::AbstractString)
     name = String(lib_name)
     symbol = ffi_struct_free_symbol(struct_name)
-    handle, cache, free_ptr, alive, generation = lock(REGISTRY_LOCK) do
+    channel_symbol = ffi_panic_symbol(symbol)
+    handle, cache, free_ptr, free_channel, alive, generation = lock(REGISTRY_LOCK) do
         alive = get!(() -> Ref(true), ARTIFACT_ALIVE, name)
         generation = get(ARTIFACT_GENERATIONS, name, 0)
         entry = get(RUST_LIBRARIES, name, nothing)
-        entry === nothing && return (C_NULL, nothing, C_NULL, alive, generation)
+        entry === nothing && return (C_NULL, nothing, C_NULL, C_NULL, alive, generation)
         handle, cache = entry
         free_ptr = get(cache, symbol, C_NULL)
-        (handle, cache, free_ptr, alive, generation)
+        (handle, cache, free_ptr, get(cache, channel_symbol, nothing), alive, generation)
     end
     if handle != C_NULL && free_ptr == C_NULL
         found = try
@@ -979,7 +984,14 @@ function artifact_generation_snapshot(lib_name::AbstractString,
             end
         end
     end
-    return ArtifactGeneration(handle, free_ptr, alive, generation)
+    if handle != C_NULL && free_channel === nothing
+        found = Libdl.dlsym(handle, channel_symbol; throw_error = false)
+        free_channel = found === nothing ? C_NULL : found
+        lock(REGISTRY_LOCK) do
+            cache[channel_symbol] = free_channel
+        end
+    end
+    return ArtifactGeneration(handle, free_ptr, alive, generation, free_channel)
 end
 
 """
@@ -996,7 +1008,8 @@ The order is the contract:
 3. bail out if the library is gone: `unload_artifact!` flipped the captured
    liveness flag, and calling into a `dlclose`d image is a jump into freed
    text, which is worse than the leak;
-4. call the captured destructor, counting rather than logging a failure.
+4. call the captured destructor and immediately consume its captured panic
+   channel, counting rather than logging a failure.
 
 No lock, no lookup, no allocation on the success path.
 """
@@ -1007,8 +1020,13 @@ function finalize_rust_object!(x)
     getfield(x, :alive)[] || return nothing
     free_ptr = getfield(x, :free_ptr)
     free_ptr == C_NULL && return nothing
+    free_channel = hasfield(typeof(x), :free_channel) ? getfield(x, :free_channel) : C_NULL
     try
         ccall(free_ptr, Cvoid, (Ptr{Cvoid},), ptr)
+        if free_channel != C_NULL
+            failed = ccall(free_channel, Csize_t, (Ptr{UInt8}, Csize_t), C_NULL, typemax(Csize_t))
+            failed > 0 && Threads.atomic_add!(FINALIZER_FREE_FAILURES, 1)
+        end
     catch
         Threads.atomic_add!(FINALIZER_FREE_FAILURES, 1)
     end
@@ -1016,7 +1034,7 @@ function finalize_rust_object!(x)
 end
 
 """
-    _generic_struct_free_target(free_name, types) -> (free_ptr, lib_name, handle, generation)
+    _generic_struct_free_target(free_name, types) -> (free_ptr, lib_name, handle, generation, channel)
 
 The destructor of one instantiation of a generic `#[julia]` struct, resolved by
 monomorphizing it **at construction time**, together with the image it came
@@ -1032,7 +1050,7 @@ Not called directly by generated code: `generic_struct_generation_snapshot`
 pairs the pointer with the liveness flag of `handle` under one lock, which is
 the value a constructor may capture.
 
-`(C_NULL, "", C_NULL, 0)` when the generic destructor is not registered — a
+`(C_NULL, "", C_NULL, 0, C_NULL)` when the generic destructor is not registered — a
 struct whose `_free` wrapper the extractor did not emit.
 """
 function _generic_struct_free_target(free_name::AbstractString, types::Tuple)
@@ -1041,17 +1059,17 @@ function _generic_struct_free_target(free_name::AbstractString, types::Tuple)
         generic_info = lock(REGISTRY_LOCK) do
             get(GENERIC_FUNCTION_REGISTRY, name, nothing)
         end
-        generic_info === nothing && return (C_NULL, "", C_NULL, 0)
+        generic_info === nothing && return (C_NULL, "", C_NULL, 0, C_NULL)
         type_params = Dict{Symbol, Type}()
         for (i, p) in enumerate(generic_info.type_params)
             type_params[p] = types[i]
         end
         info = get_monomorphized_function(name, type_params)
         info === nothing && (info = monomorphize_function(name, type_params))
-        (info.func_ptr, info.lib_name, info.handle, info.generation)
+        (info.func_ptr, info.lib_name, info.handle, info.generation, info.channel)
     catch e
         @debug "Could not resolve the destructor of $(free_name)" exception = e
-        (C_NULL, "", C_NULL, 0)
+        (C_NULL, "", C_NULL, 0, C_NULL)
     end
 end
 
@@ -1072,13 +1090,13 @@ leaks rather than calling into unmapped memory.
 """
 function generic_struct_generation_snapshot(free_name::AbstractString, types::Tuple,
                                             fallback_lib::AbstractString)
-    free_ptr, free_lib, handle, generation = _generic_struct_free_target(free_name, types)
+    free_ptr, free_lib, handle, generation, free_channel = _generic_struct_free_target(free_name, types)
     name = isempty(free_lib) ? String(fallback_lib) : free_lib
     return lock(REGISTRY_LOCK) do
         free_ptr == C_NULL &&
             return ArtifactGeneration(C_NULL, C_NULL, _state_read(DEAD_ARTIFACT, identity), generation)
         return ArtifactGeneration(handle, free_ptr, alive_ref_for_handle(handle, name),
-                                  generation)
+                                  generation, free_channel)
     end
 end
 
@@ -1285,7 +1303,7 @@ function _call_generic_constructor(func_name::String, struct_name::AbstractStrin
     if free_info !== nothing && free_info.handle == handle && free_info.lib_name == lib_name
         gen = lock(REGISTRY_LOCK) do
             ArtifactGeneration(handle, free_info.func_ptr,
-                               alive_ref_for_handle(handle, lib_name), generation)
+                               alive_ref_for_handle(handle, lib_name), generation, free_info.channel)
         end
         return (ptr, lib_name, gen)
     end
@@ -1294,9 +1312,11 @@ function _call_generic_constructor(func_name::String, struct_name::AbstractStrin
           (found = Libdl.dlsym(handle, free_symbol; throw_error = false);
            found === nothing ? C_NULL : found)
     if own != C_NULL
+        found = Libdl.dlsym(handle, ffi_panic_symbol(free_symbol); throw_error = false)
+        free_channel = found === nothing ? C_NULL : found
         gen = lock(REGISTRY_LOCK) do
             ArtifactGeneration(handle, own, alive_ref_for_handle(handle, lib_name),
-                               generation)
+                               generation, free_channel)
         end
         return (ptr, lib_name, gen)
     end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -770,6 +770,17 @@ function emit_julia_definitions(info::RustStructInfo; colliding::Set{String} = S
                     RustCall.check_not_freed(self, $struct_name_str)
                     setter_name = field_setters_map[field]
                     lib = self.lib_name
+                    field_info = $(QuoteNode(field_getters))
+                    if field_info[field][2] === :owned_string
+                        text = RustCall.ffi_string_argument(value, "value", setter_name)
+                        target = RustCall.resolve_call_target(lib, setter_name)
+                        GC.@preserve self text begin
+                            RustCall.guard_rust_panic_ptr(
+                                call_rust_function(target.func_ptr, Cvoid, self.ptr, pointer(text), Csize_t(ncodeunits(text))),
+                                target.channel, setter_name)
+                        end
+                        return value
+                    end
                     target = RustCall.resolve_call_target(lib, setter_name)
                     RustCall.guard_rust_panic_ptr(
                         GC.@preserve(self,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1379,10 +1379,9 @@ function _call_generic_field(lib_name::String, func_name::String, ptr::Ptr{Cvoid
     end
 
     info = monomorphize_function(func_name, type_params)
-    # A `String` field getter returns an owned buffer (#242); other fields
-    # use the type resolved from the struct's parameters.
-    info.string_return === :none || return _call_monomorphized(info, ptr)
-    return call_rust_function(info.func_ptr, ret_type, ptr)
+    # The specialization owns both the return ABI and the panic channel,
+    # including for a primitive field in this legacy registration path.
+    return _call_monomorphized(info, ptr)
 end
 
 function _resolve_generic_struct_field_type(field_type::String, type_param_names, type_param_values::Tuple)

--- a/test/test_accessor_panics.jl
+++ b/test/test_accessor_panics.jl
@@ -1,6 +1,55 @@
 using RustCall
 using Test
 
+@testset "String field setters use byte pairs (#291)" begin
+    scope = Module(gensym(:StringSetter291))
+    Core.eval(scope, :(using RustCall))
+    source = raw"""
+        #[julia] pub struct TextSetter291 { pub text: String }
+        #[julia] impl TextSetter291 {
+            pub fn new() -> Self { Self { text: String::new() } }
+        }
+        """
+    lib = Core.eval(scope, Expr(:macrocall, Symbol("@rust_str"), LineNumberNode(1), source))
+    object = Base.invokelatest(Base.invokelatest(getfield, scope, :TextSetter291))
+    info = RustCall.RustStructInfo(
+        "TextSetter291", String[], RustCall.RustMethod[], "",
+        [("text", "String")], true, Dict{String, Bool}();
+        field_abis = Dict("text" => "string"), has_owned_string_helper = true)
+    try
+        Core.eval(scope, quote
+            import RustCall: call_rust_function
+            const library = $lib
+            function _call_target(name)
+                target = RustCall.resolve_call_target(library, name)
+                (target.func_ptr, target.channel)
+            end
+            _guard_panic(value, channel, name) = RustCall.guard_rust_panic_ptr(value, channel, name)
+        end)
+        for flavour in (:inline, :ast, :source)
+            if flavour !== :inline
+                body = flavour === :ast ?
+                    RustCall._crate_field_write(info, "text", "String", "TextSetter291_set_text", :ptr, :value) :
+                    Meta.parse(RustCall._crate_field_write_source(info, "text", "String", "TextSetter291_set_text", "ptr", "value"))
+                Core.eval(scope, :(function set_text(ptr, value); $body; end))
+            end
+            setter(value) = flavour === :inline ?
+                Base.invokelatest(setproperty!, object, :text, value) :
+                GC.@preserve object Base.invokelatest(Base.invokelatest(getfield, scope, :set_text), getfield(object, :ptr), value)
+            for text in ("日本語\0末尾", "", "replacement")
+                setter(text)
+                @test Base.invokelatest(getproperty, object, :text) == text
+            end
+            @test_throws RustCall.RustError setter(String(UInt8[0xff]))
+            @test Base.invokelatest(getproperty, object, :text) == "replacement"
+        end
+    finally
+        finalize(object)
+        RustCall.unload_library(lib; close = true)
+        RustCall.close_retired_handles!(RustCall.retired_handles(lib))
+    end
+end
+
 @testset "both crate field emitters propagate panic channels (#291)" begin
     # The Rust tests exercise panicking Clone/Drop in generated accessors.
     # Here real guarded Rust functions stand in for accessor symbols so every

--- a/test/test_accessor_panics.jl
+++ b/test/test_accessor_panics.jl
@@ -1,0 +1,96 @@
+using RustCall
+using Test
+
+@testset "both crate field emitters propagate panic channels (#291)" begin
+    # The Rust tests exercise panicking Clone/Drop in generated accessors.
+    # Here real guarded Rust functions stand in for accessor symbols so every
+    # Julia field ABI, including borrowed text, can deterministically panic.
+    source = raw"""
+        #[julia] pub fn fail_number(_ptr: *const i32) -> i32 { panic!("number accessor"); }
+        #[julia] pub fn fail_text(_ptr: *const i32) -> String { panic!("text accessor"); }
+        #[julia] pub fn fail_borrowed(_ptr: *const i32) -> &'static str { panic!("borrowed accessor"); }
+        #[julia] pub fn fail_set(_ptr: *mut i32, _value: i32) { panic!("setter accessor"); }
+        #[julia] pub fn good_number(ptr: *const i32) -> i32 { unsafe { *ptr } }
+        """
+    lib = RustCall._compile_and_load_rust(source, "accessor_channels_291", 1)
+    info = RustCall.RustStructInfo(
+        "AccessorProbe", String[], RustCall.RustMethod[], "",
+        [("number", "i32"), ("text", "String"), ("borrowed", "&str")],
+        true, Dict{String, Bool}();
+        field_abis = Dict("text" => "string", "borrowed" => "str"),
+        has_owned_string_helper = true, has_borrowed_string_helper = true)
+    try
+        for flavour in (:ast, :source)
+            scope = Module(gensym(:AccessorChannels291))
+            Core.eval(scope, quote
+                using RustCall
+                import RustCall: call_rust_function
+                const library = $lib
+                function _call_target(name, release = "")
+                    # This fixture has only one String producer. The emitter
+                    # still has to request and use a release pointer snapshot.
+                    free = isempty(release) ? "" : "fail_text_free_rust_string"
+                    target = RustCall.resolve_call_target(library, name; free_symbol = free)
+                    isempty(release) || @assert target.free_ptr != C_NULL
+                    isempty(release) ? (target.func_ptr, target.channel) :
+                        (target.func_ptr, target.channel, target.free_ptr)
+                end
+                _guard_panic(value, channel, name) = RustCall.guard_rust_panic_ptr(value, channel, name)
+            end)
+            for (field, type, symbol) in (("number", "i32", "rustcall_fail_number"),
+                                         ("text", "String", "rustcall_fail_text"),
+                                         ("borrowed", "&str", "rustcall_fail_borrowed"),
+                                         ("number", "i32", "rustcall_good_number"))
+                name = Symbol(symbol)
+                body = flavour === :ast ?
+                    RustCall._crate_field_read(info, field, type, symbol, :ptr) :
+                    Meta.parse(RustCall._crate_field_read_source(info, field, type, symbol, "ptr"))
+                Core.eval(scope, :(function $name(ptr); $body; end))
+            end
+            body = flavour === :ast ?
+                RustCall._crate_field_write(info, "number", "i32", "rustcall_fail_set", :ptr, :value) :
+                Meta.parse(RustCall._crate_field_write_source(info, "number", "i32", "rustcall_fail_set", "ptr", "value"))
+            Core.eval(scope, :(function set_number(ptr, value); $body; end))
+            storage = Ref{Int32}(42)
+            GC.@preserve storage begin
+                ptr = Base.unsafe_convert(Ptr{Int32}, storage)
+                for name in (:rustcall_fail_number, :rustcall_fail_text, :rustcall_fail_borrowed)
+                    f = Base.invokelatest(getfield, scope, name)
+                    for _ in 1:2
+                        @test_throws RustCall.RustPanicError Base.invokelatest(f, ptr)
+                        target = RustCall.resolve_call_target(lib, String(name))
+                        @test RustCall.guard_rust_panic_ptr(nothing, target.channel, String(name)) === nothing
+                    end
+                end
+                @test_throws RustCall.RustPanicError Base.invokelatest(Base.invokelatest(getfield, scope, :set_number), ptr, 7)
+                @test Base.invokelatest(Base.invokelatest(getfield, scope, :rustcall_good_number), ptr) == 42
+            end
+        end
+    finally
+        RustCall.unload_library(lib; close = true)
+        RustCall.close_retired_handles!(RustCall.retired_handles(lib))
+    end
+end
+
+@testset "legacy generic field propagates panics (#291)" begin
+    scope = Module(gensym(:InlineAccessor291))
+    Core.eval(scope, :(using RustCall))
+    source = raw"""
+        #[julia] pub fn accessor_fixture291() -> i32 { 1 }
+        #[julia]
+        pub fn legacy_field_panic291<T>(_ptr: *const T) -> i32 {
+            panic!("legacy generic field panic");
+        }
+        """
+    lib = Core.eval(scope, Expr(:macrocall, Symbol("@rust_str"), LineNumberNode(1), source))
+    try
+        # No grouped object record: exercise the compatibility fallback, whose
+        # primitive-return branch used to bypass the specialization's channel.
+        @test_throws RustCall.RustPanicError RustCall._call_generic_field(
+            "ungrouped_accessor291", "legacy_field_panic291", Ptr{Cvoid}(C_NULL),
+            Int32, (Int32,), Ref(true))
+    finally
+        RustCall.unload_library(lib; close = true)
+        RustCall.close_retired_handles!(RustCall.retired_handles(lib))
+    end
+end

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -210,15 +210,31 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
         @test RustCall.compute_crate_hash(info; release = false) != hash1
 
         # The whole crate directory is an input, not just the scanned .rs files:
-        # a new file in the crate changes the key.
-        probe = joinpath(info.path, "rc278_probe.txt")
-        try
-            write(probe, "an input the scan never lists")
-            RustCall._artifact_reset_digest_caches!()
-            @test RustCall.compute_crate_hash(info) != hash1
-        finally
-            rm(probe; force = true)
-            RustCall._artifact_reset_digest_caches!()
+        # a new file in the crate changes the key. Never mutate the shared
+        # sample: another worker's precompile image tracks its directory, so
+        # even a temporary probe can invalidate an otherwise unchanged image.
+        mktempdir() do dir
+            mkpath(joinpath(dir, "src"))
+            write(joinpath(dir, "Cargo.toml"), """
+                [package]
+                name = "isolated_hash_probe"
+                version = "0.1.0"
+                edition = "2021"
+                """)
+            write(joinpath(dir, "src", "lib.rs"), "pub fn value() -> i32 { 1 }\n")
+            isolated = RustCall.scan_crate(dir)
+            RustCall.compute_crate_hash(isolated) # materialize Cargo.lock
+            original = RustCall.compute_crate_hash(isolated)
+            probe = joinpath(dir, "rc278_probe.txt")
+            try
+                write(probe, "an input the scan never lists")
+                RustCall._artifact_reset_digest_caches!()
+                @test RustCall.compute_crate_hash(isolated) != original
+            finally
+                rm(probe; force = true)
+                RustCall._artifact_reset_digest_caches!()
+            end
+            @test RustCall.compute_crate_hash(isolated) == original
         end
         @test RustCall.compute_crate_hash(info) == hash1
     end
@@ -1205,9 +1221,11 @@ end
     @test occursin("GC.@preserve(self, __rustcall_str_name, _call_rust_owned_string_ptr", string(RustCall._generate_crate_method_wrapper(labeler_info, label_method)))
     # Constructors still return the boxed struct
     # A boxed-struct result is bound to the generation that allocated it: the
-    # destructor and the flag come from the constructor's own snapshot (#277).
-    @test occursin("Labeler(call_rust_function(func_ptr, Ptr{Cvoid}, UInt32(count)), free_ptr, alive)", code)
-    @test occursin("Point(call_rust_function(func_ptr, Ptr{Cvoid}, Float64(x), Float64(y)), free_ptr, alive)", code)
+    # destructor, its panic channel and the flag come from the constructor's
+    # own snapshot (#277, #291).
+    @test occursin("Labeler(call_rust_function(func_ptr, Ptr{Cvoid}, UInt32(count)), free_ptr, alive, free_panic_channel)", code)
+    @test occursin("Point(call_rust_function(func_ptr, Ptr{Cvoid}, Float64(x), Float64(y)), free_ptr, alive, free_panic_channel)", code)
+    @test occursin("func_ptr, panic_channel, free_ptr, alive, free_panic_channel = _ctor_target", code)
     @test occursin("_ctor_target(\"rustcall_Point_new\", \"Point_free\")", code)
     @test Meta.parse(code) isa Expr
 

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -890,7 +890,8 @@ end
 
         code = RustCall._emit_struct_code(info)
         @test occursin("_call_target(\"rustcall_Tagged_label\", \"Tagged_free_rust_string\")", code)
-        @test occursin("_call_rust_owned_string_ptr(fp, freep, getfield(self, :ptr))", code)
+        @test occursin("_guard_panic(call_rust_function(fp, RustCall.CRustString, getfield(self, :ptr)), channel,", code)
+        @test occursin("RustCall._take_owned_string(raw, freep)", code)
         # ...and never the two-lookup form it replaced.
         @test !occursin("_get_func_ptr(\"Tagged_free_rust_string\")", code)
         @test Meta.parse("module M\n" * code * "\nend") isa Expr

--- a/test/test_destructor_panics.jl
+++ b/test/test_destructor_panics.jl
@@ -1,0 +1,182 @@
+using RustCall
+using Test
+
+include(joinpath(@__DIR__, "pyo3_wrapper_helpers.jl"))
+
+@testset "generated destructor panics are counted without STATE (#291)" begin
+    source = raw"""
+        #[julia]
+        pub struct DropBomb291 { fail: bool }
+        impl DropBomb291 {
+            pub fn new(fail: bool) -> Self { Self { fail } }
+        }
+        impl Drop for DropBomb291 {
+            fn drop(&mut self) {
+                if self.fail { panic!("ordinary destructor panic"); }
+            }
+        }
+        #[julia]
+        pub struct GenericDropBomb291<T> { value: T }
+        #[julia]
+        impl<T> GenericDropBomb291<T> {
+            pub fn new(value: T) -> Self { Self { value } }
+        }
+        impl<T> Drop for GenericDropBomb291<T> {
+            fn drop(&mut self) { panic!("generic destructor panic"); }
+        }
+        """
+    # An absent Rust catch boundary aborts a process, so exercise the actual
+    # generated FFI entries in a child rather than killing the test worker.
+    script = """
+        using RustCall, Test
+        Core.eval(Main, Expr(:macrocall, Symbol("@rust_str"), LineNumberNode(1), $(repr(source))))
+        bomb = Base.invokelatest(DropBomb291, true)
+        quiet = Base.invokelatest(DropBomb291, false)
+        generic = Base.invokelatest(GenericDropBomb291{Int32}, Int32(1))
+        @test getfield(bomb, :free_channel) != C_NULL
+        @test getfield(generic, :free_channel) != C_NULL
+        before = RustCall.finalizer_failure_count()
+        task = lock(RustCall.REGISTRY_LOCK) do
+            task = Threads.@spawn finalize(bomb)
+            @test timedwait(() -> istaskdone(task), 5.0) == :ok
+            task
+        end
+        fetch(task)
+        @test getfield(bomb, :ptr) == C_NULL
+        @test RustCall.finalizer_failure_count() == before + 1
+        finalize(bomb)
+        finalize(quiet)
+        @test RustCall.finalizer_failure_count() == before + 1
+
+        # Retire its image before finalizing: the channel, destructor and
+        # liveness must all remain those captured by this object's allocator.
+        lib = getfield(generic, :lib_name)
+        RustCall.unload_library(lib)
+        @test getfield(generic, :alive)[]
+        finalize(generic)
+        @test getfield(generic, :ptr) == C_NULL
+        @test RustCall.finalizer_failure_count() == before + 2
+        finalize(generic)
+        @test RustCall.finalizer_failure_count() == before + 2
+        RustCall.close_retired_handles!(RustCall.retired_handles(lib))
+        println("destructor panic checks passed")
+        """
+    project = dirname(@__DIR__)
+    result = read(`$(Base.julia_cmd()) --startup-file=no --project=$project --threads=4 -e $script`, String)
+    @test occursin("destructor panic checks passed", result)
+end
+
+@testset "a real PyO3 destructor panic is counted (#291)" begin
+    mktempdir() do root
+        mkpath(joinpath(root, "src"))
+        manifest = replace(read(joinpath(@__DIR__, "fixtures", "sample_crate_pyo3_only", "Cargo.toml"), String),
+                           "sample_crate_pyo3_only" => "pyo3_destructor_291")
+        write(joinpath(root, "Cargo.toml"), manifest)
+        write(joinpath(root, "src", "lib.rs"), raw"""
+            use pyo3::prelude::*;
+            #[pyclass]
+            pub struct PyDropBomb291 { fail: bool }
+            #[pymethods]
+            impl PyDropBomb291 {
+                #[new]
+                pub fn new(fail: bool) -> Self { Self { fail } }
+            }
+            impl Drop for PyDropBomb291 {
+                fn drop(&mut self) {
+                    if self.fail { panic!("PyO3 destructor panic"); }
+                }
+            }
+            """)
+        wrapper = _link_libpython_wrapper(root)
+        if wrapper === nothing
+            @test_skip "no linkable Python here"
+        else
+            script = """
+                using RustCall, Test
+                crate = $(repr(root))
+                bindings = @rust_crate crate
+                type_ = Base.invokelatest(getproperty, bindings, :PyDropBomb291)
+                bomb = Base.invokelatest(type_, true)
+                quiet = Base.invokelatest(type_, false)
+                @test getfield(bomb, :free_channel) != C_NULL
+                before = RustCall.finalizer_failure_count()
+                finalize(bomb)
+                @test RustCall.finalizer_failure_count() == before + 1
+                @test getfield(bomb, :ptr) == C_NULL
+                finalize(quiet)
+                finalize(bomb)
+                @test RustCall.finalizer_failure_count() == before + 1
+                println("PyO3 destructor panic checks passed")
+                """
+            project = dirname(@__DIR__)
+            result = read(`$(Base.julia_cmd()) --startup-file=no --project=$project -e $script`, String)
+            @test occursin("PyO3 destructor panic checks passed", result)
+        end
+    end
+end
+
+@testset "both crate emitters capture destructor panic channels (#291)" begin
+    mktempdir() do root
+        mkpath(joinpath(root, "src"))
+        macros = RustCall.escape_toml_string(joinpath(dirname(@__DIR__), "deps", "juliacall_macros"))
+        write(joinpath(root, "Cargo.toml"), """
+            [package]
+            name = "destructor_panic_291"
+            version = "0.1.0"
+            edition = "2021"
+            [lib]
+            crate-type = ["cdylib"]
+            [dependencies]
+            juliacall_macros = { path = "$macros" }
+            """)
+        write(joinpath(root, "src", "lib.rs"), raw"""
+            use juliacall_macros::julia;
+            #[julia]
+            pub struct CrateDropBomb291 { fail: bool }
+            #[julia]
+            impl CrateDropBomb291 {
+                #[julia]
+                pub fn new(fail: bool) -> Self { Self { fail } }
+            }
+            impl Drop for CrateDropBomb291 {
+                fn drop(&mut self) {
+                    if self.fail { panic!("crate destructor panic"); }
+                }
+            }
+            """)
+        output = joinpath(root, "Bindings.jl")
+        script = """
+            using RustCall, Test
+            crate = $(repr(root))
+            bindings = @rust_crate crate
+            ast_module = getfield(bindings, :module_ref)
+            RustCall.write_bindings_to_file(crate, $(repr(output)); output_module_name = "DropSource291")
+            Base.include(Main, $(repr(output)))
+            source_module = getfield(Main, :DropSource291)
+            for module_ in (ast_module, source_module)
+                type_ = Base.invokelatest(getfield, module_, :CrateDropBomb291)
+                bomb = Base.invokelatest(type_, true)
+                quiet = Base.invokelatest(type_, false)
+                @test getfield(bomb, :free_channel) != C_NULL
+                before = RustCall.finalizer_failure_count()
+                task = lock(RustCall.REGISTRY_LOCK) do
+                    task = Threads.@spawn finalize(bomb)
+                    @test timedwait(() -> istaskdone(task), 5.0) == :ok
+                    task
+                end
+                fetch(task)
+                @test getfield(bomb, :ptr) == C_NULL
+                @test RustCall.finalizer_failure_count() == before + 1
+                finalize(bomb)
+                finalize(quiet)
+                @test RustCall.finalizer_failure_count() == before + 1
+            end
+            println("crate destructor panic checks passed")
+            """
+        project = dirname(@__DIR__)
+        result = read(`$(Base.julia_cmd()) --startup-file=no --project=$project --threads=4 -e $script`, String)
+        @test occursin("crate destructor panic checks passed", result)
+        # The child has exited before deleting its Cargo tree, including on
+        # Windows where a mapped DLL would prevent cleanup in this process.
+    end
+end

--- a/test/test_generic_reload.jl
+++ b/test/test_generic_reload.jl
@@ -1,0 +1,124 @@
+using RustCall, Test
+
+function _generic_reload_stress291()
+    mktempdir() do root
+        dependency = joinpath(root, "dependency")
+        mkpath(joinpath(dependency, "src"))
+        write(joinpath(dependency, "Cargo.toml"), """
+            [package]
+            name = "reload_generic_dep291"
+            version = "0.1.0"
+            edition = "2021"
+            [lib]
+            crate-type = ["rlib", "cdylib"]
+            """)
+        path = joinpath(dependency, "src", "lib.rs")
+        write_generation(n) = write(path, "#[no_mangle] pub extern \"C\" fn marker() -> i32 { $n }\n")
+        write_generation(1)
+        source = """
+            // cargo-deps: reload_generic_dep291={path="$(RustCall.escape_toml_string(dependency))"}
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static DROPS291: AtomicUsize = AtomicUsize::new(0);
+            #[julia] pub struct ReloadBox291<T> { pub value: T, pub born: i32 }
+            #[julia] impl<T: Copy> ReloadBox291<T> {
+                pub fn new(value: T) -> Self { Self { value, born: reload_generic_dep291::marker() } }
+                pub fn stamp(&self) -> i32 { reload_generic_dep291::marker() }
+                pub fn drop_count(&self) -> usize { DROPS291.load(Ordering::SeqCst) }
+                pub fn boom(&self) -> i32 { panic!("reload generation {}", reload_generic_dep291::marker()); }
+            }
+            impl<T> Drop for ReloadBox291<T> {
+                fn drop(&mut self) { DROPS291.fetch_add(1, Ordering::SeqCst); }
+            }
+            """
+        previous = Set(keys(RustCall.RUST_LIBRARIES))
+        names = Set{String}()
+        objects = Any[]
+        readers = Task[]
+        stop = Threads.Atomic{Bool}(false)
+        calls = Threads.Atomic{Int}(0)
+        before = RustCall.finalizer_failure_count()
+        withenv("RUSTCALL_CACHE_DIR" => joinpath(root, "cache")) do
+            try
+                built = RustCall.rebuild_crate(dependency)
+                name = "actual_generic_reload291_$(basename(root))"
+                RustCall.load_artifact!(RustCall.hot_reload_policy(), built; lib_name = name)
+                push!(names, name)
+                state = RustCall.HotReloadState(dependency, built, name, [path], Dict{String, Float64}(), nothing, true, nothing)
+                scope = Module(gensym(:GenericReload291))
+                Core.eval(scope, :(using RustCall))
+                inline_lib = Core.eval(scope, Expr(:macrocall, Symbol("@rust_str"), LineNumberNode(1), source))
+                push!(names, inline_lib)
+                type_ = Core.eval(scope, :(ReloadBox291{Int32}))
+                stamp = Base.invokelatest(getfield, scope, :stamp)
+                drops = Base.invokelatest(getfield, scope, :drop_count)
+                boom = Base.invokelatest(getfield, scope, :boom)
+                old = Base.invokelatest(type_, Int32(7))
+                push!(objects, old)
+                push!(names, getfield(old, :lib_name))
+                @test Base.invokelatest(stamp, old) == 1
+                for _ in 1:2
+                    push!(readers, Threads.@spawn begin
+                        valid = true
+                        iterations = 0
+                        while !stop[]
+                            valid &= Base.invokelatest(stamp, old) == 1
+                            iterations += 1
+                            if iterations % 128 == 1
+                                err = try Base.invokelatest(boom, old); nothing catch error; error end
+                                valid &= err isa RustCall.RustPanicError && occursin("generation 1", sprint(showerror, err))
+                            end
+                            Threads.atomic_add!(calls, 1)
+                            sleep(0.01)
+                        end
+                        valid
+                    end)
+                end
+                for generation in 2:3
+                    prior_calls = calls[]
+                    write_generation(generation)
+                    @test RustCall.reload_library(state)
+                    @test isempty(state.last_failure)
+                    target = RustCall.resolve_call_target(name, "marker")
+                    @test RustCall.call_rust_function(target.func_ptr, Int32) == generation
+                    current = Base.invokelatest(type_, Int32(generation))
+                    push!(objects, current)
+                    push!(names, getfield(current, :lib_name))
+                    @test Base.invokelatest(stamp, current) == generation
+                    @test Base.invokelatest(getproperty, current, :born) == generation
+                    @test getfield(current, :lib_name) != getfield(old, :lib_name)
+                    temporary = Base.invokelatest(type_, Int32(0))
+                    push!(objects, temporary)
+                    count = Base.invokelatest(drops, current)
+                    finalize(temporary)
+                    @test Base.invokelatest(drops, current) == count + 1
+                    @test calls[] > prior_calls
+                    if generation == 2
+                        RustCall.unload_library(getfield(old, :lib_name))
+                        @test getfield(old, :alive)[]
+                    end
+                end
+            finally
+                stop[] = true
+                results = fetch.(readers)
+                @test all(results)
+                @test calls[] > 0
+                foreach(finalize, objects)
+                @test RustCall.finalizer_failure_count() == before
+                union!(names, setdiff(Set(keys(RustCall.RUST_LIBRARIES)), previous))
+                for name in names
+                    haskey(RustCall.RUST_LIBRARIES, name) && RustCall.unload_library(name; close = true)
+                    RustCall.close_retired_handles!(RustCall.retired_handles(name))
+                end
+            end
+        end
+    end
+end
+
+@testset "generic objects overlap actual Cargo reloads (#291)" begin
+    if Threads.nthreads() < 2
+        @test_skip "concurrent reload stress requires multiple threads"
+    else
+        _generic_reload_stress291()
+    end
+end
+

--- a/test/test_loadpolicy.jl
+++ b/test/test_loadpolicy.jl
@@ -553,7 +553,7 @@ end
         # A constructor allocates, so the object it returns is built from the
         # constructor's own snapshot — never from a second lookup afterwards.
         @test occursin("ptr, tgt = GC.@preserve", _src("structs.jl"))
-        @test occursin("\$esc_struct(ptr, tgt.lib_name, tgt.free_ptr, tgt.alive)",
+        @test occursin("\$esc_struct(ptr, tgt.lib_name, tgt.free_ptr, tgt.alive, tgt.free_channel)",
                        _src("structs.jl"))
         @test occursin("_ctor_target(", _src("crate_bindings.jl"))
         @test occursin("alive_ref_for_handle(", _src("structs.jl"))

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -1347,16 +1347,18 @@ end
         @test c.ownership === :owned_by_rust
         @test c.free_symbol == "Rc246Counter_free_rust_string"
 
-        # Both crate-path generators read it through the owned-buffer helper and
-        # release it through the contract's symbol. On `main` this branch read
+        # Both crate-path generators check the raw buffer's panic channel before
+        # copying it and release it through the contract's symbol. Previously this branch read
         # `call_rust_function(ptr, Any, ...)` and leaked.
         emitted = RustCall._emit_struct_code(info)
-        @test occursin("_call_rust_owned_string_ptr", emitted)
+        @test occursin("_guard_panic(call_rust_function(fp, RustCall.CRustString", emitted)
+        @test occursin("RustCall._take_owned_string(raw, freep)", emitted)
         @test occursin("Rc246Counter_free_rust_string", emitted)
         @test !occursin("call_rust_function(func_ptr, Any", emitted)
 
         generated = string(RustCall._generate_property_accessors(info))
-        @test occursin("_call_rust_owned_string_ptr", generated)
+        @test occursin("_guard_panic(call_rust_function(fp, RustCall.CRustString", generated)
+        @test occursin("RustCall._take_owned_string(raw, freep)", generated)
         @test occursin("Rc246Counter_free_rust_string", generated)
 
         # A plain field is unaffected.

--- a/test/test_state.jl
+++ b/test/test_state.jl
@@ -189,6 +189,8 @@ end
         pub fn state_lookup_value() -> $type { $value }
         #[no_mangle]
         pub extern "C" fn state_lookup_release() {}
+        #[no_mangle]
+        pub extern "C" fn state_lookup_release_take_panic(_out: *mut u8, _cap: usize) -> usize { 0 }
         """
     old = RustCall._compile_and_load_rust(source("i32", "111"), "state_lookup", 1)
     replacement = RustCall._compile_and_load_rust(source("f64", "222.0"), "state_lookup", 1)
@@ -231,6 +233,7 @@ end
         @test RustCall.call_rust_function(target.func_ptr, Int32) == 111
         @test target.channel == RustCall.Libdl.dlsym(old_handle, "rustcall_state_lookup_value_take_panic")
         @test target.free_ptr == RustCall.Libdl.dlsym(old_handle, "state_lookup_release")
+        @test target.free_channel == RustCall.Libdl.dlsym(old_handle, "state_lookup_release_take_panic")
         current = RustCall.resolve_call_target(old, "state_lookup_value";
             free_symbol = "state_lookup_release")
         @test current.handle == replacement_handle
@@ -239,6 +242,8 @@ end
         @test RustCall._snapshot_return_type(current) === Float64
         @test RustCall.call_rust_function(current.func_ptr, Float64) == 222.0
         @test current.free_ptr == RustCall.Libdl.dlsym(replacement_handle, "state_lookup_release")
+        @test current.free_channel == RustCall.Libdl.dlsym(replacement_handle, "state_lookup_release_take_panic")
+        @test current.free_channel != target.free_channel
         @test current.generation == target.generation + 1
         RustCall.alias_artifact!(RustCall.inline_rustc_policy(), replacement, old)
         @test RustCall.resolve_call_target(old, "state_lookup_value").generation == current.generation


### PR DESCRIPTION
## Scope

Closes #251. Closes #291. Follow-up to merged #361; this PR is not a release publication.

### Implemented in the destructor step

- Use the shared Rust unwind boundary for generated inline, proc-macro and
  PyO3 class destructors. Generic specialization uses its existing boundary.
- Capture a destructor's panic channel together with its function pointer and
  image liveness before allocation. Both Julia crate emitters use that snapshot.
- Consume the captured channel immediately after free in the finalizer, count
  failures, and never acquire STATE, resolve symbols, or log there.
- Reserve destructor panic-reader exports in collision checks; private TLS
  identifiers preserve case-sensitive class identities.
- Isolate the crate-hash test's temporary input from shared precompile fixtures.

### Requirement-to-test evidence

| Requirement | Named test |
| --- | --- |
| Actual unwinding Drop survives both Rust codegen flavours | `generated_destructors_contain_panics_in_both_flavours` in `destructor_panics.rs` |
| New reader exports participate in Julia/PyO3 collisions | `destructor_channels_participate_in_symbol_collisions` |
| Ordinary and generic finalizers count once without STATE; retirement keeps the captured image | `generated destructor panics are counted without STATE (#291)` |
| Real libpython-linked PyO3 wrapper contains a destructor panic | `a real PyO3 destructor panic is counted (#291)` |
| Both in-memory and written crate modules capture destructor channels | `both crate emitters capture destructor panic channels (#291)` |
| Cold resolution retains old/new destructor channels across a concurrent swap | `cold symbol resolution releases STATE and retains the captured generation (#251)` |

### Accessor and actual-reload follow-up

- Generated inline/proc-macro/PyO3 field helpers and inline clone helpers now
  use the shared boundary. Vec panic results are valid empty Vecs, not zeroed
  invalid values. New reader exports participate in collision checks.
- Both Julia crate emitters read panic channels before converting field
  results, including owned/borrowed strings; the legacy generic field fallback
  uses its specialization's ABI and panic channel too.
- `generated_accessors_contain_clone_and_drop_panics` runs real user Clone/Drop
  panics through generated Rust accessors and clone. `accessor_channels_are_reserved`
  checks Julia and PyO3 collision ownership.
- `both crate field emitters propagate panic channels (#291)` exercises 28
  actual guarded Rust calls from both Julia emitter forms; the legacy generic
  field test adds one panic-propagation check.
- `generic objects overlap actual Cargo reloads (#291)` rebuilds and replaces
  a real path-dependency crate twice while old generic objects are called and
  panic on reader threads. New same-type specializations retain their own
  generation and destructor counts. Both the prototype and repository test
  passed 21 assertions with --threads=4 --check-bounds=yes. The dedicated CI
  step runs the repository test with those flags; one-thread runs skip it.
- docs/STATE_AUDIT.md maps #251 acceptance criteria to the state-container
  checks, mixed compile/reload stress and audited transaction boundaries.

The requirement mapping below covers the original issue items. Closure occurs
on merge after the current head's remaining required CI succeeds.

The additional String setter ABI audit found a real mismatch. Both Rust codegen
flavours now take byte pointer/length inputs, using the common String argument
conversion inside the panic boundary. Inline Julia and both crate emitters
validate UTF-8 and preserve the text while calling. `String field setters use
byte pairs (#291)` passes 15 assertions covering embedded NUL, non-ASCII, empty
and replacement strings plus invalid UTF-8 rejection without mutation.
`string_setters_copy_byte_pairs_in_both_flavours` compiles and runs both actual
Rust codegen flavours. Borrowed-field input behaviour was not changed.

The cfg-probe cost decision now has a reproducible
`benchmark/benchmarks_cfg_probe.jl`: ten warm probes on an isolated small crate,
plus a build-script input change whose new cfg is asserted. The documented
initial run measured a 75 ms warm median; a repository-script rerun measured
62 ms. These are illustrative local costs, not workspace-wide bounds.

#303's public re-export, signature/default-argument,
extends, generated-source and workspace-feature cases remain milestone work.

### Final requirement mapping for #251 and #291

| Issue requirement | Evidence (merged #361 foundations plus this PR) |
| --- | --- |
| #251 one Lockable state, no independent mutable registries | `the mutable runtime registry lives in one Lockable state (#251)`; `lint_state_container.sh` |
| #251 four-thread bounds-checked compile/call/cache/reload stress | `inline compile, calls and cache hits overlap reloads (#251)`; CI `Bounds-checked state and mixed reload stress` |
| #251 lock policy and audited FFI/callback exclusion | RustCallState docstring, docs/STATE_AUDIT.md; `state transactions contain no blocking, FFI, or logging callouts (#251)` plus named callback/metadata/lookup tests in the audit |
| #291 one generic-instantiation image | `a generic struct is bound to the image that allocated it`; `same-name generic rebuild retains each object's image (#291)`; atomic group-registration test |
| #291 real generic reload concurrency | `generic objects overlap actual Cargo reloads (#291)`; dedicated four-thread CI step |
| #291 build.rs inputs and probe cost | `the cfg probe follows a feature change (#255)` includes cfg.flag without build.rs edits; unconditional probe; benchmarks_cfg_probe.jl and documented local measurements |
| #291 reclamation design decision | explicit quiescence contract, retired-image tests; benchmarks_retirement.jl and cost assessment in panics.md (automatic reclamation was conditional on its cost) |
| #291 remaining LLVM load exception | @rust_llvm removed; lint_load_path.sh and lint_generation_snapshot.sh have no LLVM exception |
| #291 generated helper panic boundaries | destructor/accessor tests and String setter ABI tests listed above, including actual PyO3 execution |
| #291 Cargo-backed generic specialization | `Cargo generics preserve dependencies and the registered cfg environment (#291)` |

Issue #303 remains follow-up work; no release has been published. Final
merge/closure still requires the current head's CI and unresolved-thread check.

## Validation

Local validation of the initial destructor commit (CI will track its head SHA):

- Core Rust tests and clippy passed; intentional destructor/read-channel golden
  changes were reviewed and plain tests rerun after regeneration.
- Extractor tests, proc-macro all-feature tests, all lints and docs passed.
- Focused destructor tests include actual PyO3 execution, not a skipped wrapper.
- Four-thread bounds-checked STATE test passed with 264 assertions.
- The initial full Julia run had stale source-shape expectations and a
  precompile-cache invalidation during the non-file-environment test. Expectations
  are updated and the shared hash probe is isolated. The subsequent full run's
  parallel phase passed: 10,116 assertions and 4 existing Broken, including the
  precompile test. Its serial phase passed all 651 assertions; `Pkg.test()`
  exited 0. Focused precompile and isolated crate-binding tests also exited 0.

Per maintainer instruction, the initial 1642230 push omitted `@codex review`.
That push already honored the instruction without requesting
review; it is not a standing waiver for subsequent pushes.

Follow-up local validation: full parallel phase passed 10,148 assertions
with 5 Broken (4 existing plus the one-thread generic-reload skip). The real
four-thread generic-reload run passed 21. The serial phase passed all 651
assertions, and Pkg.test() reported RustCall tests passed. Core tests, clippy,
proc-macro all-feature tests, all lints and docs also passed locally.

CI evidence for pushed head 6fa739b: the Ubuntu four-thread job's
`Bounds-checked state and mixed reload stress` step succeeded (job
102432450405). This includes the actual generic reload test. The job's full
Pkg.test phase was still running at this observation; this is not an overall
CI success claim or evidence for unpushed String setter changes.

String-setter follow-up local validation: full Pkg.test exited 0, with 10,163
parallel assertions (5 Broken as above) and all 651 serial assertions. Core
tests, clippy, all lints, the new benchmark and the updated docs build passed.
The prior 6fa739b review completed without major findings; the next pushed head
will receive its own CI and review, not inherit that result.
