### PR TITLE
Resolve public PyO3 re-export routes

### DIFF
--- a/.github/workflows/Examples.yml
+++ b/.github/workflows/Examples.yml
@@ -72,6 +72,9 @@ jobs:
           # Python"). Only SampleCratePyO3Only.jl and
           # RustCrateMacroPyO3Only.jl read it.
           PYO3_PYTHON: ${{ steps.python.outputs.python-path }}
+          # Compare precompile/runtime fingerprint components for the
+          # reproducible toolchain mismatch in this example (#363).
+          JULIA_DEBUG: ${{ matrix.package == 'RustCrateMacroPyO3Only.jl' && 'RustCall' || '' }}
         run: >
           julia --color=yes --project=examples/${{ matrix.package }} -e '
             using Pkg

--- a/deps/rustcall_core/src/cfg.rs
+++ b/deps/rustcall_core/src/cfg.rs
@@ -420,7 +420,26 @@ impl CfgSet {
                         errors.extend(self.prune_items(inner));
                     }
                 }
-                Item::Enum(e) => self.prune_generics(&mut e.generics, &mut errors),
+                Item::Enum(e) => {
+                    self.prune_generics(&mut e.generics, &mut errors);
+                    let mut kept = syn::punctuated::Punctuated::new();
+                    for mut variant in std::mem::take(&mut e.variants) {
+                        let errs = self.expand_cfg_attrs(&mut variant.attrs);
+                        if !errs.is_empty() {
+                            errors.extend(errs);
+                            continue;
+                        }
+                        match self.attrs_active(&variant.attrs) {
+                            Ok(true) => {
+                                self.strip_decided_cfgs(&mut variant.attrs);
+                                kept.push(variant);
+                            }
+                            Ok(false) => {}
+                            Err(error) => errors.push(error),
+                        }
+                    }
+                    e.variants = kept;
+                }
                 Item::Trait(t) => self.prune_generics(&mut t.generics, &mut errors),
                 Item::Impl(imp) => {
                     self.prune_generics(&mut imp.generics, &mut errors);

--- a/deps/rustcall_core/src/expand.rs
+++ b/deps/rustcall_core/src/expand.rs
@@ -407,6 +407,7 @@ fn concrete_struct_entry(
     let stem = crate::codegen::symbol_stem(module_path, &model.name());
     let effective_cfg = crate::cfg::effective_cfg_attrs(enclosing_cfg, &model.item.attrs);
     Struct {
+        callable_path: Vec::new(),
         cfg: predicate_string(&effective_cfg),
         cfg_features: crate::cfg::predicate_features(&effective_cfg),
         name: model.name(),
@@ -479,6 +480,7 @@ fn generic_struct_entry(
     }
 
     Struct {
+        callable_path: Vec::new(),
         cfg: predicate_string(&effective_cfg),
         cfg_features: crate::cfg::predicate_features(&effective_cfg),
         name: model.name(),

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -232,6 +232,7 @@ pub fn function_entry(
         ""
     };
     Function {
+        callable_path: Vec::new(),
         name,
         ffi_name,
         symbol,
@@ -1243,6 +1244,7 @@ fn crate_struct_entry(
         })
         .collect();
     Struct {
+        callable_path: Vec::new(),
         cfg: predicate_string(&effective_cfg),
         cfg_features: crate::cfg::predicate_features(&effective_cfg),
         name: model.name(),

--- a/deps/rustcall_core/src/lib.rs
+++ b/deps/rustcall_core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod extract;
 pub mod manifest;
 pub mod model;
 pub mod paths;
+pub mod public_routes;
 pub mod pyo3;
 pub mod specialize;
 pub mod types;

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -107,7 +107,10 @@ use serde::{Deserialize, Serialize};
 ///   never released and leaks, silently. `src/manifest.jl` validates exact
 ///   equality, so bumping the version is what makes such a consumer refuse the
 ///   manifest instead of using the wrong owner (#342 review).
-pub const SCHEMA_VERSION: u32 = 8;
+/// * **9** adds [`Function::callable_path`] and [`Struct::callable_path`]
+///   (#303): wrappers must call the externally reachable re-export instead
+///   of a canonical definition inside a private module.
+pub const SCHEMA_VERSION: u32 = 9;
 
 /// Vocabulary of [`Function::skip_reason`] / [`Struct::skip_reason`] /
 /// [`Method::skip_reason`]. An empty reason means the item is wrappable.
@@ -424,6 +427,10 @@ pub struct Function {
     /// from it, and a consumer that lays items out per module keys on it.
     #[serde(default)]
     pub module_path: Vec<String>,
+    /// External Rust spelling, including the item name, when re-exported from
+    /// its canonical module. Empty means module_path + name (legacy manifests).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub callable_path: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -643,6 +650,9 @@ pub struct Struct {
     /// Enclosing inline modules of the struct (see [`Function::module_path`]).
     #[serde(default)]
     pub module_path: Vec<String>,
+    /// External Rust spelling; canonical identity remains module_path + name.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub callable_path: Vec<String>,
 }
 
 /// A generic wrapper of a generic inline struct. In inline mode the wrapper is

--- a/deps/rustcall_core/src/paths.rs
+++ b/deps/rustcall_core/src/paths.rs
@@ -317,12 +317,19 @@ fn flatten_use_tree(
         }
         syn::UseTree::Name(name) => {
             let mut full = prefix.clone();
-            full.push(name.ident.to_string());
-            out.push((name.ident.to_string(), full, false));
+            let alias = if name.ident == "self" && !prefix.is_empty() {
+                prefix.last().unwrap().clone()
+            } else {
+                full.push(name.ident.to_string());
+                name.ident.to_string()
+            };
+            out.push((alias, full, false));
         }
         syn::UseTree::Rename(rename) => {
             let mut full = prefix.clone();
-            full.push(rename.ident.to_string());
+            if rename.ident != "self" || prefix.is_empty() {
+                full.push(rename.ident.to_string());
+            }
             out.push((rename.rename.to_string(), full, false));
         }
         syn::UseTree::Group(group) => {

--- a/deps/rustcall_core/src/public_routes.rs
+++ b/deps/rustcall_core/src/public_routes.rs
@@ -98,6 +98,11 @@ impl PublicRoutes {
             }
             if let Item::Use(v) = item {
                 for binding in imports_of_use(v, module) {
+                    // `use ... as _` imports anonymously and creates no path
+                    // a dependent crate can name, even when the use is pub.
+                    if !binding.glob && binding.alias == "_" {
+                        continue;
+                    }
                     if !binding.glob {
                         self.names.insert(binding.alias.clone());
                     }

--- a/deps/rustcall_core/src/public_routes.rs
+++ b/deps/rustcall_core/src/public_routes.rs
@@ -103,6 +103,29 @@ impl PublicRoutes {
                         module: is_module,
                         predicates: predicates(&effective),
                     });
+                if let Item::Enum(v) = item {
+                    for variant in &v.variants {
+                        let mut variant_path = path.clone();
+                        variant_path.push(variant.ident.to_string());
+                        self.names.insert(variant.ident.to_string());
+                        let attrs = crate::cfg::effective_cfg_attrs(&effective, &variant.attrs);
+                        for namespace in [Namespace::Type, Namespace::Value] {
+                            if namespace == Namespace::Value
+                                && matches!(variant.fields, syn::Fields::Named(_))
+                            {
+                                continue;
+                            }
+                            self.definitions
+                                .entry((namespace, variant_path.clone()))
+                                .or_default()
+                                .push(Definition {
+                                    visibility: syn::parse_quote!(pub),
+                                    module: false,
+                                    predicates: predicates(&attrs),
+                                });
+                        }
+                    }
+                }
                 if let Item::Struct(v) = item {
                     if !matches!(v.fields, syn::Fields::Named(_)) {
                         let constructor_visibility = if v

--- a/deps/rustcall_core/src/public_routes.rs
+++ b/deps/rustcall_core/src/public_routes.rs
@@ -1,0 +1,372 @@
+//! External call paths, distinct from canonical definition identities (#303).
+//! Inputs are the same cfg-pruned syn items as the PyO3 scan. Predicates are
+//! retained for lenient scans; a conditional import must not grant unconditional
+//! access to an otherwise unconditional definition.
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use syn::{Attribute, Item, Visibility};
+
+use crate::paths::{imports_of_use, visible_from, ScannedImport};
+
+type Path = Vec<String>;
+
+#[derive(Clone, Debug)]
+struct Definition {
+    visibility: Visibility,
+    module: bool,
+    predicates: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug)]
+struct Import {
+    binding: ScannedImport,
+    visibility: Visibility,
+    predicates: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Target {
+    path: Path,
+    predicates: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublicRoute {
+    pub path: Path,
+    pub predicates: BTreeSet<String>,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct PublicRoutes {
+    definitions: BTreeMap<Path, Vec<Definition>>,
+    imports: Vec<Import>,
+    names: BTreeSet<String>,
+}
+
+impl PublicRoutes {
+    /// Resolve within one cfg variant. A public module in a mutually exclusive
+    /// variant must not grant access to the private copy at the same path.
+    pub fn resolve_for(&self, cfg: &str) -> BTreeMap<Path, PublicRoute> {
+        let compatible = |predicates: &BTreeSet<String>| {
+            !predicates
+                .iter()
+                .any(|predicate| crate::cfg::cfg_exclusive(predicate, cfg))
+        };
+        let mut scoped = self.clone();
+        scoped.definitions.retain(|_, definitions| {
+            definitions.retain(|definition| compatible(&definition.predicates));
+            !definitions.is_empty()
+        });
+        scoped
+            .imports
+            .retain(|import| compatible(&import.predicates));
+        scoped.resolve()
+    }
+    /// Add one file; inline modules recurse here, file modules are supplied by
+    /// the existing file walker with their canonical path and enclosing cfg.
+    pub fn file(&mut self, items: &[Item], module: &[String], cfg: &[Attribute]) {
+        for item in items {
+            let entry = match item {
+                Item::Fn(v) => Some((&v.sig.ident, &v.vis, &v.attrs, false)),
+                Item::Struct(v) => Some((&v.ident, &v.vis, &v.attrs, false)),
+                Item::Enum(v) => Some((&v.ident, &v.vis, &v.attrs, false)),
+                Item::Type(v) => Some((&v.ident, &v.vis, &v.attrs, false)),
+                Item::Const(v) => Some((&v.ident, &v.vis, &v.attrs, false)),
+                Item::Static(v) => Some((&v.ident, &v.vis, &v.attrs, false)),
+                Item::Union(v) => Some((&v.ident, &v.vis, &v.attrs, false)),
+                Item::Trait(v) => Some((&v.ident, &v.vis, &v.attrs, false)),
+                Item::Mod(v) => Some((&v.ident, &v.vis, &v.attrs, true)),
+                _ => None,
+            };
+            if let Some((name, visibility, attrs, is_module)) = entry {
+                let mut path = module.to_vec();
+                self.names.insert(name.to_string());
+                path.push(name.to_string());
+                let effective = crate::cfg::effective_cfg_attrs(cfg, attrs);
+                self.definitions
+                    .entry(path.clone())
+                    .or_default()
+                    .push(Definition {
+                        visibility: visibility.clone(),
+                        module: is_module,
+                        predicates: predicates(&effective),
+                    });
+                if let Item::Mod(v) = item {
+                    if let Some((_, items)) = &v.content {
+                        self.file(items, &path, &effective);
+                    }
+                }
+            }
+            if let Item::Use(v) = item {
+                for binding in imports_of_use(v, module) {
+                    if !binding.glob {
+                        self.names.insert(binding.alias.clone());
+                    }
+                    self.imports.push(Import {
+                        binding,
+                        visibility: v.vis.clone(),
+                        predicates: predicates(&crate::cfg::effective_cfg_attrs(cfg, &v.attrs)),
+                    });
+                }
+            }
+        }
+    }
+
+    fn name(
+        &self,
+        module: &[String],
+        name: &str,
+        observer: Option<&[String]>,
+        visiting: &mut BTreeSet<(Path, String)>,
+    ) -> BTreeSet<Target> {
+        let key = (module.to_vec(), name.to_string());
+        if !visiting.insert(key.clone()) {
+            return BTreeSet::new();
+        }
+        let mut path = module.to_vec();
+        path.push(name.to_string());
+        let mut result = BTreeSet::new();
+        let direct = self.definitions.get(&path);
+        let explicit: Vec<_> = self
+            .imports
+            .iter()
+            .filter(|v| {
+                v.binding.module_path == module && !v.binding.glob && v.binding.alias == name
+            })
+            .collect();
+        if let Some(definitions) = direct {
+            for definition in definitions {
+                if accessible(&definition.visibility, module, observer) {
+                    result.insert(Target {
+                        path: path.clone(),
+                        predicates: definition.predicates.clone(),
+                    });
+                }
+            }
+        }
+        for import in &explicit {
+            if accessible(&import.visibility, module, observer) {
+                for mut target in self.import_target(import, visiting) {
+                    target.predicates.extend(import.predicates.clone());
+                    result.insert(target);
+                }
+            }
+        }
+        // Named bindings shadow globs even when the named binding is private.
+        if direct.is_none() && explicit.is_empty() {
+            for import in self.imports.iter().filter(|v| {
+                v.binding.module_path == module
+                    && v.binding.glob
+                    && accessible(&v.visibility, module, observer)
+            }) {
+                for source in self.import_target(import, visiting) {
+                    for mut target in self.name(&source.path, name, Some(module), visiting) {
+                        target.predicates.extend(source.predicates.clone());
+                        target.predicates.extend(import.predicates.clone());
+                        result.insert(target);
+                    }
+                }
+            }
+        }
+        visiting.remove(&key);
+        result
+    }
+
+    fn import_target(
+        &self,
+        import: &Import,
+        visiting: &mut BTreeSet<(Path, String)>,
+    ) -> BTreeSet<Target> {
+        let binding = &import.binding;
+        let mut qualifier = binding.qualifier.clone();
+        if !binding.glob {
+            if let Some(last) = binding.path.last() {
+                qualifier.segments.push(last.clone());
+            }
+        }
+        for path in qualifier.candidates(&binding.module_path) {
+            let mut targets = BTreeSet::from([Target {
+                path: Vec::new(),
+                predicates: BTreeSet::new(),
+            }]);
+            for segment in path {
+                let mut next = BTreeSet::new();
+                for parent in targets {
+                    for mut target in
+                        self.name(&parent.path, &segment, Some(&binding.module_path), visiting)
+                    {
+                        target.predicates.extend(parent.predicates.clone());
+                        next.insert(target);
+                    }
+                }
+                targets = next;
+            }
+            if !targets.is_empty() {
+                return targets;
+            }
+        }
+        BTreeSet::new()
+    }
+
+    /// Select a deterministic externally reachable spelling for each canonical
+    /// item. Ambiguous names are never chosen. Module cycles are traversed once
+    /// per route, so re-export loops cannot grow paths indefinitely.
+    pub fn resolve(&self) -> BTreeMap<Path, PublicRoute> {
+        let mut result = BTreeMap::new();
+        let mut queue =
+            VecDeque::from([(Vec::new(), Vec::new(), BTreeSet::new(), BTreeSet::new())]);
+        while let Some((module, prefix, inherited, mut ancestors)) = queue.pop_front() {
+            if !ancestors.insert(module.clone()) {
+                continue;
+            }
+            for name in &self.names {
+                let targets = self.name(&module, name, None, &mut BTreeSet::new());
+                if targets
+                    .iter()
+                    .map(|v| &v.path)
+                    .collect::<BTreeSet<_>>()
+                    .len()
+                    != 1
+                {
+                    continue;
+                }
+                for target in targets {
+                    let Some(definitions) = self.definitions.get(&target.path) else {
+                        continue;
+                    };
+                    if !definitions
+                        .iter()
+                        .any(|v| matches!(v.visibility, Visibility::Public(_)))
+                    {
+                        continue;
+                    }
+                    let mut path = prefix.clone();
+                    path.push(name.clone());
+                    let mut predicates = inherited.clone();
+                    predicates.extend(target.predicates);
+                    let candidate = PublicRoute {
+                        path: path.clone(),
+                        predicates: predicates.clone(),
+                    };
+                    let rank = |route: &PublicRoute| {
+                        (route.predicates.len(), route.path.len(), route.path.clone())
+                    };
+                    result
+                        .entry(target.path.clone())
+                        .and_modify(|current| {
+                            if rank(&candidate) < rank(current) {
+                                *current = candidate.clone();
+                            }
+                        })
+                        .or_insert(candidate);
+                    if definitions.iter().any(|v| v.module) {
+                        queue.push_back((target.path, path, predicates, ancestors.clone()));
+                    }
+                }
+            }
+        }
+        result
+    }
+}
+
+fn accessible(vis: &Visibility, module: &[String], observer: Option<&[String]>) -> bool {
+    observer.map_or(matches!(vis, Visibility::Public(_)), |from| {
+        visible_from(vis, module, from)
+    })
+}
+
+fn predicates(attrs: &[Attribute]) -> BTreeSet<String> {
+    let text = crate::cfg::predicate_string(attrs);
+    if text.is_empty() {
+        BTreeSet::new()
+    } else {
+        BTreeSet::from([text])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn routes(source: &str) -> BTreeMap<Path, PublicRoute> {
+        let file = syn::parse_file(source).unwrap();
+        let mut routes = PublicRoutes::default();
+        routes.file(&file.items, &[], &[]);
+        routes.resolve()
+    }
+    fn path(value: &str) -> Path {
+        value.split("::").map(String::from).collect()
+    }
+
+    #[test]
+    fn follows_alias_chains_globs_and_module_aliases() {
+        for (export, expected) in [
+            ("pub use hidden::calculate as exposed;", "exposed"),
+            (
+                "mod bridge { pub use crate::hidden::calculate as exposed; } pub use bridge::*;",
+                "exposed",
+            ),
+            ("pub use hidden::api as facade;", "facade::calculate"),
+        ] {
+            let nested = expected.contains("::");
+            let source = if nested {
+                "mod hidden { pub mod api { pub fn calculate() {} } }"
+            } else {
+                "mod hidden { pub fn calculate() {} }"
+            };
+            let routes = routes(&format!("{source} {export}"));
+            let canonical = if nested {
+                "hidden::api::calculate"
+            } else {
+                "hidden::calculate"
+            };
+            assert_eq!(routes[&path(canonical)].path, path(expected));
+        }
+    }
+
+    #[test]
+    fn rejects_private_ambiguous_and_cyclic_routes() {
+        for export in [
+            "use hidden::calculate;",
+            "pub(crate) use hidden::calculate;",
+        ] {
+            assert!(!routes(&format!(
+                "mod hidden {{ pub fn calculate() {{}} }} {export}"
+            ))
+            .contains_key(&path("hidden::calculate")));
+        }
+        let result =
+            routes("mod a { pub fn f() {} } mod b { pub fn f() {} } pub use a::*; pub use b::*;");
+        assert!(!result.contains_key(&path("a::f")));
+        assert!(!result.contains_key(&path("b::f")));
+        assert!(routes(
+            "mod a { pub use crate::b::*; } mod b { pub use crate::a::*; } pub use a::*;"
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn retains_conditional_import_predicates() {
+        let result =
+            routes("mod hidden { pub fn f() {} } #[cfg(feature = \"api\")] pub use hidden::f;");
+        assert!(!result[&path("hidden::f")].predicates.is_empty());
+    }
+
+    #[test]
+    fn conditional_alias_does_not_gate_an_unconditional_public_path() {
+        let result = routes(
+            "pub mod api { pub fn f() {} } #[cfg(feature = \"optional\")] pub use api::f as alias;",
+        );
+        assert_eq!(result[&path("api::f")].path, path("api::f"));
+        assert!(result[&path("api::f")].predicates.is_empty());
+    }
+
+    #[test]
+    fn named_import_shadows_globs_and_private_modules_stay_private() {
+        let result =
+            routes("mod a { pub fn f() {} } mod b { pub fn f() {} } pub use a::*; pub use b::f;");
+        assert_eq!(result[&path("b::f")].path, path("f"));
+        assert!(!result.contains_key(&path("a::f")));
+        let result =
+            routes("mod hidden { mod private { pub fn f() {} } } pub use hidden::private::f;");
+        assert!(!result.contains_key(&path("hidden::private::f")));
+    }
+}

--- a/deps/rustcall_core/src/public_routes.rs
+++ b/deps/rustcall_core/src/public_routes.rs
@@ -9,6 +9,15 @@ use crate::paths::{imports_of_use, visible_from, ScannedImport};
 
 type Path = Vec<String>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Namespace {
+    Type,
+    Value,
+}
+
+type RouteKey = (Namespace, Path);
+type Visiting = BTreeSet<(Namespace, Path, String)>;
+
 #[derive(Clone, Debug)]
 struct Definition {
     visibility: Visibility,
@@ -37,7 +46,7 @@ pub struct PublicRoute {
 
 #[derive(Clone, Default, Debug)]
 pub struct PublicRoutes {
-    definitions: BTreeMap<Path, Vec<Definition>>,
+    definitions: BTreeMap<RouteKey, Vec<Definition>>,
     imports: Vec<Import>,
     names: BTreeSet<String>,
 }
@@ -45,7 +54,7 @@ pub struct PublicRoutes {
 impl PublicRoutes {
     /// Resolve within one cfg variant. A public module in a mutually exclusive
     /// variant must not grant access to the private copy at the same path.
-    pub fn resolve_for(&self, cfg: &str) -> BTreeMap<Path, PublicRoute> {
+    pub fn resolve_for(&self, cfg: &str) -> BTreeMap<RouteKey, PublicRoute> {
         let compatible = |predicates: &BTreeSet<String>| {
             !predicates
                 .iter()
@@ -82,14 +91,39 @@ impl PublicRoutes {
                 self.names.insert(name.to_string());
                 path.push(name.to_string());
                 let effective = crate::cfg::effective_cfg_attrs(cfg, attrs);
+                let namespace = match item {
+                    Item::Fn(_) | Item::Const(_) | Item::Static(_) => Namespace::Value,
+                    _ => Namespace::Type,
+                };
                 self.definitions
-                    .entry(path.clone())
+                    .entry((namespace, path.clone()))
                     .or_default()
                     .push(Definition {
                         visibility: visibility.clone(),
                         module: is_module,
                         predicates: predicates(&effective),
                     });
+                if let Item::Struct(v) = item {
+                    if !matches!(v.fields, syn::Fields::Named(_)) {
+                        let constructor_visibility = if v
+                            .fields
+                            .iter()
+                            .all(|f| matches!(f.vis, Visibility::Public(_)))
+                        {
+                            visibility.clone()
+                        } else {
+                            Visibility::Inherited
+                        };
+                        self.definitions
+                            .entry((Namespace::Value, path.clone()))
+                            .or_default()
+                            .push(Definition {
+                                visibility: constructor_visibility,
+                                module: false,
+                                predicates: predicates(&effective),
+                            });
+                    }
+                }
                 if let Item::Mod(v) = item {
                     if let Some((_, items)) = &v.content {
                         self.file(items, &path, &effective);
@@ -120,17 +154,18 @@ impl PublicRoutes {
         &self,
         module: &[String],
         name: &str,
+        namespace: Namespace,
         observer: Option<&[String]>,
-        visiting: &mut BTreeSet<(Path, String)>,
+        visiting: &mut Visiting,
     ) -> BTreeSet<Target> {
-        let key = (module.to_vec(), name.to_string());
+        let key = (namespace, module.to_vec(), name.to_string());
         if !visiting.insert(key.clone()) {
             return BTreeSet::new();
         }
         let mut path = module.to_vec();
         path.push(name.to_string());
         let mut result = BTreeSet::new();
-        let direct = self.definitions.get(&path);
+        let direct = self.definitions.get(&(namespace, path.clone()));
         let explicit: Vec<_> = self
             .imports
             .iter()
@@ -148,23 +183,28 @@ impl PublicRoutes {
                 }
             }
         }
+        let mut named_present = direct.is_some();
         for import in &explicit {
+            let targets = self.import_target(import, namespace, visiting);
+            named_present |= !targets.is_empty();
             if accessible(&import.visibility, module, observer) {
-                for mut target in self.import_target(import, visiting) {
+                for mut target in targets {
                     target.predicates.extend(import.predicates.clone());
                     result.insert(target);
                 }
             }
         }
         // Named bindings shadow globs even when the named binding is private.
-        if direct.is_none() && explicit.is_empty() {
+        if !named_present {
             for import in self.imports.iter().filter(|v| {
                 v.binding.module_path == module
                     && v.binding.glob
                     && accessible(&v.visibility, module, observer)
             }) {
-                for source in self.import_target(import, visiting) {
-                    for mut target in self.name(&source.path, name, Some(module), visiting) {
+                for source in self.import_target(import, Namespace::Type, visiting) {
+                    for mut target in
+                        self.name(&source.path, name, namespace, Some(module), visiting)
+                    {
                         target.predicates.extend(source.predicates.clone());
                         target.predicates.extend(import.predicates.clone());
                         result.insert(target);
@@ -179,7 +219,8 @@ impl PublicRoutes {
     fn import_target(
         &self,
         import: &Import,
-        visiting: &mut BTreeSet<(Path, String)>,
+        namespace: Namespace,
+        visiting: &mut Visiting,
     ) -> BTreeSet<Target> {
         let binding = &import.binding;
         let mut qualifier = binding.qualifier.clone();
@@ -193,12 +234,21 @@ impl PublicRoutes {
                 path: Vec::new(),
                 predicates: BTreeSet::new(),
             }]);
-            for segment in path {
+            for (index, segment) in path.iter().enumerate() {
+                let segment_namespace = if index + 1 == path.len() {
+                    namespace
+                } else {
+                    Namespace::Type
+                };
                 let mut next = BTreeSet::new();
                 for parent in targets {
-                    for mut target in
-                        self.name(&parent.path, &segment, Some(&binding.module_path), visiting)
-                    {
+                    for mut target in self.name(
+                        &parent.path,
+                        segment,
+                        segment_namespace,
+                        Some(&binding.module_path),
+                        visiting,
+                    ) {
                         target.predicates.extend(parent.predicates.clone());
                         next.insert(target);
                     }
@@ -215,7 +265,7 @@ impl PublicRoutes {
     /// Select a deterministic externally reachable spelling for each canonical
     /// item. Ambiguous names are never chosen. Module cycles are traversed once
     /// per route, so re-export loops cannot grow paths indefinitely.
-    pub fn resolve(&self) -> BTreeMap<Path, PublicRoute> {
+    pub fn resolve(&self) -> BTreeMap<RouteKey, PublicRoute> {
         let mut result = BTreeMap::new();
         let mut queue =
             VecDeque::from([(Vec::new(), Vec::new(), BTreeSet::new(), BTreeSet::new())]);
@@ -224,47 +274,51 @@ impl PublicRoutes {
                 continue;
             }
             for name in &self.names {
-                let targets = self.name(&module, name, None, &mut BTreeSet::new());
-                if targets
-                    .iter()
-                    .map(|v| &v.path)
-                    .collect::<BTreeSet<_>>()
-                    .len()
-                    != 1
-                {
-                    continue;
-                }
-                for target in targets {
-                    let Some(definitions) = self.definitions.get(&target.path) else {
-                        continue;
-                    };
-                    if !definitions
+                for namespace in [Namespace::Type, Namespace::Value] {
+                    let targets = self.name(&module, name, namespace, None, &mut BTreeSet::new());
+                    if targets
                         .iter()
-                        .any(|v| matches!(v.visibility, Visibility::Public(_)))
+                        .map(|v| &v.path)
+                        .collect::<BTreeSet<_>>()
+                        .len()
+                        != 1
                     {
                         continue;
                     }
-                    let mut path = prefix.clone();
-                    path.push(name.clone());
-                    let mut predicates = inherited.clone();
-                    predicates.extend(target.predicates);
-                    let candidate = PublicRoute {
-                        path: path.clone(),
-                        predicates: predicates.clone(),
-                    };
-                    let rank = |route: &PublicRoute| {
-                        (route.predicates.len(), route.path.len(), route.path.clone())
-                    };
-                    result
-                        .entry(target.path.clone())
-                        .and_modify(|current| {
-                            if rank(&candidate) < rank(current) {
-                                *current = candidate.clone();
-                            }
-                        })
-                        .or_insert(candidate);
-                    if definitions.iter().any(|v| v.module) {
-                        queue.push_back((target.path, path, predicates, ancestors.clone()));
+                    for target in targets {
+                        let Some(definitions) =
+                            self.definitions.get(&(namespace, target.path.clone()))
+                        else {
+                            continue;
+                        };
+                        if !definitions
+                            .iter()
+                            .any(|v| matches!(v.visibility, Visibility::Public(_)))
+                        {
+                            continue;
+                        }
+                        let mut path = prefix.clone();
+                        path.push(name.clone());
+                        let mut predicates = inherited.clone();
+                        predicates.extend(target.predicates);
+                        let candidate = PublicRoute {
+                            path: path.clone(),
+                            predicates: predicates.clone(),
+                        };
+                        let rank = |route: &PublicRoute| {
+                            (route.predicates.len(), route.path.len(), route.path.clone())
+                        };
+                        result
+                            .entry((namespace, target.path.clone()))
+                            .and_modify(|current| {
+                                if rank(&candidate) < rank(current) {
+                                    *current = candidate.clone();
+                                }
+                            })
+                            .or_insert(candidate);
+                        if definitions.iter().any(|v| v.module) {
+                            queue.push_back((target.path, path, predicates, ancestors.clone()));
+                        }
                     }
                 }
             }
@@ -295,10 +349,46 @@ mod tests {
         let file = syn::parse_file(source).unwrap();
         let mut routes = PublicRoutes::default();
         routes.file(&file.items, &[], &[]);
-        routes.resolve()
+        routes
+            .resolve()
+            .into_iter()
+            .map(|((_, path), route)| (path, route))
+            .collect()
     }
     fn path(value: &str) -> Path {
         value.split("::").map(String::from).collect()
+    }
+
+    #[test]
+    fn canonical_type_and_value_keep_independent_routes() {
+        let file = syn::parse_file("mod hidden { pub struct Thing { pub value: i32 } pub fn Thing() {} } pub use hidden::*; pub use hidden::Thing as Z; pub fn Thing() {}").unwrap();
+        let mut scan = PublicRoutes::default();
+        scan.file(&file.items, &[], &[]);
+        let routes = scan.resolve();
+        assert_eq!(
+            routes[&(Namespace::Type, path("hidden::Thing"))].path,
+            path("Thing")
+        );
+        assert_eq!(
+            routes[&(Namespace::Value, path("hidden::Thing"))].path,
+            path("Z")
+        );
+    }
+
+    #[test]
+    fn a_named_type_does_not_shadow_a_glob_value() {
+        let file = syn::parse_file("mod types { pub struct Thing { pub value: i32 } } mod values { pub fn Thing() {} } pub use types::Thing; pub use values::*;").unwrap();
+        let mut scan = PublicRoutes::default();
+        scan.file(&file.items, &[], &[]);
+        let routes = scan.resolve();
+        assert_eq!(
+            routes[&(Namespace::Type, path("types::Thing"))].path,
+            path("Thing")
+        );
+        assert_eq!(
+            routes[&(Namespace::Value, path("values::Thing"))].path,
+            path("Thing")
+        );
     }
 
     #[test]

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -108,6 +108,8 @@ pub struct Pyo3Scan {
     classes: Vec<ScannedClass>,
     impls: Vec<ScannedImpl>,
     imports: Vec<ScannedImport>,
+    routes: crate::public_routes::PublicRoutes,
+    intrinsic_skips: std::collections::BTreeMap<(Vec<String>, String, usize, String), String>,
 }
 
 #[derive(Debug)]
@@ -215,6 +217,7 @@ impl Pyo3Scan {
         enclosing_cfg: &[syn::Attribute],
         manifest: &mut Manifest,
     ) -> Vec<PendingModule> {
+        self.routes.file(items, module_path, enclosing_cfg);
         let mut path = module_path.to_vec();
         let mut dirs = Vec::new();
         let mut pending = Vec::new();
@@ -257,6 +260,22 @@ impl Pyo3Scan {
                     }
                     match pyo3_marker(&f.attrs) {
                         Some(Pyo3Marker::Function) => {
+                            let intrinsic = function_entry(
+                                f,
+                                Attribute::PyFunction,
+                                true,
+                                module_path,
+                                enclosing_cfg,
+                            );
+                            self.intrinsic_skips.insert(
+                                (
+                                    module_path.clone(),
+                                    intrinsic.name.clone(),
+                                    intrinsic.line,
+                                    intrinsic.cfg.clone(),
+                                ),
+                                intrinsic.skip_reason,
+                            );
                             manifest.functions.push(function_entry(
                                 f,
                                 Attribute::PyFunction,
@@ -365,6 +384,54 @@ impl Pyo3Scan {
     /// Order is by (module path, line) so the result does not depend on the
     /// order the caller happened to visit files in.
     pub fn finish(mut self, manifest: &mut Manifest) {
+        let mut route_cache = std::collections::BTreeMap::new();
+        for function in &mut manifest.functions {
+            if !function.attribute.is_pyo3_scan() {
+                continue;
+            }
+            let mut canonical = function.module_path.clone();
+            canonical.push(function.name.clone());
+            let routes = route_cache
+                .entry(function.cfg.clone())
+                .or_insert_with(|| self.routes.resolve_for(&function.cfg));
+            if let Some(route) = routes.get(&canonical) {
+                if function.skip_reason == skip_reason::NOT_PUBLIC {
+                    if let Some(intrinsic) = self.intrinsic_skips.get(&(
+                        function.module_path.clone(),
+                        function.name.clone(),
+                        function.line,
+                        function.cfg.clone(),
+                    )) {
+                        function.skip_reason = intrinsic.clone();
+                    }
+                }
+                if route.path != canonical {
+                    function.callable_path = route.path.clone();
+                }
+                merge_route_cfg(&mut function.cfg, &mut function.cfg_features, route);
+            }
+        }
+        for class in &mut self.classes {
+            let mut canonical = class.module_path.clone();
+            canonical.push(class.entry.name.clone());
+            let routes = route_cache
+                .entry(class.entry.cfg.clone())
+                .or_insert_with(|| self.routes.resolve_for(&class.entry.cfg));
+            if let Some(route) = routes.get(&canonical) {
+                if class.entry.skip_reason == skip_reason::NOT_PUBLIC {
+                    class.entry.skip_reason = item_skip_reason(
+                        &class.visibility,
+                        true,
+                        !class.entry.type_params.is_empty(),
+                    )
+                    .unwrap_or_default();
+                }
+                if route.path != canonical {
+                    class.entry.callable_path = route.path.clone();
+                }
+                merge_route_cfg(&mut class.entry.cfg, &mut class.entry.cfg_features, route);
+            }
+        }
         self.impls.sort_by(|a, b| {
             a.header
                 .module_path
@@ -971,6 +1038,32 @@ fn struct_symbols(s: &Struct) -> Vec<String> {
     out
 }
 
+fn merge_route_cfg(
+    cfg: &mut String,
+    features: &mut Vec<String>,
+    route: &crate::public_routes::PublicRoute,
+) {
+    let mut predicates = route.predicates.clone();
+    if !cfg.is_empty() {
+        predicates.insert(cfg.clone());
+    }
+    if predicates.is_empty() {
+        return;
+    }
+    *cfg = if predicates.len() == 1 {
+        predicates.into_iter().next().unwrap()
+    } else {
+        format!(
+            "all({})",
+            predicates.into_iter().collect::<Vec<_>>().join(",")
+        )
+    };
+    let meta: syn::Meta =
+        syn::parse_str(&format!("cfg({cfg})")).expect("cfg predicates came from syn");
+    let attrs: Vec<syn::Attribute> = vec![syn::parse_quote!(#[#meta])];
+    *features = crate::cfg::predicate_features(&attrs);
+}
+
 fn qualified(module_path: &[String], name: &str) -> String {
     if module_path.is_empty() {
         name.to_string()
@@ -1052,6 +1145,7 @@ fn function_entry(
         body_has_cfg: crate::cfg::body_has_cfg(&func.block),
         line: func.span().start().line,
         module_path: module_path.to_vec(),
+        callable_path: Vec::new(),
     }
 }
 
@@ -1148,6 +1242,7 @@ fn class_entry(
         generic_wrappers: Vec::new(),
         line: item.span().start().line,
         module_path: module_path.to_vec(),
+        callable_path: Vec::new(),
     }
 }
 

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -117,6 +117,9 @@ struct ScannedClass {
     module_path: Vec<String>,
     entry: Struct,
     visibility: syn::Visibility,
+    /// Accessors under the same field/type checks, before module reachability
+    /// disables them. A public re-export can restore that reachability later.
+    reachable_fields: Vec<Field>,
     /// The `#[cfg]` of the enclosing modules: what tells cfg-exclusive copies
     /// of one fragment apart, and what a `#[pymethods]` block written beside
     /// one copy shares with it (#357 review).
@@ -304,6 +307,8 @@ impl Pyo3Scan {
                         self.classes.push(ScannedClass {
                             module_path: module_path.clone(),
                             entry: class_entry(s, reachable, module_path, enclosing_cfg),
+                            reachable_fields: class_entry(s, true, module_path, enclosing_cfg)
+                                .fields,
                             visibility: s.vis.clone(),
                             cfg: enclosing_cfg.to_vec(),
                         });
@@ -425,6 +430,7 @@ impl Pyo3Scan {
                         !class.entry.type_params.is_empty(),
                     )
                     .unwrap_or_default();
+                    class.entry.fields = std::mem::take(&mut class.reachable_fields);
                 }
                 if route.path != canonical {
                     class.entry.callable_path = route.path.clone();

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -399,7 +399,9 @@ impl Pyo3Scan {
             let routes = route_cache
                 .entry(function.cfg.clone())
                 .or_insert_with(|| self.routes.resolve_for(&function.cfg));
-            if let Some(route) = routes.get(&canonical) {
+            if let Some(route) =
+                routes.get(&(crate::public_routes::Namespace::Value, canonical.clone()))
+            {
                 if function.skip_reason == skip_reason::NOT_PUBLIC {
                     if let Some(intrinsic) = self.intrinsic_skips.get(&(
                         function.module_path.clone(),
@@ -422,7 +424,9 @@ impl Pyo3Scan {
             let routes = route_cache
                 .entry(class.entry.cfg.clone())
                 .or_insert_with(|| self.routes.resolve_for(&class.entry.cfg));
-            if let Some(route) = routes.get(&canonical) {
+            if let Some(route) =
+                routes.get(&(crate::public_routes::Namespace::Type, canonical.clone()))
+            {
                 if class.entry.skip_reason == skip_reason::NOT_PUBLIC {
                     class.entry.skip_reason = item_skip_reason(
                         &class.visibility,

--- a/deps/rustcall_core/src/specialize.rs
+++ b/deps/rustcall_core/src/specialize.rs
@@ -465,6 +465,7 @@ fn function_entry(func: &ItemFn, module_path: &[String]) -> Function {
         .collect();
     let return_type = return_type_to_string(&func.sig.output);
     Function {
+        callable_path: Vec::new(),
         cfg: crate::cfg::predicate_string(&func.attrs),
         cfg_features: crate::cfg::predicate_features(&func.attrs),
         name: func.sig.ident.to_string(),

--- a/deps/rustcall_core/src/wrap.rs
+++ b/deps/rustcall_core/src/wrap.rs
@@ -258,7 +258,12 @@ fn function_wrapper(
         receiver: None,
         args,
         ret: plan.ret,
-        target: CallTarget::Free(item_path(krate, &f.module_path, &f.name)),
+        target: CallTarget::Free(callable_path(
+            krate,
+            &f.callable_path,
+            &f.module_path,
+            &f.name,
+        )),
         call_suffix: plan.call_suffix,
     });
 
@@ -288,7 +293,7 @@ fn function_wrapper(
 /// the build the wrapper is compiled against may not have it, and a call to a
 /// missing member is a compile error in generated code (#307 review).
 fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStream2 {
-    let class = item_path(krate, &s.module_path, &s.name);
+    let class = callable_path(krate, &s.callable_path, &s.module_path, &s.name);
     let mut out = TokenStream2::new();
 
     // `<Struct>_free`, the destructor `RustCall.ffi_struct_free_symbol` names
@@ -718,6 +723,13 @@ fn item_path(krate: &Ident, module_path: &[String], name: &str) -> syn::Path {
     }
     path.segments.push(format_ident!("{}", name).into());
     path
+}
+
+fn callable_path(krate: &Ident, route: &[String], module: &[String], name: &str) -> syn::Path {
+    match route.split_last() {
+        Some((name, module)) => item_path(krate, module, name),
+        None => item_path(krate, module, name),
+    }
 }
 
 fn symbol_ident(name: &str) -> Result<Ident, String> {

--- a/deps/rustcall_core/tests/corpus/cfg_items.crate.toml
+++ b/deps/rustcall_core/tests/corpus/cfg_items.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/cfg_items.inline.toml
+++ b/deps/rustcall_core/tests/corpus/cfg_items.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.crate.toml
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 functions = []
 

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.inline.toml
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 functions = []
 

--- a/deps/rustcall_core/tests/corpus/generics_and_crate.crate.toml
+++ b/deps/rustcall_core/tests/corpus/generics_and_crate.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/generics_and_crate.inline.toml
+++ b/deps/rustcall_core/tests/corpus/generics_and_crate.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/modules.crate.toml
+++ b/deps/rustcall_core/tests/corpus/modules.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/modules.inline.toml
+++ b/deps/rustcall_core/tests/corpus/modules.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.crate.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.inline.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 structs = []
 

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.crate.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.inline.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 structs = []
 

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/strings.crate.toml
+++ b/deps/rustcall_core/tests/corpus/strings.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/strings.inline.toml
+++ b/deps/rustcall_core/tests/corpus/strings.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.crate.toml
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.inline.toml
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/syntax_stress.crate.toml
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "crate"
 structs = []
 

--- a/deps/rustcall_core/tests/corpus/syntax_stress.inline.toml
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 8
+schema_version = 9
 mode = "inline"
 structs = []
 

--- a/deps/rustcall_core/tests/pyo3_public_routes.rs
+++ b/deps/rustcall_core/tests/pyo3_public_routes.rs
@@ -1,6 +1,66 @@
 use rustcall_core::{extract::extract, manifest::Mode, wrap::wrapper_crate};
 
 #[test]
+fn renamed_and_named_self_imports_expose_modules() {
+    for route in [
+        "pub use outer::inner::{self as facade};",
+        "pub use outer::inner::{self};",
+    ] {
+        let scanned = extract(&format!(
+            "mod outer {{ pub mod inner {{ #[pyfunction] pub fn calculate() -> i32 {{ 42 }} }} }} {route}"
+        ), Mode::Crate).unwrap();
+        let expected = if route.contains("facade") {
+            "facade"
+        } else {
+            "inner"
+        };
+        assert!(scanned.functions[0].skip_reason.is_empty());
+        assert_eq!(scanned.functions[0].callable_path, [expected, "calculate"]);
+        let wrapped = wrapper_crate(&scanned, "user_crate", true);
+        assert!(wrapped
+            .lib_rs
+            .contains(&format!("user_crate::{expected}::calculate()")));
+    }
+}
+
+#[test]
+fn enum_variant_globs_prevent_ambiguous_function_routes() {
+    for variant in ["calculate", "calculate(i32)"] {
+        let scanned = extract(
+            &format!(
+                r#"
+            mod a {{ pub enum E {{ {variant} }} pub use E::*; }}
+            mod b {{ #[pyfunction] pub fn calculate() -> i32 {{ 42 }} }}
+            pub use a::*;
+            pub use b::*;
+        "#
+            ),
+            Mode::Crate,
+        )
+        .unwrap();
+        assert_eq!(scanned.functions[0].skip_reason, "not_public");
+        assert!(scanned.functions[0].callable_path.is_empty());
+    }
+}
+
+#[test]
+fn disabled_enum_variants_do_not_block_public_function_routes() {
+    let scanned = rustcall_core::extract::extract_with_cfg(
+        r#"
+        mod a { pub enum E { #[cfg(any())] calculate } pub use E::*; }
+        mod b { #[pyfunction] pub fn calculate() -> i32 { 42 } }
+        pub use a::*;
+        pub use b::*;
+    "#,
+        Mode::Crate,
+        Some(&rustcall_core::cfg::CfgSet::default()),
+    )
+    .unwrap();
+    assert!(scanned.functions[0].skip_reason.is_empty());
+    assert_eq!(scanned.functions[0].callable_path, ["calculate"]);
+}
+
+#[test]
 fn public_class_and_unrelated_same_named_value_are_not_ambiguous() {
     let scanned = extract(
         r#"

--- a/deps/rustcall_core/tests/pyo3_public_routes.rs
+++ b/deps/rustcall_core/tests/pyo3_public_routes.rs
@@ -1,6 +1,59 @@
 use rustcall_core::{extract::extract, manifest::Mode, wrap::wrapper_crate};
 
 #[test]
+fn public_alias_restores_only_supported_field_accessors() {
+    for options in ["", "get_all, set_all", "get_all, frozen"] {
+        let definition = format!(
+            r#"
+            #[pyclass({options})] pub struct Counter {{
+                #[pyo3(get, set)] pub value: i32,
+                #[pyo3(get, set)] pub text: String,
+                #[pyo3(get, set)] private: i32,
+                #[pyo3(get, set)] pub unsupported: Vec<i32>,
+                pub automatic: i32,
+            }}
+        "#
+        );
+        let direct = extract(&format!("pub mod hidden {{ {definition} }}"), Mode::Crate).unwrap();
+        let alias = extract(
+            &format!("mod hidden {{ {definition} }} pub use hidden::Counter as PublicCounter;"),
+            Mode::Crate,
+        )
+        .unwrap();
+        assert_eq!(
+            alias.structs[0].fields, direct.structs[0].fields,
+            "{options}"
+        );
+        let fields = &alias.structs[0].fields;
+        assert!(!fields[0].getter.is_empty());
+        assert_eq!(fields[0].setter.is_empty(), options.contains("frozen"));
+        assert!(fields[2].getter.is_empty() && fields[2].setter.is_empty());
+        assert!(fields[3].getter.is_empty() && fields[3].setter.is_empty());
+        let wrapped = wrapper_crate(&alias, "user_crate", true);
+        assert!(wrapped
+            .lib_rs
+            .contains("rustcall_hidden__Counter_get_value"));
+    }
+}
+
+#[test]
+fn underscore_imports_never_grant_callable_routes() {
+    let source = "mod hidden { #[pyfunction] pub fn calculate() -> i32 { 42 } } pub use hidden::calculate as _;";
+    let anonymous = extract(source, Mode::Crate).unwrap();
+    assert_eq!(anonymous.functions[0].skip_reason, "not_public");
+    assert!(anonymous.functions[0].callable_path.is_empty());
+    let named = extract(
+        &format!("{source} pub use hidden::calculate as public_calculate;"),
+        Mode::Crate,
+    )
+    .unwrap();
+    assert!(named.functions[0].skip_reason.is_empty());
+    assert_eq!(named.functions[0].callable_path, ["public_calculate"]);
+    let wrapped = wrapper_crate(&named, "user_crate", true);
+    assert!(wrapped.lib_rs.contains("user_crate::public_calculate"));
+}
+
+#[test]
 fn intrinsic_signature_reasons_are_owned_by_the_cfg_variant() {
     // Identical canonical name and source line, as when two cfg-exclusive
     // fragments define different signatures at the same source position.

--- a/deps/rustcall_core/tests/pyo3_public_routes.rs
+++ b/deps/rustcall_core/tests/pyo3_public_routes.rs
@@ -1,0 +1,196 @@
+use rustcall_core::{extract::extract, manifest::Mode, wrap::wrapper_crate};
+
+#[test]
+fn intrinsic_signature_reasons_are_owned_by_the_cfg_variant() {
+    // Identical canonical name and source line, as when two cfg-exclusive
+    // fragments define different signatures at the same source position.
+    let source = r#"#[cfg(feature = "x")] mod hidden { #[pyfunction] pub fn f() -> i32 { 1 } } #[cfg(not(feature = "x"))] mod hidden { #[pyfunction] pub async fn f() -> i32 { 2 } } pub use hidden::f;"#;
+    let manifest = extract(source, Mode::Crate).unwrap();
+    let normal = manifest
+        .functions
+        .iter()
+        .find(|f| f.cfg == "feature = \"x\"")
+        .unwrap();
+    let asynchronous = manifest
+        .functions
+        .iter()
+        .find(|f| f.cfg == "not(feature = \"x\")")
+        .unwrap();
+    assert_eq!(normal.line, asynchronous.line);
+    assert!(normal.skip_reason.is_empty());
+    assert_eq!(asynchronous.skip_reason, "async_fn");
+}
+
+#[test]
+fn cfg_exclusive_module_copies_do_not_share_reachability() {
+    let manifest = extract(
+        r#"
+        #[cfg(feature = "x")]
+        pub mod api { #[pyfunction] pub fn calculate() -> i32 { 1 } }
+        #[cfg(not(feature = "x"))]
+        mod api { #[pyfunction] pub fn calculate() -> i32 { 2 } }
+    "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    assert_eq!(manifest.functions.len(), 2);
+    let public = manifest
+        .functions
+        .iter()
+        .find(|f| f.cfg == "feature = \"x\"")
+        .unwrap();
+    let private = manifest
+        .functions
+        .iter()
+        .find(|f| f.cfg == "not(feature = \"x\")")
+        .unwrap();
+    assert!(public.skip_reason.is_empty());
+    assert_eq!(private.skip_reason, "not_public");
+}
+
+#[test]
+fn cfg_exclusive_classes_keep_their_methods_predicate() {
+    let manifest = extract(
+        r#"
+        #[cfg(feature = "x")]
+        pub mod api {
+            #[pyclass] pub struct Counter;
+            #[pymethods] impl Counter { pub fn value(&self) -> i32 { 1 } }
+        }
+        #[cfg(not(feature = "x"))]
+        pub mod api {
+            #[pyclass] pub struct Counter;
+            #[pymethods] impl Counter { pub fn value(&self) -> i32 { 2 } }
+        }
+    "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    assert_eq!(manifest.structs.len(), 2);
+    for class in manifest.structs {
+        assert_eq!(class.methods.len(), 1);
+        assert_eq!(class.methods[0].cfg, class.cfg);
+        assert!(class.methods[0].skip_reason.is_empty());
+    }
+}
+
+#[test]
+fn public_routes_follow_the_selected_feature_and_keep_lenient_cfg() {
+    use rustcall_core::{cfg::CfgSet, extract::extract_with_cfg};
+    let source = r#"
+        mod hidden { #[pyfunction] pub fn calculate() -> i32 { 42 } }
+        #[cfg(feature = "api")] pub use hidden::calculate as exposed;
+    "#;
+    let disabled = extract_with_cfg(source, Mode::Crate, Some(&CfgSet::default())).unwrap();
+    assert_eq!(disabled.functions[0].skip_reason, "not_public");
+    let enabled = extract_with_cfg(
+        source,
+        Mode::Crate,
+        Some(&CfgSet::default().with_pair("feature", "api")),
+    )
+    .unwrap();
+    assert!(enabled.functions[0].skip_reason.is_empty());
+    assert_eq!(enabled.functions[0].callable_path, ["exposed"]);
+    let lenient = extract(source, Mode::Crate).unwrap();
+    assert!(lenient.functions[0]
+        .cfg_features
+        .contains(&"api".to_string()));
+    let wrapped = wrapper_crate(&lenient, "user_crate", false);
+    assert!(!wrapped.manifest.functions[0].skip_reason.is_empty());
+}
+
+#[test]
+fn a_public_alias_exposes_a_function_in_a_private_module() {
+    let scanned = extract(
+        r#"
+        mod hidden { #[pyfunction] pub fn calculate() -> i32 { 42 } }
+        pub use hidden::calculate as public_calculate;
+    "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    let function = &scanned.functions[0];
+    assert!(function.skip_reason.is_empty(), "{}", function.skip_reason);
+    assert_eq!(function.module_path, ["hidden"]);
+    let wrapped = wrapper_crate(&scanned, "user_crate", true);
+    assert!(wrapped.lib_rs.contains("user_crate::public_calculate"));
+    assert!(!wrapped.lib_rs.contains("user_crate::hidden::calculate"));
+}
+
+#[test]
+fn public_class_routes_are_resolved_before_method_attachment() {
+    let scanned = extract(
+        r#"
+        mod hidden {
+            #[pyclass] pub struct Counter { value: i32 }
+            #[pymethods] impl Counter {
+                #[new] pub fn new() -> Self { Self { value: 7 } }
+                pub fn value(&self) -> i32 { self.value }
+            }
+        }
+        pub use hidden::Counter as PublicCounter;
+    "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    let class = &scanned.structs[0];
+    assert!(class.skip_reason.is_empty(), "{}", class.skip_reason);
+    assert_eq!(class.methods.len(), 2);
+    assert!(class
+        .methods
+        .iter()
+        .all(|method| method.skip_reason.is_empty()));
+    let wrapped = wrapper_crate(&scanned, "user_crate", true);
+    assert!(wrapped.lib_rs.contains("user_crate::PublicCounter"));
+    assert!(!wrapped.lib_rs.contains("user_crate::hidden::Counter"));
+}
+
+#[test]
+fn chained_glob_and_module_alias_routes_reach_the_same_definition() {
+    for exports in [
+        "mod bridge { pub use crate::hidden::calculate as renamed; } pub use bridge::renamed;",
+        "pub use hidden::*;",
+        "pub use hidden::api as public_api;",
+    ] {
+        let definition = if exports.contains("hidden::api") {
+            "mod hidden { pub mod api { #[pyfunction] pub fn calculate() -> i32 { 42 } } }"
+        } else {
+            "mod hidden { #[pyfunction] pub fn calculate() -> i32 { 42 } }"
+        };
+        let scanned = extract(&format!("{definition} {exports}"), Mode::Crate).unwrap();
+        assert!(scanned.functions[0].skip_reason.is_empty(), "{exports}");
+        assert_eq!(scanned.functions.len(), 1);
+    }
+}
+
+#[test]
+fn private_routes_do_not_grant_access_and_public_routes_keep_signature_checks() {
+    for exports in [
+        "use hidden::calculate;",
+        "pub(crate) use hidden::calculate;",
+    ] {
+        let scanned = extract(
+            &format!(
+                r#"
+            mod hidden {{ #[pyfunction] pub fn calculate() -> i32 {{ 42 }} }}
+            {exports}
+        "#
+            ),
+            Mode::Crate,
+        )
+        .unwrap();
+        assert!(!scanned.functions[0].skip_reason.is_empty());
+    }
+    let scanned = extract(
+        r#"
+        mod hidden { #[pyfunction] pub async fn calculate() -> i32 { 42 } }
+        pub use hidden::calculate;
+    "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    assert_eq!(
+        scanned.functions[0].skip_reason,
+        rustcall_core::manifest::skip_reason::ASYNC_FN
+    );
+}

--- a/deps/rustcall_core/tests/pyo3_public_routes.rs
+++ b/deps/rustcall_core/tests/pyo3_public_routes.rs
@@ -1,6 +1,29 @@
 use rustcall_core::{extract::extract, manifest::Mode, wrap::wrapper_crate};
 
 #[test]
+fn public_class_and_unrelated_same_named_value_are_not_ambiguous() {
+    let scanned = extract(
+        r#"
+        mod hidden {
+            #[pyclass] pub struct Thing { #[pyo3(get, set)] pub value: i32 }
+            #[pymethods] impl Thing { #[new] pub fn new() -> Self { Self { value: 42 } } }
+        }
+        pub use hidden::Thing;
+        pub fn Thing() -> i32 { 99 }
+    "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    let class = &scanned.structs[0];
+    assert!(class.skip_reason.is_empty());
+    assert_eq!(class.callable_path, ["Thing"]);
+    assert!(!class.fields[0].getter.is_empty());
+    assert!(class.methods[0].skip_reason.is_empty());
+    let wrapped = wrapper_crate(&scanned, "user_crate", true);
+    assert!(wrapped.lib_rs.contains("user_crate::Thing::new()"));
+}
+
+#[test]
 fn public_alias_restores_only_supported_field_accessors() {
     for options in ["", "get_all, set_all", "get_all, frozen"] {
         let definition = format!(

--- a/docs/src/pyo3.md
+++ b/docs/src/pyo3.md
@@ -255,7 +255,7 @@ nothing emits it yet. The manifest describes what Phase 2 will generate.
 
 | reason | meaning |
 | --- | --- |
-| `not_public` | the item is not `pub`, so a wrapper crate compiled outside the scanned crate cannot name it (rustc `E0603`). A `pub` item inside a private `mod` counts as private. |
+| `not_public` | no externally accessible Rust path names the item. A `pub` item inside a private module can be wrapped when an accessible `pub use` re-exports it. Restricted or private imports do not grant access. |
 | `pyo3_type:<T>` | the signature mentions `<T>`, which only exists with a live interpreter: `PyObject`, `Py<T>`, `Bound<'_, T>`, `&PyAny`, `Python<'_>`, `PyRef`, `PyRefMut`, anything under `pyo3::` |
 | `pymodule` | a `#[pymodule]` initializer: it exists to be called by Python's import machinery |
 | `generic` | a generic item; monomorphizing PyO3 items is out of scope |
@@ -313,16 +313,27 @@ can be hidden behind a concrete, non-generic `#[pyclass]`.
 
 ### Modules are followed, not guessed
 
-An item's `module_path` is what a wrapper crate has to write
-(`user_crate::api::item`), so it has to be right. The extractor therefore
+An item's `module_path` records its canonical definition location, which fixes
+its exported symbol identity and Julia module layout. Schema 9 adds
+`callable_path` for an external Rust spelling when a public re-export is needed;
+an empty path uses `module_path` plus the item's name. The extractor therefore
 follows the crate's module tree from `src/lib.rs` (`rustcall-extract manifest
 --crate-root`) rather than treating each `.rs` file as its own root:
 `pub mod api;` backed by `src/api.rs`, `src/deep/mod.rs`, `#[path = "..."]`
 overrides, and an out-of-line module declared inside an inline one
 (`mod outer { pub mod child; }` → `src/outer/child.rs`) are all resolved the
-way rustc resolves them. That is also how a private parent is caught — a
-`mod hidden;` without `pub` makes everything inside it `not_public`, however
-`pub` the items themselves are.
+way rustc resolves them. A private parent blocks direct access, but an accessible
+`pub use hidden::Item as PublicItem` can provide the external call path.
+Named, chained and glob re-exports, including aliases of public modules, are
+resolved separately from local imports used to attach impl blocks. Private or
+restricted imports, inaccessible intermediate modules and ambiguous glob names
+do not grant external access. Conditional routes retain their cfg; an
+unconditional public route is preferred over a conditional alias.
+
+Aliases do not create duplicate Julia owning types: the class is still bound
+once at its canonical Julia module location, while its constructor, methods
+and destructor call the accessible Rust spelling. Public reachability does not
+remove other restrictions such as async or unsupported signatures.
 
 The root is the crate's library root: `[lib] path` when the manifest sets one,
 otherwise `src/lib.rs`. A `mod` declaration whose file does not exist (behind a

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -870,7 +870,10 @@ function _warn_if_build_env_changed(recorded, crate_path::AbstractString, lib_na
             @debug "Could not fingerprint the toolchain" exception = e
             recorded_toolchain
         end
-        now_toolchain == recorded_toolchain || push!(changed, "<Rust toolchain>")
+        if now_toolchain != recorded_toolchain
+            @debug "Generated crate toolchain mismatch" lib_name crate_path recorded_toolchain now_toolchain
+            push!(changed, "<Rust toolchain>")
+        end
     end
     isempty(changed) && return nothing
     message = """
@@ -959,6 +962,7 @@ function emit_crate_module(info::CrateInfo, lib_path::String;
         @debug "Could not record the toolchain fingerprint" exception = e
         ""
     end
+    @debug "Recording generated crate toolchain" lib_key toolchain
     crate_dir = abspath(String(info.path))
     # The effective Cargo configuration is chosen by `CARGO_HOME`, which is not
     # an allowlisted variable: its digest is what says whether the same build

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -44,7 +44,7 @@ release a cross-module method's `String` through a symbol the library does not
 export, and leak it. The version is what makes such a consumer refuse the
 manifest rather than get the owner wrong (#342 review).
 """
-const MANIFEST_SCHEMA_VERSION = 8
+const MANIFEST_SCHEMA_VERSION = 9
 
 """
     ExtractorError <: Exception

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -178,6 +178,7 @@ function toolchain_fingerprint()
                 "cfg=$(bytes2hex(sha256(_rustc_cfg_text())))",
             ]
             fingerprint = bytes2hex(sha256(join(parts, "\n")))
+            @debug "Computed RustCall toolchain fingerprint" fingerprint parts
             # A fingerprint computed without a usable toolchain describes
             # nothing that could have been compiled; never memoize it.
             identified || return fingerprint

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -126,9 +126,12 @@ function _rust_sources_digest(dirs::AbstractString...)
     ctx = IOBuffer()
     for dir in dirs
         files = String[]
-        for (root, _, names) in walkdir(dir)
+        manifest = joinpath(dir, "Cargo.toml")
+        isfile(manifest) && push!(files, manifest)
+        source = joinpath(dir, "src")
+        for (root, _, names) in (isdir(source) ? walkdir(source) : ())
             for n in names
-                if endswith(n, ".rs") || n == "Cargo.toml"
+                if endswith(n, ".rs")
                     push!(files, joinpath(root, n))
                 end
             end
@@ -178,7 +181,7 @@ function toolchain_fingerprint()
                 "cfg=$(bytes2hex(sha256(_rustc_cfg_text())))",
             ]
             fingerprint = bytes2hex(sha256(join(parts, "\n")))
-            @debug "Computed RustCall toolchain fingerprint" fingerprint parts
+            @debug "Computed RustCall toolchain fingerprint" fingerprint components = join(parts, "\n")
             # A fingerprint computed without a usable toolchain describes
             # nothing that could have been compiled; never memoize it.
             identified || return fingerprint

--- a/test/test_julia_attribute.jl
+++ b/test/test_julia_attribute.jl
@@ -165,8 +165,9 @@ using Libdl
     end
 
     @testset "manifest: schema version guard" begin
-        @test RustCall.MANIFEST_SCHEMA_VERSION == 8
-        @test RustCall._parse_manifest("schema_version = 8\nmode = \"inline\"\n")["schema_version"] == 8
+        @test RustCall.MANIFEST_SCHEMA_VERSION == 9
+        @test RustCall._parse_manifest("schema_version = 9\nmode = \"inline\"\n")["schema_version"] == 9
+        @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 8\nmode = \"inline\"\n")
         # Schema 1 predates the string ABI columns (`abi`, `return_abi`, the
         # helper flags), schema 2 predates the additive `symbol` semantics
         # (#279), schema 3 predates the contract columns
@@ -193,7 +194,7 @@ using Libdl
         end
         @test err isa RustCall.ExtractorError
         @test occursin("schema 1", sprint(showerror, err))
-        @test occursin("expects 8", sprint(showerror, err))
+        @test occursin("expects 9", sprint(showerror, err))
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 2\nmode = \"inline\"\n")
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 3\nmode = \"inline\"\n")
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 4\nmode = \"inline\"\n")

--- a/test/test_manifest.jl
+++ b/test/test_manifest.jl
@@ -2,6 +2,27 @@
 # the only component that interprets Rust syntax; Julia consumes its manifest.
 using RustCall
 using Test
+
+@testset "Rust source digest ignores Cargo outputs and tests" begin
+    mktempdir() do root
+        mkpath(joinpath(root, "src", "nested"))
+        mkpath(joinpath(root, "target", "debug", "build", "generated", "out"))
+        mkpath(joinpath(root, "tests"))
+        write(joinpath(root, "Cargo.toml"), "[package]\nname = \"digest\"\nversion = \"0.1.0\"\n")
+        source = joinpath(root, "src", "nested", "lib.rs")
+        output = joinpath(root, "target", "debug", "build", "generated", "out", "private.rs")
+        test_source = joinpath(root, "tests", "integration.rs")
+        write(source, "pub fn value() -> i32 { 1 }")
+        write(output, "generated one")
+        write(test_source, "test one")
+        baseline = RustCall._rust_sources_digest(root)
+        write(output, "generated two")
+        write(test_source, "test two")
+        @test RustCall._rust_sources_digest(root) == baseline
+        write(source, "pub fn value() -> i32 { 2 }")
+        @test RustCall._rust_sources_digest(root) != baseline
+    end
+end
 using TOML
 
 @testset "FFI Manifest" begin

--- a/test/test_pyo3_public_routes.jl
+++ b/test/test_pyo3_public_routes.jl
@@ -17,7 +17,7 @@ function _public_route_wrapper303(file_module)
         hidden_source = raw"""
                 use pyo3::prelude::*;
                 #[pyfunction] pub fn calculate() -> i32 { 42 }
-                #[pyclass] pub struct Counter { value: i32 }
+                #[pyclass] pub struct Counter { #[pyo3(get, set)] pub value: i32 }
                 #[pymethods] impl Counter {
                     #[new] pub fn new(value: i32) -> Self { Self { value } }
                     pub fn value(&self) -> i32 { self.value }
@@ -37,6 +37,7 @@ function _public_route_wrapper303(file_module)
             mod bridge { pub use crate::hidden::Counter as PublicCounter; }
             pub use bridge::*;
             pub use hidden::calculate as public_calculate;
+            pub use hidden::calculate as _;
             pub use hidden::api as public_api;
             """)
         wrapper = _link_libpython_wrapper(root)
@@ -58,6 +59,10 @@ function _public_route_wrapper303(file_module)
                 @test Base.invokelatest(calculate) == 42
                 object = Base.invokelatest(counter, Int32(23))
                 @test Base.invokelatest(value, object) == 23
+                @test Base.invokelatest(getproperty, object, :value) == 23
+                Base.invokelatest(setproperty!, object, :value, Int32(31))
+                @test Base.invokelatest(getproperty, object, :value) == 31
+                @test Base.invokelatest(value, object) == 31
                 @test Base.invokelatest(answer) == 17
             finally
                 object === nothing || finalize(object)

--- a/test/test_pyo3_public_routes.jl
+++ b/test/test_pyo3_public_routes.jl
@@ -1,0 +1,76 @@
+using RustCall, Test
+include(joinpath(@__DIR__, "pyo3_wrapper_helpers.jl"))
+
+function _public_route_wrapper303(file_module)
+    mktempdir() do root
+        mkpath(joinpath(root, "src"))
+        write(joinpath(root, "Cargo.toml"), """
+            [package]
+            name = "public_routes303"
+            version = "0.1.0"
+            edition = "2021"
+            [lib]
+            crate-type = ["rlib"]
+            [dependencies]
+            pyo3 = { version = "0.29", default-features = false, features = ["macros"] }
+            """)
+        hidden_source = raw"""
+                use pyo3::prelude::*;
+                #[pyfunction] pub fn calculate() -> i32 { 42 }
+                #[pyclass] pub struct Counter { value: i32 }
+                #[pymethods] impl Counter {
+                    #[new] pub fn new(value: i32) -> Self { Self { value } }
+                    pub fn value(&self) -> i32 { self.value }
+                }
+                pub mod api {
+                    use pyo3::prelude::*;
+                    #[pyfunction] pub fn answer() -> i32 { 17 }
+                }
+            """
+        module_source = if file_module
+            write(joinpath(root, "src", "implementation.rs"), hidden_source)
+            "#[path = \"implementation.rs\"] mod hidden;"
+        else
+            "mod hidden {\n" * hidden_source * "\n}"
+        end
+        write(joinpath(root, "src", "lib.rs"), module_source * raw"""
+            mod bridge { pub use crate::hidden::Counter as PublicCounter; }
+            pub use bridge::*;
+            pub use hidden::calculate as public_calculate;
+            pub use hidden::api as public_api;
+            """)
+        wrapper = _link_libpython_wrapper(root)
+        if wrapper === nothing
+            @test_skip "no linkable Python here"
+        else
+            bindings = @rust_crate root
+            module_ = getfield(bindings, :module_ref)
+            object = nothing
+            try
+                # Julia's canonical layout is unchanged; only the external
+                # Rust call path uses the public aliases. One owning type.
+                hidden = Base.invokelatest(getfield, module_, :hidden)
+                calculate = Base.invokelatest(getfield, hidden, :calculate)
+                counter = Base.invokelatest(getfield, hidden, :Counter)
+                value = Base.invokelatest(getfield, hidden, :value)
+                api = Base.invokelatest(getfield, hidden, :api)
+                answer = Base.invokelatest(getfield, api, :answer)
+                @test Base.invokelatest(calculate) == 42
+                object = Base.invokelatest(counter, Int32(23))
+                @test Base.invokelatest(value, object) == 23
+                @test Base.invokelatest(answer) == 17
+            finally
+                object === nothing || finalize(object)
+                name = Base.invokelatest(getfield, module_, :_LIB_NAME)
+                RustCall.unload_library(name; close = true)
+                RustCall.close_retired_handles!(RustCall.retired_handles(name))
+            end
+        end
+    end
+end
+
+@testset "public re-exports build and call real PyO3 wrappers (#303)" begin
+    @testset "$layout module" for layout in (:inline, :file)
+        _public_route_wrapper303(layout === :file)
+    end
+end

--- a/test/test_pyo3_public_routes.jl
+++ b/test/test_pyo3_public_routes.jl
@@ -36,6 +36,9 @@ function _public_route_wrapper303(file_module)
         write(joinpath(root, "src", "lib.rs"), module_source * raw"""
             mod bridge { pub use crate::hidden::Counter as PublicCounter; }
             pub use bridge::*;
+            // Rust permits this value beside the re-exported type. It must
+            // not make the class's type-namespace route ambiguous.
+            #[allow(non_snake_case)] pub fn PublicCounter() -> i32 { 99 }
             pub use hidden::calculate as public_calculate;
             pub use hidden::calculate as _;
             pub use hidden::api as public_api;

--- a/test/test_pyo3_public_routes.jl
+++ b/test/test_pyo3_public_routes.jl
@@ -41,7 +41,14 @@ function _public_route_wrapper303(file_module)
             #[allow(non_snake_case)] pub fn PublicCounter() -> i32 { 99 }
             pub use hidden::calculate as public_calculate;
             pub use hidden::calculate as _;
-            pub use hidden::api as public_api;
+            pub use hidden::api::{self as public_api};
+            mod functions { pub use crate::hidden::calculate; }
+            mod variants {
+                #[allow(non_camel_case_types)] pub enum E { calculate }
+                pub use E::*;
+            }
+            pub use functions::*;
+            pub use variants::*;
             """)
         wrapper = _link_libpython_wrapper(root)
         if wrapper === nothing


### PR DESCRIPTION
## Scope

Advances #303. Follow-up to merged #362; the remaining PyO3 breadth work is
still tracked on that issue. This PR is not a release publication.

## Public Rust call paths

- Resolve public named/renamed/chained/glob imports and public module aliases
  separately from local imports used to attach impls.
- Preserve canonical definition paths for symbol identity and Julia layout.
  Schema 9 adds a distinct callable_path for external wrapper calls; aliases
  do not create duplicate owning Julia types.
- Resolve class reachability before attaching methods. A public alias does
  not erase independent unsupported-signature reasons.
- Keep cfg predicates from re-export routes. Prefer an unconditional public
  route over a conditional shortcut. Restricted/private imports, inaccessible
  intermediate modules, ambiguous globs and unanchored cycles grant no access.

## Evidence

| Requirement | Named test |
| --- | --- |
| Public function alias and correct external wrapper spelling | a_public_alias_exposes_a_function_in_a_private_module |
| Class aliases enable constructors and methods together | public_class_routes_are_resolved_before_method_attachment |
| Chains, globs and module aliases preserve canonical identity | chained_glob_and_module_alias_routes_reach_the_same_definition |
| Private/restricted imports and async signatures remain refused | private_routes_do_not_grant_access_and_public_routes_keep_signature_checks |
| Feature-selected and unresolved cfg routes | public_routes_follow_the_selected_feature_and_keep_lenient_cfg |
| Mutually exclusive module/class definitions retain separate visibility and method cfg | cfg_exclusive_module_copies_do_not_share_reachability; cfg_exclusive_classes_keep_their_methods_predicate |
| Same-line cfg variants retain independent unsupported-signature reasons | intrinsic_signature_reasons_are_owned_by_the_cfg_variant |
| Public aliases restore field accessors without bypassing private/type/frozen checks | public_alias_restores_only_supported_field_accessors |
| Anonymous underscore imports never become call paths | underscore_imports_never_grant_callable_routes |
| Public class alongside an unrelated same-named value | public_class_and_unrelated_same_named_value_are_not_ambiguous; native inline/file PublicCounter fixture |
| Type/value routes remain independent even at the same canonical spelling | canonical_type_and_value_keep_independent_routes |
| A named type import does not shadow a value glob import | a_named_type_does_not_shadow_a_glob_value |
| Named/renamed self module imports | renamed_and_named_self_imports_expose_modules; inline/file native public_api fixture |
| Enum variants participate in value glob ambiguity | enum_variant_globs_prevent_ambiguous_function_routes; inline/file native ambiguous calculate fixture with usable explicit alias |
| Disabled enum variants do not block active functions | disabled_enum_variants_do_not_block_public_function_routes (strict cfg) |
| No conditional alias regression; named imports shadow globs; private intermediate modules | PublicRoutes unit tests in public_routes.rs |
| Real generated PyO3 wrapper builds, loads and calls across inline and file modules | public re-exports build and call real PyO3 wrappers (#303), with link_libpython; round-1 regression adds public-field reads/writes and an underscore alias alongside the named alias |
| Manifest version gate | manifest: schema version guard in test_julia_attribute.jl, including rejection of schema 8 |

## Validation

Core tests, clippy, extractor tests, proc-macro all-feature tests, all lints,
docs, the Julia attribute test file and real PyO3 integration tests passed
locally. Schema golden changes were regenerated only after plain tests
reported the expected mismatch; every changed golden line is schema 8 -> 9.

The first full Pkg.test on the pre-#362 base found five cfg-exclusive module
regressions (10,110 parallel assertions passed). The resolver had shared one
public route between mutually exclusive definitions at the same canonical
path. Resolution now filters definitions/imports by the requesting cfg context,
with Rust regression tests for public/private module copies and class-method
predicates. Existing Julia expectations were not weakened.

The branch now incorporates merged #362 (0e4699a). The Julia cross-module
regressions passed unchanged, and a fresh full Pkg.test exited 0 with 10,170
parallel assertions (5 Broken) plus all 651 serial assertions. A subsequent
isolated audit found that the intrinsic-signature lookup also needed cfg in
its key for same-line definitions. That fix and its new regression pass core
tests and clippy; the CLI probe now reports the normal and async variants
independently. The final full-suite run for this exact revision passed too:
10,170 parallel assertions (5 Broken), then all 651 serial assertions.
All lints and documentation also passed on this revision. CI and review are
requested on the pushed head; no remote result is claimed yet.

## Remaining milestone work

The remaining CI-only toolchain mismatch was traced to the crate-source digest:
it recursively included Cargo outputs under `target/` (and integration tests), so
the generated wrapper could fingerprint files created after precompilation. The
digest now covers only the root `Cargo.toml` and `src/**/*.rs`. A manifest
regression test proves that edits under `target/` and `tests/` are ignored while
an edit under `src/` changes the digest. Debug output now records the complete
fingerprint components and both sides of a mismatch without weakening the
strict guard. The focused manifest test, all lints and docs passed. Full
`Pkg.test()` passed 10,178 parallel assertions (5 Broken), then all 651 serial
assertions. Remote success is not yet claimed.

Round-3 normalizes self module import paths and models enum variant namespaces;
strict cfg pruning now removes disabled variants before route resolution.
Core tests/clippy, all-feature proc-macro tests, native wrappers (12 assertions,
no skip), lints and docs pass. Full Pkg.test exited 0: 10,176 parallel assertions
(5 Broken), then 651 serial assertions. Per scope decision comment5602293118,
this fix push ends re-review of this route-resolution class. Existing findings
are fixed and resolved with their SHA; merging still requires all CI checks on
the new head to pass. Remaining type-alias routes/broader namespace cases stay
in #303, as recorded in comment5602293574.

Round-2 separates Rust type/value namespace resolution, including distinct
routes at the same canonical spelling and namespace-specific import shadowing.
Core tests/clippy, proc-macro tests, lints/docs and the native 12-assertion
integration test pass. Full Pkg.test exited 0 again: 10,176 parallel assertions
(5 Broken) and 651 serial assertions. The failing CI example reproduced on a
retry; debug-only fingerprint component logging is enabled for that example
to diagnose its precompile/runtime toolchain mismatch. The strict guard stays
enabled; remote success is not yet established.

Round-1 review fixes restore public-field accessors when a re-export makes the
class reachable, and exclude anonymous underscore imports from callable routes.
Core tests, clippy, proc-macro tests, all lints and docs passed. Both native Julia
layouts passed 12 assertions with no skip. The final full Pkg.test passed
10,176 parallel assertions (5 Broken), then all 651 serial assertions.

Signature/default arguments, extends, build.rs-generated sources and workspace
feature unification remain under #303. Public type-alias routes and richer Rust
namespace interactions also need audit before claiming exhaustive re-export
coverage; the tests above define what has actually been exercised so far.
