### PR TITLE
Support PyO3 String field setters

### DIFF
--- a/deps/rustcall_core/src/codegen.rs
+++ b/deps/rustcall_core/src/codegen.rs
@@ -1434,8 +1434,8 @@ fn crate_field_accessors(
     ffi_functions
 }
 
-fn struct_field_setter(
-    owner: &Ident,
+pub(crate) fn struct_field_setter(
+    owner: &impl quote::ToTokens,
     field: &Ident,
     ty: &Type,
     setter: &Ident,

--- a/deps/rustcall_core/src/wrap.rs
+++ b/deps/rustcall_core/src/wrap.rs
@@ -362,14 +362,6 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
                     }
                 }));
             }
-            // A `String` field is read by copying it out; writing one would
-            // need the byte-pair ABI on a setter, which no accessor shape
-            // covers yet (#303). A `set`-only `String` field therefore has no
-            // accessor at all, and the manifest says so.
-            f.setter.clear();
-            if f.getter.is_empty() {
-                f.ffi_compatible = false;
-            }
         } else {
             if !f.getter.is_empty() {
                 let getter = format_ident!("{}", f.getter);
@@ -383,15 +375,17 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
                     }
                 }));
             }
-            if !f.setter.is_empty() {
-                let setter = format_ident!("{}", f.setter);
-                out.extend(crate::codegen::guard_struct_helper(quote! {
-                    #[no_mangle]
-                    pub extern "C" fn #setter(ptr: *mut #class, value: #ty) {
-                        unsafe { (*ptr).#field = value; }
-                    }
-                }));
-            }
+        }
+        if !f.setter.is_empty() {
+            // Share byte-pair String conversion and the panic boundary with
+            // the in-crate/inline accessor generator (#303).
+            out.extend(crate::codegen::struct_field_setter(
+                &class,
+                &field,
+                &ty,
+                &format_ident!("{}", f.setter),
+                &[],
+            ));
         }
     }
 

--- a/deps/rustcall_core/tests/pyo3_field_payloads.rs
+++ b/deps/rustcall_core/tests/pyo3_field_payloads.rs
@@ -1,0 +1,39 @@
+use rustcall_core::{extract::extract, manifest::Mode, wrap::wrapper_crate};
+
+#[test]
+fn string_setters_use_the_shared_byte_pair_abi() {
+    for access in ["set", "get, set"] {
+        let scan = extract(
+            &format!("#[pyclass] pub struct Text {{ #[pyo3({access})] pub value: String }}"),
+            Mode::Crate,
+        )
+        .unwrap();
+        let wrapped = wrapper_crate(&scan, "user_crate", true);
+        let class = &wrapped.manifest.structs[0];
+        assert!(class.fields[0].ffi_compatible);
+        assert_eq!(class.fields[0].setter, "rustcall_Text_set_value");
+        assert_eq!(class.fields[0].getter.is_empty(), access == "set");
+        assert_eq!(class.has_owned_string_helper, access != "set");
+        assert!(wrapped.lib_rs.contains("value_ptr: *const u8"));
+        assert!(wrapped.lib_rs.contains("value_len: usize"));
+        assert!(wrapped.lib_rs.contains("String::from_utf8_lossy"));
+        assert!(wrapped
+            .lib_rs
+            .contains(&rustcall_core::codegen::panic_symbol(
+                "rustcall_Text_set_value"
+            )));
+    }
+}
+
+#[test]
+fn string_setters_keep_frozen_and_private_field_restrictions() {
+    for source in [
+        "#[pyclass(frozen, get_all)] pub struct Text { #[pyo3(set)] pub value: String }",
+        "#[pyclass] pub struct Text { #[pyo3(get, set)] value: String }",
+    ] {
+        let scan = extract(source, Mode::Crate).unwrap();
+        let wrapped = wrapper_crate(&scan, "user_crate", true);
+        assert!(wrapped.manifest.structs[0].fields[0].setter.is_empty());
+        assert!(!wrapped.lib_rs.contains("fn rustcall_Text_set_value("));
+    }
+}

--- a/docs/src/pyo3.md
+++ b/docs/src/pyo3.md
@@ -49,6 +49,14 @@ depends on it and exports one `extern "C"` entry point per wrappable item:
   `rustcall_<Class>_get_<field>` / `_set_<field>` for the fields
   `#[pyo3(get, set)]`, `get_all` or `set_all` expose.
 
+Public `String` fields support both reads and writes, including a
+`#[pyo3(set)]` write-only field. Setters take a UTF-8 byte pointer and length,
+so empty strings and embedded NUL characters are preserved; Julia rejects
+invalid UTF-8 before entering Rust. Inline bindings expose `set_<field>!`
+alongside property assignment; written bindings expose property assignment.
+Private fields and setters on a `frozen` class remain inaccessible through
+this native wrapper path.
+
 A crate may carry **both** kinds of marker. `#[julia]` is additive since #279
 and exports `rustcall_<name>` from the crate itself, so the wrapper generates
 entry points for the PyO3 items and *links* the `#[julia]` ones; one

--- a/test/test_pyo3_field_payloads.jl
+++ b/test/test_pyo3_field_payloads.jl
@@ -1,0 +1,80 @@
+using RustCall, Test
+include(joinpath(@__DIR__, "pyo3_wrapper_helpers.jl"))
+
+@testset "PyO3 String fields use the byte-pair setter ABI (#303)" begin
+    mktempdir() do root
+        mkpath(joinpath(root, "src"))
+        write(joinpath(root, "Cargo.toml"), """
+            [package]
+            name = "string_fields303"
+            version = "0.1.0"
+            edition = "2021"
+            [dependencies]
+            pyo3 = { version = "0.29", default-features = false, features = ["macros"] }
+            """)
+        write(joinpath(root, "src", "lib.rs"), raw"""
+            use pyo3::prelude::*;
+            #[pyclass]
+            pub struct TextFields303 {
+                #[pyo3(get, set)] pub label: String,
+                #[pyo3(set)] pub write_only: String,
+            }
+            #[pymethods]
+            impl TextFields303 {
+                #[new] pub fn new() -> Self {
+                    Self { label: "initial".into(), write_only: "hidden".into() }
+                }
+                pub fn read_write_only(&self) -> String { self.write_only.clone() }
+            }
+            """)
+        wrapper = _link_libpython_wrapper(root)
+        if wrapper === nothing
+            @test_skip "no linkable Python here"
+        else
+            binding = @rust_crate root
+            inline = binding.module_ref
+            file = joinpath(root, "StringFields.jl")
+            RustCall.write_bindings_to_file(root, file; output_module_name = "StringFields303")
+            holder = Module(gensym(:StringFieldHolder303))
+            Base.include(holder, file)
+            written = Base.invokelatest(getfield, holder, :StringFields303)
+            modules = [inline, written]
+            try
+                for module_ in modules
+                    constructor = Base.invokelatest(getfield, module_, :TextFields303)
+                    object = Base.invokelatest(constructor)
+                    read_hidden = Base.invokelatest(getfield, module_, :read_write_only)
+                    try
+                        @test Base.invokelatest(getproperty, object, :label) == "initial"
+                        for value in ("", "日本語\0tail", SubString("[substring]", 2, 10))
+                            Base.invokelatest(setproperty!, object, :label, value)
+                            @test Base.invokelatest(getproperty, object, :label) == value
+                            Base.invokelatest(setproperty!, object, :write_only, value)
+                            @test Base.invokelatest(read_hidden, object) == value
+                            if module_ === inline
+                                set_label = Base.invokelatest(getfield, module_, :set_label!)
+                                set_hidden = Base.invokelatest(getfield, module_, :set_write_only!)
+                                Base.invokelatest(set_label, object, value)
+                                @test Base.invokelatest(getproperty, object, :label) == value
+                                Base.invokelatest(set_hidden, object, value)
+                                @test Base.invokelatest(read_hidden, object) == value
+                            end
+                        end
+                        @test !isdefined(module_, :get_write_only)
+                        @test_throws Exception Base.invokelatest(getproperty, object, :write_only)
+                        @test_throws MethodError Base.invokelatest(setproperty!, object, :label, 17)
+                        @test_throws RustCall.RustError Base.invokelatest(setproperty!, object, :label, String(UInt8[0xff]))
+                    finally
+                        finalize(object)
+                    end
+                    @test_throws RustCall.RustError Base.invokelatest(setproperty!, object, :label, "after free")
+                end
+            finally
+                for name in unique(Base.invokelatest(getfield, m, :_LIB_NAME) for m in modules)
+                    RustCall.unload_library(name; close = true)
+                    RustCall.close_retired_handles!(RustCall.retired_handles(name))
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Scope

Advances #303. This phase adds owned `String` payloads to supported PyO3 field
setters in both inline and generated-file bindings. It does not publish a
release or claim the remaining owned-vector, default-argument, inheritance, or
aggregate-return work complete.

## Changes

- Generate PyO3 `String` setters through the shared panic-safe field-setter
  helper instead of suppressing them during wrapper generation.
- Preserve setter-only fields: a `#[pyo3(set)] String` remains usable without
  generating an owned-string getter helper.
- Accept Julia strings through the existing UTF-8 pointer/length ABI, including
  empty strings, Unicode, embedded NUL bytes, and `SubString` values.
- Keep private and frozen fields unavailable, and retain generation-liveness
  checks after wrapper unload.
- Document String field read/write behavior and conversion semantics.

## Requirement → test

| Requirement | Evidence |
| --- | --- |
| `#[pyo3(get, set)] String` emits a panic-safe pointer/length setter | `getset String fields generate owned payload accessors (#303)` |
| `#[pyo3(set)] String` remains writable without a getter/helper | `set-only String fields remain writable (#303)` |
| Private and frozen fields do not gain setters | `private and frozen String fields remain unavailable (#303)` |
| Inline and written bindings support assignment | `PyO3 String field payloads (#303)` |
| Empty, Unicode, embedded-NUL and `SubString` values round-trip | same Julia native integration test |
| Bad Julia values and invalid Rust UTF-8 fail safely | same Julia native integration test |
| Calls after wrapper retirement are rejected | same Julia native integration test |

## Validation

After #364 merged, the branch was rebased onto `fdc2aad` without conflicts.
Core tests, release extractor build, clippy, extractor tests, all-feature
proc-macro tests, all lints and docs passed. The native link-libpython
integration passed 30 assertions without skipping. Full `Pkg.test()` passed
10,281 parallel assertions (5 Broken), then all 651 serial assertions. Remote
success is not yet claimed.

## Remaining

Owned `Vec<T>` field payloads, signature/default arguments, `extends` lifetime
ownership, public type-alias routes, and wider PyO3 aggregate returns remain
under #303.
