### PR TITLE
Support owned PyO3 Vec field buffers

### DIFF
--- a/deps/rustcall_core/src/expand.rs
+++ b/deps/rustcall_core/src/expand.rs
@@ -387,6 +387,8 @@ fn fields_of(model: &StructModel, accessors: &[(String, String, String)]) -> Vec
                 name: name.to_string(),
                 rust_type: type_to_string(ty),
                 abi: crate::codegen::field_abi(ty).to_string(),
+                vec_element: String::new(),
+                free_symbol: String::new(),
                 ffi_compatible: acc.is_some(),
                 getter: acc.map(|a| a.1.clone()).unwrap_or_default(),
                 setter: acc.map(|a| a.2.clone()).unwrap_or_default(),

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -1198,6 +1198,8 @@ fn crate_struct_entry(
                 name: name.to_string(),
                 rust_type: type_to_string(ty),
                 abi: crate::codegen::field_abi(ty).to_string(),
+                vec_element: String::new(),
+                free_symbol: String::new(),
                 ffi_compatible,
                 getter: if ffi_compatible {
                     crate::codegen::field_getter_symbol(&stem, &name.to_string())

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -110,7 +110,11 @@ use serde::{Deserialize, Serialize};
 /// * **9** adds [`Function::callable_path`] and [`Struct::callable_path`]
 ///   (#303): wrappers must call the externally reachable re-export instead
 ///   of a canonical definition inside a private module.
-pub const SCHEMA_VERSION: u32 = 9;
+/// * **10** adds the owned-vector field ABI. [`Field::vec_element`] states the
+///   element spelling and [`Field::free_symbol`] names the allocator-matched
+///   release export; an older consumer would otherwise read the returned
+///   `(ptr, len, cap)` aggregate as a Rust `Vec<T>` value.
+pub const SCHEMA_VERSION: u32 = 10;
 
 /// Vocabulary of [`Function::skip_reason`] / [`Struct::skip_reason`] /
 /// [`Method::skip_reason`]. An empty reason means the item is wrappable.
@@ -439,11 +443,19 @@ pub struct Field {
     pub rust_type: String,
     /// How the generated getter returns the field: `""` as written
     /// (`rust_type`), `"string"` for an owned `<Struct>_RustCallOwnedString`
-    /// released through `<Struct>_free_rust_string`. Same vocabulary as
+    /// released through `<Struct>_free_rust_string`, or `"vec"` for the
+    /// owned buffer described by [`Field::vec_element`] and [`Field::free_symbol`]. Same vocabulary as
     /// [`Arg::abi`] / [`Method::return_abi`], so Julia never has to re-derive
     /// the lowering from the type spelling (#276).
     #[serde(default)]
     pub abi: String,
+    /// Element type for the `"vec"` ABI. Empty for every other field.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub vec_element: String,
+    /// Export that reconstructs and drops the owned vector returned by this
+    /// getter. Empty unless `abi == "vec"` and a getter is emitted.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub free_symbol: String,
     /// Whether Julia may read this field through an exported getter.
     pub ffi_compatible: bool,
     /// Exported symbol that reads the field. Usually `<Struct>_get_<field>`; in

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -870,6 +870,7 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
                 f.ffi_compatible = false;
                 f.getter.clear();
                 f.setter.clear();
+                f.free_symbol.clear();
             }
             continue;
         }
@@ -928,6 +929,7 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
                         f.ffi_compatible = false;
                         f.getter.clear();
                         f.setter.clear();
+                        f.free_symbol.clear();
                     }
                 }
             } else {
@@ -937,20 +939,34 @@ fn mark_symbol_collisions(manifest: &mut Manifest) {
             }
         }
         for f in &mut s.fields {
-            for accessor in [&mut f.getter, &mut f.setter] {
-                if accessor.is_empty() {
-                    continue;
+            if !f.getter.is_empty() {
+                let mut symbols = vec![f.getter.clone(), crate::codegen::panic_symbol(&f.getter)];
+                if f.abi == "vec" {
+                    symbols.push(format!("{}_RustCallOwnedVec", f.getter));
+                    symbols.push(f.free_symbol.clone());
                 }
-                let symbols = [accessor.clone(), crate::codegen::panic_symbol(accessor)];
-                match taken
+                if taken
                     .iter()
-                    .find(|(t, _, c)| symbols.contains(t) && cfg_clash(c, &s_cfg))
+                    .any(|(t, _, c)| symbols.contains(t) && cfg_clash(c, &s_cfg))
                 {
-                    Some(_) => accessor.clear(),
-                    None => {
-                        for symbol in symbols {
-                            taken.push((symbol, owner.clone(), s_cfg.clone()));
-                        }
+                    f.getter.clear();
+                    f.free_symbol.clear();
+                } else {
+                    for symbol in symbols {
+                        taken.push((symbol, owner.clone(), s_cfg.clone()));
+                    }
+                }
+            }
+            if !f.setter.is_empty() {
+                let symbols = [f.setter.clone(), crate::codegen::panic_symbol(&f.setter)];
+                if taken
+                    .iter()
+                    .any(|(t, _, c)| symbols.contains(t) && cfg_clash(c, &s_cfg))
+                {
+                    f.setter.clear();
+                } else {
+                    for symbol in symbols {
+                        taken.push((symbol, owner.clone(), s_cfg.clone()));
                     }
                 }
             }
@@ -1039,6 +1055,10 @@ fn struct_symbols(s: &Struct) -> Vec<String> {
         if !f.getter.is_empty() {
             out.push(f.getter.clone());
             out.push(crate::codegen::panic_symbol(&f.getter));
+            if f.abi == "vec" {
+                out.push(format!("{}_RustCallOwnedVec", f.getter));
+                out.push(f.free_symbol.clone());
+            }
         }
         if !f.setter.is_empty() {
             out.push(f.setter.clone());
@@ -1199,24 +1219,39 @@ fn class_entry(
             // only a `pub` field gets accessors. A skipped class has no handle
             // type, so its fields have none either, whatever their visibility.
             let field_is_public = matches!(f.vis, syn::Visibility::Public(_));
-            // A `String` field crosses as the owned-string ABI; a `Vec<T>`
-            // has no ABI on the Julia side yet, so advertising an accessor for
-            // it would make the whole binding fail after the wrapper built
-            // (#307 review; #303 owns an owned-vector ABI).
+            let vec_element = crate::types::pyo3_vec_element_type(&f.ty);
+            // A `String` field crosses as the owned-string ABI. A `Vec<T>` is
+            // available when T has a concrete Julia FFI scalar representation;
+            // its element and allocator-matched release export are manifest
+            // data rather than guesses made by the consumer (#303).
             let usable = reason.is_empty()
                 && field_is_public
                 && pyo3_type_in(&f.ty).is_none()
-                && (is_ffi_compatible_type(&f.ty) || is_string_type(&f.ty));
+                && (is_ffi_compatible_type(&f.ty)
+                    || is_string_type(&f.ty)
+                    || vec_element.is_some());
+            let getter = if usable && access.get {
+                crate::codegen::method_symbol_of(&stem, &format!("get_{ident}"))
+            } else {
+                String::new()
+            };
+            let vec_free = if vec_element.is_some() && !getter.is_empty() {
+                format!("{getter}_free_rust_vec")
+            } else {
+                String::new()
+            };
             fields.push(Field {
                 name: ident.to_string(),
                 rust_type: type_to_string(&f.ty),
-                abi: crate::codegen::field_abi(&f.ty).to_string(),
-                ffi_compatible: usable,
-                getter: if usable && access.get {
-                    crate::codegen::method_symbol_of(&stem, &format!("get_{ident}"))
+                abi: if vec_element.is_some() {
+                    "vec".to_string()
                 } else {
-                    String::new()
+                    crate::codegen::field_abi(&f.ty).to_string()
                 },
+                vec_element: vec_element.as_ref().map(type_to_string).unwrap_or_default(),
+                free_symbol: vec_free,
+                ffi_compatible: usable,
+                getter,
                 setter: if usable && access.set {
                     crate::codegen::method_symbol_of(&stem, &format!("set_{ident}"))
                 } else {

--- a/deps/rustcall_core/src/types.rs
+++ b/deps/rustcall_core/src/types.rs
@@ -231,6 +231,52 @@ pub fn is_vec_type(ty: &Type) -> bool {
     last_ident(ty).map(|id| id == "Vec").unwrap_or(false)
 }
 
+/// The element of a `Vec<T>`, when the spelling has exactly one type argument.
+pub fn extract_vec_type(ty: &Type) -> Option<Type> {
+    let Type::Path(tp) = unparen(ty) else {
+        return None;
+    };
+    if tp.qself.is_some() {
+        return None;
+    }
+    let segments: Vec<String> = tp
+        .path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect();
+    if !matches!(segments.as_slice(), [name] if name == "Vec")
+        && !matches!(segments.as_slice(), [root, module, name]
+            if matches!(root.as_str(), "std" | "alloc") && module == "vec" && name == "Vec")
+    {
+        return None;
+    }
+    let mut args = angle_args(ty, "Vec")?;
+    (args.len() == 1).then(|| args.remove(0))
+}
+
+/// Whether `Vec<T>` can use RustCall's owned-buffer field ABI.
+///
+/// Zero-sized values and the Rust scalars for which Julia has no concrete FFI
+/// type are refused. Raw pointers and the remaining primitive scalars have a
+/// stable element size/alignment on both sides of this crate boundary.
+pub fn pyo3_vec_element_type(ty: &Type) -> Option<Type> {
+    let element = extract_vec_type(ty)?;
+    if !is_ffi_compatible_type(&element) {
+        return None;
+    }
+    let unsupported = last_ident(&element)
+        // `Vec<bool>` is bit-packed and therefore is not a contiguous `bool`
+        // buffer. The remaining exclusions have no concrete Julia FFI row.
+        .map(|id| matches!(id.to_string().as_str(), "bool" | "i128" | "u128" | "char"))
+        .unwrap_or(false);
+    if unsupported || matches!(unparen(&element), Type::Tuple(tuple) if tuple.elems.is_empty()) {
+        None
+    } else {
+        Some(element)
+    }
+}
+
 /// Check if a type is `Self` or the struct name.
 pub fn is_self_type(ty: &Type, struct_name: &Ident) -> bool {
     match unparen(ty) {

--- a/deps/rustcall_core/src/wrap.rs
+++ b/deps/rustcall_core/src/wrap.rs
@@ -56,7 +56,9 @@ use crate::codegen::{
     WrapperReceiver, WrapperReturn, WrapperSpec,
 };
 use crate::manifest::{skip_reason, Arg, Manifest, Method, ReturnKind, Struct};
-use crate::types::{is_ffi_compatible_type, is_str_ref_type, is_string_type};
+use crate::types::{
+    is_ffi_compatible_type, is_str_ref_type, is_string_type, pyo3_vec_element_type,
+};
 
 /// The only error value a wrapped `PyResult` reports, see the module docs.
 pub const PYERR_CODE: i32 = 1;
@@ -169,6 +171,7 @@ pub fn wrapper_crate(scanned: &Manifest, crate_name: &str, cfg_resolved: bool) -
                 f.ffi_compatible = false;
                 f.getter.clear();
                 f.setter.clear();
+                f.free_symbol.clear();
             }
             out.structs.push(entry);
             continue;
@@ -313,6 +316,7 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
             f.ffi_compatible = false;
             f.getter.clear();
             f.setter.clear();
+            f.free_symbol.clear();
         }
     }
 
@@ -337,14 +341,17 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
             f.ffi_compatible = false;
             f.getter.clear();
             f.setter.clear();
+            f.free_symbol.clear();
             continue;
         };
         let Ok(ty) = syn::parse_str::<Type>(&f.rust_type) else {
             f.ffi_compatible = false;
             f.getter.clear();
             f.setter.clear();
+            f.free_symbol.clear();
             continue;
         };
+        let vec_element = pyo3_vec_element_type(&ty);
         if is_string_type(&ty) {
             if !f.getter.is_empty() {
                 let getter = format_ident!("{}", f.getter);
@@ -358,6 +365,46 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
                             cap: rustcall_bytes.capacity(),
                         };
                         ::std::mem::forget(rustcall_bytes);
+                        rustcall_ret
+                    }
+                }));
+            }
+        } else if let Some(element) = &vec_element {
+            if !f.getter.is_empty() {
+                let getter = format_ident!("{}", f.getter);
+                let helper = format_ident!("{}_RustCallOwnedVec", f.getter);
+                let Ok(free) = syn::parse_str::<Ident>(&f.free_symbol) else {
+                    f.ffi_compatible = false;
+                    f.getter.clear();
+                    f.setter.clear();
+                    f.free_symbol.clear();
+                    continue;
+                };
+                out.extend(quote! {
+                    #[repr(C)]
+                    pub struct #helper {
+                        pub ptr: *mut #element,
+                        pub len: usize,
+                        pub cap: usize,
+                    }
+
+                    #[no_mangle]
+                    pub extern "C" fn #free(value: #helper) {
+                        if !value.ptr.is_null() {
+                            unsafe { drop(Vec::from_raw_parts(value.ptr, value.len, value.cap)); }
+                        }
+                    }
+                });
+                out.extend(crate::codegen::guard_struct_helper(quote! {
+                    #[no_mangle]
+                    pub extern "C" fn #getter(ptr: *const #class) -> #helper {
+                        let mut rustcall_vec = unsafe { (*ptr).#field.clone() };
+                        let rustcall_ret = #helper {
+                            ptr: rustcall_vec.as_mut_ptr(),
+                            len: rustcall_vec.len(),
+                            cap: rustcall_vec.capacity(),
+                        };
+                        ::std::mem::forget(rustcall_vec);
                         rustcall_ret
                     }
                 }));
@@ -377,15 +424,35 @@ fn class_wrappers(krate: &Ident, s: &mut Struct, cfg_resolved: bool) -> TokenStr
             }
         }
         if !f.setter.is_empty() {
-            // Share byte-pair String conversion and the panic boundary with
-            // the in-crate/inline accessor generator (#303).
-            out.extend(crate::codegen::struct_field_setter(
-                &class,
-                &field,
-                &ty,
-                &format_ident!("{}", f.setter),
-                &[],
-            ));
+            if let Some(element) = &vec_element {
+                let setter = format_ident!("{}", f.setter);
+                out.extend(crate::codegen::guard_struct_helper(quote! {
+                    #[no_mangle]
+                    pub extern "C" fn #setter(
+                        ptr: *mut #class,
+                        value: *const #element,
+                        len: usize,
+                    ) {
+                        let value = if len == 0 {
+                            Vec::new()
+                        } else {
+                            assert!(!value.is_null(), "non-empty Vec field input has a null pointer");
+                            unsafe { ::std::slice::from_raw_parts(value, len).to_vec() }
+                        };
+                        unsafe { (*ptr).#field = value; }
+                    }
+                }));
+            } else {
+                // Share byte-pair String conversion and the panic boundary with
+                // the in-crate/inline accessor generator (#303).
+                out.extend(crate::codegen::struct_field_setter(
+                    &class,
+                    &field,
+                    &ty,
+                    &format_ident!("{}", f.setter),
+                    &[],
+                ));
+            }
         }
     }
 

--- a/deps/rustcall_core/tests/corpus/cfg_items.crate.toml
+++ b/deps/rustcall_core/tests/corpus/cfg_items.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/cfg_items.inline.toml
+++ b/deps/rustcall_core/tests/corpus/cfg_items.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.crate.toml
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 functions = []
 

--- a/deps/rustcall_core/tests/corpus/cross_module_impl.inline.toml
+++ b/deps/rustcall_core/tests/corpus/cross_module_impl.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 functions = []
 

--- a/deps/rustcall_core/tests/corpus/generics_and_crate.crate.toml
+++ b/deps/rustcall_core/tests/corpus/generics_and_crate.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/generics_and_crate.inline.toml
+++ b/deps/rustcall_core/tests/corpus/generics_and_crate.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/modules.crate.toml
+++ b/deps/rustcall_core/tests/corpus/modules.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/modules.inline.toml
+++ b/deps/rustcall_core/tests/corpus/modules.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.crate.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.inline.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 structs = []
 

--- a/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_scan.wrap.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.crate.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]
@@ -539,9 +539,11 @@ vis = "pub"
 [[structs.fields]]
 name = "tags"
 rust_type = "Vec<i32>"
-abi = ""
-ffi_compatible = false
-getter = ""
+abi = "vec"
+vec_element = "i32"
+free_symbol = "rustcall_geometry__Rect_get_tags_free_rust_vec"
+ffi_compatible = true
+getter = "rustcall_geometry__Rect_get_tags"
 setter = ""
 python_name = ""
 vis = "pub"

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.inline.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 structs = []
 

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.rs
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.rs
@@ -1487,6 +1487,113 @@ pub extern "C" fn rustcall_geometry__Rect_get_name(
         }
     }
 }
+#[repr(C)]
+pub struct rustcall_geometry__Rect_get_tags_RustCallOwnedVec {
+    pub ptr: *mut i32,
+    pub len: usize,
+    pub cap: usize,
+}
+#[no_mangle]
+pub extern "C" fn rustcall_geometry__Rect_get_tags_free_rust_vec(
+    value: rustcall_geometry__Rect_get_tags_RustCallOwnedVec,
+) {
+    if !value.ptr.is_null() {
+        unsafe {
+            drop(Vec::from_raw_parts(value.ptr, value.len, value.cap));
+        }
+    }
+}
+thread_local! {
+    static
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F74616773
+    : ::std::cell::RefCell < ::std::option::Option < ::std::string::String >> =
+    ::std::cell::RefCell::new(::std::option::Option::None);
+}
+#[no_mangle]
+pub extern "C" fn rustcall_geometry__Rect_get_tags_take_panic(
+    out: *mut u8,
+    cap: usize,
+) -> usize {
+    __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F74616773
+        .with(|rustcall_slot| {
+            let mut rustcall_slot = rustcall_slot.borrow_mut();
+            if out.is_null() && cap == usize::MAX {
+                return rustcall_slot.take().map_or(0, |message| message.len());
+            }
+            let rustcall_len = match rustcall_slot.as_ref() {
+                ::std::option::Option::Some(message) => {
+                    let bytes = message.as_bytes();
+                    if bytes.len() <= cap && !out.is_null() {
+                        unsafe {
+                            ::std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr(),
+                                out,
+                                bytes.len(),
+                            );
+                        }
+                        Some(bytes.len())
+                    } else {
+                        return bytes.len();
+                    }
+                }
+                ::std::option::Option::None => ::std::option::Option::None,
+            };
+            match rustcall_len {
+                ::std::option::Option::Some(n) => {
+                    *rustcall_slot = ::std::option::Option::None;
+                    n
+                }
+                ::std::option::Option::None => 0,
+            }
+        })
+}
+#[no_mangle]
+pub extern "C" fn rustcall_geometry__Rect_get_tags(
+    ptr: *const user_crate::geometry::Rect,
+) -> rustcall_geometry__Rect_get_tags_RustCallOwnedVec {
+    match ::std::panic::catch_unwind(
+        ::std::panic::AssertUnwindSafe(|| {
+            {
+                let mut rustcall_vec = unsafe { (*ptr).tags.clone() };
+                let rustcall_ret = rustcall_geometry__Rect_get_tags_RustCallOwnedVec {
+                    ptr: rustcall_vec.as_mut_ptr(),
+                    len: rustcall_vec.len(),
+                    cap: rustcall_vec.capacity(),
+                };
+                ::std::mem::forget(rustcall_vec);
+                rustcall_ret
+            }
+        }),
+    ) {
+        ::std::result::Result::Ok(rustcall_value) => rustcall_value,
+        ::std::result::Result::Err(rustcall_payload) => {
+            let rustcall_message: ::std::string::String = if let ::std::option::Option::Some(
+                s,
+            ) = rustcall_payload.downcast_ref::<&'static str>()
+            {
+                ::std::string::ToString::to_string(s)
+            } else if let ::std::option::Option::Some(s) = rustcall_payload
+                .downcast_ref::<::std::string::String>()
+            {
+                s.clone()
+            } else {
+                ::std::string::ToString::to_string("Box<dyn Any>")
+            };
+            let rustcall_message = ::std::format!(
+                "{} panicked: {}", "rustcall_geometry__Rect_get_tags", rustcall_message
+            );
+            __RUSTCALL_HELPER_PANIC_7275737463616C6C5F67656F6D657472795F5F526563745F6765745F74616773
+                .with(|rustcall_slot| {
+                    *rustcall_slot.borrow_mut() = ::std::option::Option::Some(
+                        rustcall_message,
+                    );
+                });
+            unsafe {
+                ::std::mem::zeroed::<rustcall_geometry__Rect_get_tags_RustCallOwnedVec>()
+            }
+        }
+    }
+}
 thread_local! {
     static __RUSTCALL_PANIC_RUSTCALL_GEOMETRY__RECT_NEW : ::std::cell::RefCell <
     ::std::option::Option < ::std::string::String >> =

--- a/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.toml
+++ b/deps/rustcall_core/tests/corpus/pyo3_wrap.wrap.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]
@@ -539,9 +539,11 @@ vis = "pub"
 [[structs.fields]]
 name = "tags"
 rust_type = "Vec<i32>"
-abi = ""
-ffi_compatible = false
-getter = ""
+abi = "vec"
+vec_element = "i32"
+free_symbol = "rustcall_geometry__Rect_get_tags_free_rust_vec"
+ffi_compatible = true
+getter = "rustcall_geometry__Rect_get_tags"
 setter = ""
 python_name = ""
 vis = "pub"

--- a/deps/rustcall_core/tests/corpus/strings.crate.toml
+++ b/deps/rustcall_core/tests/corpus/strings.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/strings.inline.toml
+++ b/deps/rustcall_core/tests/corpus/strings.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.crate.toml
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/struct_wrappers.inline.toml
+++ b/deps/rustcall_core/tests/corpus/struct_wrappers.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 
 [[functions]]

--- a/deps/rustcall_core/tests/corpus/syntax_stress.crate.toml
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.crate.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "crate"
 structs = []
 

--- a/deps/rustcall_core/tests/corpus/syntax_stress.inline.toml
+++ b/deps/rustcall_core/tests/corpus/syntax_stress.inline.toml
@@ -1,4 +1,4 @@
-schema_version = 9
+schema_version = 10
 mode = "inline"
 structs = []
 

--- a/deps/rustcall_core/tests/pyo3_field_payloads.rs
+++ b/deps/rustcall_core/tests/pyo3_field_payloads.rs
@@ -37,3 +37,45 @@ fn string_setters_keep_frozen_and_private_field_restrictions() {
         assert!(!wrapped.lib_rs.contains("fn rustcall_Text_set_value("));
     }
 }
+
+#[test]
+fn vec_fields_export_owned_buffers_and_slice_setters() {
+    let scan = extract(
+        "#[pyclass] pub struct Values { #[pyo3(get, set)] pub data: Vec<i32> }",
+        Mode::Crate,
+    )
+    .unwrap();
+    let wrapped = wrapper_crate(&scan, "user_crate", true);
+    let field = &wrapped.manifest.structs[0].fields[0];
+    assert_eq!(field.abi, "vec");
+    assert_eq!(field.vec_element, "i32");
+    assert_eq!(field.free_symbol, "rustcall_Values_get_data_free_rust_vec");
+    assert!(wrapped
+        .lib_rs
+        .contains("struct rustcall_Values_get_data_RustCallOwnedVec"));
+    assert!(wrapped
+        .lib_rs
+        .contains("fn rustcall_Values_get_data_free_rust_vec"));
+    assert!(wrapped
+        .lib_rs
+        .contains("drop(Vec::from_raw_parts(value.ptr, value.len, value.cap))"));
+    assert!(wrapped.lib_rs.contains("value: *const i32"));
+    assert!(wrapped
+        .lib_rs
+        .contains("from_raw_parts(value, len).to_vec()"));
+}
+
+#[test]
+fn set_only_vec_fields_need_no_return_helper() {
+    let scan = extract(
+        "#[pyclass] pub struct Values { #[pyo3(set)] pub data: Vec<f64> }",
+        Mode::Crate,
+    )
+    .unwrap();
+    let wrapped = wrapper_crate(&scan, "user_crate", true);
+    let field = &wrapped.manifest.structs[0].fields[0];
+    assert!(field.getter.is_empty());
+    assert!(field.free_symbol.is_empty());
+    assert!(wrapped.lib_rs.contains("fn rustcall_Values_set_data"));
+    assert!(!wrapped.lib_rs.contains("RustCallOwnedVec"));
+}

--- a/deps/rustcall_core/tests/pyo3_public_routes.rs
+++ b/deps/rustcall_core/tests/pyo3_public_routes.rs
@@ -92,7 +92,7 @@ fn public_alias_restores_only_supported_field_accessors() {
                 #[pyo3(get, set)] pub value: i32,
                 #[pyo3(get, set)] pub text: String,
                 #[pyo3(get, set)] private: i32,
-                #[pyo3(get, set)] pub unsupported: Vec<i32>,
+                #[pyo3(get, set)] pub unsupported: Vec<Vec<i32>>,
                 pub automatic: i32,
             }}
         "#

--- a/deps/rustcall_core/tests/pyo3_scan.rs
+++ b/deps/rustcall_core/tests/pyo3_scan.rs
@@ -1460,23 +1460,36 @@ fn the_panic_reader_symbol_is_reserved_too() {
     assert_eq!(by("m_take_panic").skip_reason, "symbol_collision:C");
 }
 
-/// A `Vec<T>` field gets no accessor: the Julia side has no ABI for it yet,
-/// and an advertised getter it cannot bind would fail the whole binding after
-/// the wrapper had built (#307 review; #303). A `String` field still does.
+/// A scalar-element `Vec<T>` field carries its owned-buffer metadata. Nested
+/// and otherwise unsupported elements remain unadvertised (#303).
 #[test]
-fn vec_fields_get_no_accessor() {
+fn vec_fields_use_the_owned_buffer_abi() {
     let manifest = scan(
         "#[pyclass] pub struct P {\n\
             #[pyo3(get, set)] pub tags: Vec<i32>,\n\
+            #[pyo3(get)] pub nested: Vec<Vec<i32>>,\n\
+            #[pyo3(get)] pub qualified: std::vec::Vec<u16>,\n\
+            #[pyo3(get)] pub lookalike: crate::Vec<i32>,\n\
             #[pyo3(get)] pub name: String,\n\
             #[pyo3(get)] pub n: i32,\n\
          }",
     );
     let p = manifest.structs.iter().find(|s| s.name == "P").unwrap();
     let field = |n: &str| p.fields.iter().find(|f| f.name == n).unwrap();
-    assert!(!field("tags").ffi_compatible);
-    assert_eq!(field("tags").getter, "");
-    assert_eq!(field("tags").setter, "");
+    assert!(field("tags").ffi_compatible);
+    assert_eq!(field("tags").abi, "vec");
+    assert_eq!(field("tags").vec_element, "i32");
+    assert_eq!(field("tags").getter, "rustcall_P_get_tags");
+    assert_eq!(field("tags").setter, "rustcall_P_set_tags");
+    assert_eq!(
+        field("tags").free_symbol,
+        "rustcall_P_get_tags_free_rust_vec"
+    );
+    assert!(!field("nested").ffi_compatible);
+    assert_eq!(field("nested").getter, "");
+    assert_eq!(field("qualified").abi, "vec");
+    assert_eq!(field("qualified").vec_element, "u16");
+    assert!(!field("lookalike").ffi_compatible);
     assert!(field("name").ffi_compatible);
     assert_eq!(field("name").getter, "rustcall_P_get_name");
     assert!(field("n").ffi_compatible);
@@ -1558,6 +1571,27 @@ fn string_helper_names_are_reserved_too() {
     // which came first.
     assert_eq!(by("label").skip_reason, "symbol_collision:User_label");
     assert_eq!(by("count").skip_reason, "");
+}
+
+#[test]
+fn vec_release_symbols_are_reserved_too() {
+    let manifest = scan(
+        "#[pyfunction] pub fn P_get_tags_free_rust_vec() -> i32 { 0 }\n\
+         #[pyclass] pub struct P { #[pyo3(get)] pub tags: Vec<i32> }",
+    );
+    assert_eq!(
+        function(&manifest, "P_get_tags_free_rust_vec").skip_reason,
+        ""
+    );
+    let field = &manifest
+        .structs
+        .iter()
+        .find(|s| s.name == "P")
+        .unwrap()
+        .fields[0];
+    assert!(!field.ffi_compatible);
+    assert!(field.getter.is_empty());
+    assert!(field.free_symbol.is_empty());
 }
 
 /// The private thread-local slot a wrapper's panic reader drains is named from

--- a/docs/src/pyo3.md
+++ b/docs/src/pyo3.md
@@ -57,6 +57,16 @@ alongside property assignment; written bindings expose property assignment.
 Private fields and setters on a `frozen` class remain inaccessible through
 this native wrapper path.
 
+Public `Vec<T>` fields are also readable and writable when `T` has a concrete
+scalar or pointer FFI representation (`i8`–`i64`, `u8`–`u64`, `isize`,
+`usize`, `f32`, `f64`, and raw pointers). A getter clones the Rust vector and
+returns a `RustVec{T}`; call `collect` to copy it into a Julia `Vector`, and
+`drop!` it when deterministic release matters. The object retains the exact
+release function and library generation that allocated the buffer, including
+across reloads. Setters accept Julia iterables and convert every element to
+`T` before entering Rust. `Vec<bool>` is excluded because Rust bit-packs it;
+nested vectors and elements without a concrete Julia FFI layout are excluded.
+
 A crate may carry **both** kinds of marker. `#[julia]` is additive since #279
 and exports `rustcall_<name>` from the crate itself, so the wrapper generates
 entry points for the PyO3 items and *links* the `#[julia]` ones; one
@@ -253,6 +263,7 @@ Manifest schema 5 adds, for every function, struct and method:
 | `python_name` | the name PyO3 exposes it under, when `#[pyo3(name = "...")]` renames it |
 | `accessor` | `getter` / `setter` for a `#[getter]` / `#[setter]` method |
 | `return_kind` + `ok_type` / `err_type` / `inner_type` | on methods too, not just free functions: a `#[pymethods]` method returning `PyResult<T>` is `py_result` with `T`, so Phase 2 never re-reads the Rust type spelling |
+| field `abi = "vec"` + `vec_element` + `free_symbol` | schema 10's owned-vector contract: the exact Julia element layout and the export that must release this getter's `(ptr, len, cap)` buffer |
 
 A scanned item's `symbol` is the wrapper a Phase-2 wrapper crate *will* export —
 `rustcall_<name>` for a function, `rustcall_<Struct>_<method>` for a method, the

--- a/src/crate_bindings.jl
+++ b/src/crate_bindings.jl
@@ -1142,6 +1142,18 @@ function emit_crate_module(info::CrateInfo, lib_path::String;
              _required_symbol(handle, free_symbol))
         end
 
+        # An owned Vec outlives the getter call. Capture its release export and
+        # the producing generation's liveness flag with the getter snapshot so
+        # reload cannot pair the buffer with another allocator (#303).
+        function _vec_target(symbol::String, free_symbol::String)
+            gen = _LIB_GEN[]
+            handle = _live_handle(gen)
+            (_required_symbol(handle, symbol),
+             _symbol(handle, RustCall.ffi_panic_symbol(symbol)),
+             _required_symbol(handle, free_symbol),
+             gen.alive)
+        end
+
         # The constructor arm: the wrapper that *allocates*, its channel, and
         # the destructor and liveness flag the resulting object will carry —
         # all from one deref. Taking the object's half after the call returned
@@ -1402,12 +1414,12 @@ end
 
 The names a generated crate module defines once, at its root, and every
 submodule imports from its parent: the library record and the snapshot
-constructors (`_call_target`, `_ctor_target`, `_struct_generation`), the
+constructors (`_call_target`, `_vec_target`, `_ctor_target`, `_struct_generation`), the
 symbol cache and the panic guard. One definition per module tree, so a reload
 swaps the image for every submodule at once.
 """
 const _CRATE_MODULE_HELPERS = (:_LIB_NAME, :_LIB_GEN, :_symbol, :_required_symbol,
-                               :_live_handle, :_get_func_ptr, :_call_target, :_ctor_target,
+                               :_live_handle, :_get_func_ptr, :_call_target, :_vec_target, :_ctor_target,
                                :_struct_generation, :_guard_panic)
 
 # `import ..name, ..name2, ...` — every helper from the enclosing module. A
@@ -1931,6 +1943,14 @@ function _crate_field_read(info::RustStructInfo, field_name::AbstractString,
                 RustCall._take_owned_string(raw, freep)
             end
         end
+    elseif ffi_owned_vec_return(c)
+        element_type = c.surface_type.parameters[1]
+        return quote
+            let (fp, channel, freep, alive) = _vec_target($name, $(c.free_symbol))
+                raw = _guard_panic(call_rust_function(fp, RustCall.CRustVec, $self_ptr_expr), channel, $name)
+                RustCall.RustVec{$element_type}(raw.ptr, raw.len, raw.cap, (freep, alive))
+            end
+        end
     elseif ffi_borrowed_string_return(c)
         return quote
             let (fp, channel) = _call_target($name)
@@ -1964,6 +1984,19 @@ function _crate_field_write(info::RustStructInfo, field_name::AbstractString,
                             field_type::AbstractString, setter_symbol::AbstractString,
                             self_ptr_expr, value_expr)
     name = String(setter_symbol)
+    if get(info.field_abis, field_name, "") == "vec"
+        element_type = ffi_vec_element_type(get(info.field_vec_elements, field_name, ""))
+        return quote
+            let values = collect($element_type, $value_expr),
+                (fp, channel) = _call_target($name)
+                GC.@preserve values begin
+                    _guard_panic(call_rust_function(fp, Cvoid, $self_ptr_expr,
+                                                    pointer(values), Csize_t(length(values))),
+                                 channel, $name)
+                end
+            end
+        end
+    end
     c = _ffi_field_return(info, field_name, field_type)
     if ffi_owned_string_return(c)
         # Match the wrapper's byte pointer/length input; never pass Rust String
@@ -2001,6 +2034,11 @@ function _crate_field_write_source(info::RustStructInfo, field_name::AbstractStr
                                    field_type::AbstractString, setter_symbol::AbstractString,
                                    self_ptr::String, value::String; strict::Symbol = FFI_STRICT[])
     target = "(fp, channel) = _call_target(\"$setter_symbol\")"
+    if get(info.field_abis, field_name, "") == "vec"
+        element_type = string(ffi_vec_element_type(get(info.field_vec_elements, field_name, "")))
+        return "let values = collect($element_type, $value), $target; " *
+               "GC.@preserve values begin _guard_panic(call_rust_function(fp, Cvoid, $self_ptr, pointer(values), Csize_t(length(values))), channel, \"$setter_symbol\"); end; end"
+    end
     c = _ffi_field_return(info, field_name, field_type)
     if ffi_owned_string_return(c)
         return "let text = RustCall.ffi_string_argument($value, \"value\", \"$setter_symbol\"), $target; " *
@@ -2030,6 +2068,11 @@ function _crate_field_read_source(info::RustStructInfo, field_name::AbstractStri
         return "let (fp, channel, freep) = _call_target(\"$getter_symbol\", \"$(c.free_symbol)\"); " *
                "raw = _guard_panic(call_rust_function(fp, RustCall.CRustString, $self_ptr), channel, \"$getter_symbol\"); " *
                "RustCall._take_owned_string(raw, freep); end"
+    elseif ffi_owned_vec_return(c)
+        element_type = string(c.surface_type.parameters[1])
+        return "let (fp, channel, freep, alive) = _vec_target(\"$getter_symbol\", \"$(c.free_symbol)\"); " *
+               "raw = _guard_panic(call_rust_function(fp, RustCall.CRustVec, $self_ptr), channel, \"$getter_symbol\"); " *
+               "RustCall.RustVec{$element_type}(raw.ptr, raw.len, raw.cap, (freep, alive)); end"
     elseif ffi_borrowed_string_return(c)
         return "let $target; raw = _guard_panic(call_rust_function(fp, RustCall.CRustStr, $self_ptr), channel, \"$getter_symbol\"); " *
                "RustCall._crust_str_to_julia(raw); end"
@@ -3713,6 +3756,16 @@ function emit_crate_module_code(info::CrateInfo, lib_path::String;
     push!(lines, "    (_required_symbol(handle, symbol),")
     push!(lines, "     _symbol(handle, RustCall.ffi_panic_symbol(symbol)),")
     push!(lines, "     _required_symbol(handle, free_symbol))")
+    push!(lines, "end")
+    push!(lines, "")
+    push!(lines, "# Owned Vec getter and release export from one generation (#303).")
+    push!(lines, "function _vec_target(symbol::String, free_symbol::String)")
+    push!(lines, "    gen = _LIB_GEN[]")
+    push!(lines, "    handle = _live_handle(gen)")
+    push!(lines, "    (_required_symbol(handle, symbol),")
+    push!(lines, "     _symbol(handle, RustCall.ffi_panic_symbol(symbol)),")
+    push!(lines, "     _required_symbol(handle, free_symbol),")
+    push!(lines, "     gen.alive)")
     push!(lines, "end")
     push!(lines, "")
     push!(lines, "# The constructor arm: the allocating wrapper, its channel, and the")

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -1175,6 +1175,7 @@ end
 """
     ffi_owned_string_return(c) -> Bool
     ffi_borrowed_string_return(c) -> Bool
+    ffi_owned_vec_return(c) -> Bool
 
 Whether a return contract describes a lowered **owned** (`CRustString`,
 `(ptr, len, cap)`) or **borrowed** (`CRustStr`, `(ptr, len)`) string buffer.
@@ -1182,10 +1183,45 @@ Whether a return contract describes a lowered **owned** (`CRustString`,
 Every generator branches on these rather than on `return_abi == "string"`, on
 `has_owned_string_helper`, or on the Rust spelling — the three vocabularies
 #276 collapses. An owned contract also carries the `free_symbol` that releases
-it, which is the half #246 and #249 are about.
+it, which is the half #246 and #249 are about. `ffi_owned_vec_return` identifies
+the schema-10 `CRustVec` aggregate separately because it stays owned by Julia.
 """
 ffi_owned_string_return(c::FFIContract) = c.aggregate_type === CRustString
 ffi_borrowed_string_return(c::FFIContract) = c.aggregate_type === CRustStr
+ffi_owned_vec_return(c::FFIContract) = c.aggregate_type === CRustVec
+
+"""
+    ffi_owned_vec_contract(rust_type, element_type, free_symbol) -> FFIContract
+
+Build the manifest-stated contract for a `Vec<T>` field getter. Unlike an
+owned String, a vector remains live on the Julia side as `RustVec{T}`, so its
+release function accepts the complete `CRustVec` aggregate and is retained by
+the resulting object together with the producing library generation.
+"""
+function ffi_owned_vec_contract(rust_type::AbstractString,
+                                element_type::AbstractString,
+                                free_symbol::AbstractString)
+    isempty(element_type) && throw(ArgumentError(
+        "the vec field ABI for $rust_type is missing vec_element"))
+    isempty(free_symbol) && throw(ArgumentError(
+        "the vec field ABI for $rust_type is missing free_symbol"))
+    surface = Core.apply_type(RustVec, ffi_vec_element_type(element_type))
+    return FFIContract(ffi_normalize_spelling(rust_type), :return, :ptr_len_cap,
+                       Type[CRustVec], CRustVec,
+                       Type[Ptr{Cvoid}, Csize_t, Csize_t], surface,
+                       :transferred_to_julia, String(free_symbol), true)
+end
+
+function ffi_vec_element_type(element_type::AbstractString)
+    element = ffi_lookup(element_type)
+    element === nothing && throw(ArgumentError(
+        "the vec field ABI has unsupported element type `$element_type`"))
+    element.abi in (:by_value, :pointer) || throw(ArgumentError(
+        "the vec field ABI requires a scalar or pointer element, got `$element_type`"))
+    isbitstype(element.surface_type) || throw(ArgumentError(
+        "the vec field ABI requires an isbits Julia element, got $(element.surface_type)"))
+    return element.surface_type
+end
 
 """
     ffi_signature_context(name, arg_types, return_type; owner = nothing) -> String

--- a/src/julia_functions.jl
+++ b/src/julia_functions.jl
@@ -266,14 +266,20 @@ _ffi_function_return(sig::RustFunctionSignature) =
 """
     _ffi_field_return(info, field_name, field_type) -> FFIContract
 
-The return contract of a struct field getter. `Field.abi` (manifest schema 4)
-says whether the getter hands back an owned buffer, and the struct owns the
-`<Struct>_free_rust_string` that releases it — on both wrapper flavours, named
-after the struct's FFI name (#300).
+The return contract of a struct field getter. `Field.abi` says whether the
+getter hands back an owned String or Vec buffer. String release is derived from
+the struct's FFI name; a Vec carries its element and exact release symbol in
+schema 10 so the resulting `RustVec` retains the producing allocator (#303).
 """
-_ffi_field_return(info, field_name::AbstractString, field_type::AbstractString) =
-    ffi_return_contract(field_type; abi = get(info.field_abis, field_name, ""),
-                        owner = info.ffi_name)
+function _ffi_field_return(info, field_name::AbstractString, field_type::AbstractString)
+    abi = get(info.field_abis, field_name, "")
+    if abi == "vec"
+        element = get(info.field_vec_elements, field_name, "")
+        free_symbol = get(info.field_free_symbols, field_name, "")
+        return ffi_owned_vec_contract(field_type, element, free_symbol)
+    end
+    return ffi_return_contract(field_type; abi = abi, owner = info.ffi_name)
+end
 
 # A field getter reads as `Struct::field -> T`.
 _ffi_field_context(info, field_name::AbstractString, field_type::AbstractString) =

--- a/src/manifest.jl
+++ b/src/manifest.jl
@@ -42,9 +42,13 @@ a method sharing its struct's buffers and a cross-module method carrying its
 own — so a schema-7 consumer, which derives the owner from the flavour, would
 release a cross-module method's `String` through a symbol the library does not
 export, and leak it. The version is what makes such a consumer refuse the
-manifest rather than get the owner wrong (#342 review).
+manifest rather than get the owner wrong (#342 review). Schema 9 adds the
+externally callable re-export path used for items defined behind private
+modules (#303). Schema 10 adds the `vec` field ABI, its `vec_element`, and its
+allocator-matched `free_symbol`; a schema-9 consumer would call the returned
+owned buffer as a Rust `Vec<T>` value and could not release it (#303).
 """
-const MANIFEST_SCHEMA_VERSION = 9
+const MANIFEST_SCHEMA_VERSION = 10
 
 """
     ExtractorError <: Exception
@@ -1229,12 +1233,18 @@ function manifest_struct_infos(manifest::Dict; origins = nothing)
         isempty(keep) || _mstr(s, "attribute") in keep || continue
         fields = Tuple{String, String}[]
         field_abis = Dict{String, String}()
+        field_vec_elements = Dict{String, String}()
+        field_free_symbols = Dict{String, String}()
         getters = Dict{String, String}()
         setters = Dict{String, String}()
         for f in _mvec(s, "fields")
             name = _mstr(f, "name")
             push!(fields, (name, _mstr(f, "rust_type")))
             field_abis[name] = _mstr(f, "abi")
+            isempty(_mstr(f, "vec_element")) ||
+                (field_vec_elements[name] = _mstr(f, "vec_element"))
+            isempty(_mstr(f, "free_symbol")) ||
+                (field_free_symbols[name] = _mstr(f, "free_symbol"))
             # Each accessor on its own: a `#[julia]` struct carries both, a
             # `#[pyclass]` field carries what `#[pyo3(get)]` / `#[pyo3(set)]`
             # declared, and a `set`-only field is a setter with no getter
@@ -1258,6 +1268,8 @@ function manifest_struct_infos(manifest::Dict; origins = nothing)
             true,
             derive_options;
             field_abis = field_abis,
+            field_vec_elements = field_vec_elements,
+            field_free_symbols = field_free_symbols,
             field_getters = getters,
             field_setters = setters,
             has_clone = _mbool(s, "has_clone"),

--- a/src/pyo3.jl
+++ b/src/pyo3.jl
@@ -1565,6 +1565,8 @@ function _pyo3_wrapper_items(manifest::Dict)
             st.name, st.type_params, kept, st.context_code, st.fields,
             st.has_derive_julia_struct, st.derive_options;
             field_abis = st.field_abis, field_getters = st.field_getters,
+            field_vec_elements = st.field_vec_elements,
+            field_free_symbols = st.field_free_symbols,
             field_setters = st.field_setters, has_clone = st.has_clone,
             has_owned_string_helper = st.has_owned_string_helper,
             has_borrowed_string_helper = st.has_borrowed_string_helper,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -175,9 +175,10 @@ end
 A `#[julia]` / `#[derive(JuliaStruct)]` struct as recorded in the manifest.
 
 - `fields`: `(name, rust_type)` for every named field
-- `field_abis`: manifest `Field.abi` per field — `"string"` when the getter
-  returns an owned `<Struct>_RustCallOwnedString` buffer, `""` when it returns
-  the field as written (schema 4, #276). Absent keys mean `""`
+- `field_abis`: manifest `Field.abi` per field — `"string"` for an owned UTF-8
+  buffer, `"vec"` for an owned `RustVec` buffer, `""` when returned as written
+- `field_vec_elements` / `field_free_symbols`: the element type and exact
+  allocator-matched release export of a `"vec"` getter (schema 10, #303)
 - `field_getters` / `field_setters`: exported accessor symbols per accessible field
 - `context_code`: struct + impl source (generic structs only)
 - `generic_wrappers`: `(name, source, type_params)` wrappers registered for monomorphization;
@@ -193,6 +194,8 @@ struct RustStructInfo
     context_code::String
     fields::Vector{Tuple{String, String}}
     field_abis::Dict{String, String}
+    field_vec_elements::Dict{String, String}
+    field_free_symbols::Dict{String, String}
     has_derive_julia_struct::Bool
     derive_options::Dict{String, Bool}
     field_getters::Dict{String, String}
@@ -225,6 +228,8 @@ function RustStructInfo(name::String, type_params::Vector{String}, methods::Vect
                         context_code::String, fields::Vector{Tuple{String, String}},
                         has_derive_julia_struct::Bool, derive_options::Dict{String, Bool};
                         field_abis::Dict{String, String} = Dict{String, String}(),
+                        field_vec_elements::Dict{String, String} = Dict{String, String}(),
+                        field_free_symbols::Dict{String, String} = Dict{String, String}(),
                         field_getters::Dict{String, String} = Dict{String, String}(),
                         field_setters::Dict{String, String} = Dict{String, String}(),
                         has_clone::Bool = get(derive_options, "Clone", false),
@@ -238,6 +243,7 @@ function RustStructInfo(name::String, type_params::Vector{String}, methods::Vect
                         cfg_features::Vector{String} = String[],
                         ffi_name::String = name)
     RustStructInfo(name, type_params, methods, context_code, fields, field_abis,
+                   field_vec_elements, field_free_symbols,
                    has_derive_julia_struct,
                    derive_options, field_getters, field_setters, has_clone,
                    has_owned_string_helper, has_borrowed_string_helper, generic_wrappers, constraints,

--- a/test/test_ffi_contract.jl
+++ b/test/test_ffi_contract.jl
@@ -566,6 +566,16 @@ const ALL_SPELLINGS = vcat(
         plain = RustCall.ffi_return_contract("i32")
         @test !RustCall.ffi_owned_string_return(plain)
         @test !RustCall.ffi_borrowed_string_return(plain)
+        vector = RustCall.ffi_owned_vec_contract("Vec<i32>", "i32", "get_v_free_rust_vec")
+        @test RustCall.ffi_owned_vec_return(vector)
+        @test vector.aggregate_type === RustCall.CRustVec
+        @test vector.ccall_types == Type[RustCall.CRustVec]
+        @test vector.surface_type === RustCall.RustVec{Int32}
+        @test vector.ownership === :transferred_to_julia
+        @test vector.free_symbol == "get_v_free_rust_vec"
+        @test_throws ArgumentError RustCall.ffi_owned_vec_contract("Vec<i32>", "", "free")
+        @test_throws ArgumentError RustCall.ffi_owned_vec_contract("Vec<i32>", "i32", "")
+        @test_throws ArgumentError RustCall.ffi_owned_vec_contract("Vec<String>", "String", "free")
         # `Cstring` is gone from the string path: there is no `julia_to_c_type`
         # lowering of `RustString` / `RustStr` to a NUL-terminated pointer left.
         @test RustCall.julia_to_c_type(RustCall.RustString) !== Cstring

--- a/test/test_julia_attribute.jl
+++ b/test/test_julia_attribute.jl
@@ -165,8 +165,8 @@ using Libdl
     end
 
     @testset "manifest: schema version guard" begin
-        @test RustCall.MANIFEST_SCHEMA_VERSION == 9
-        @test RustCall._parse_manifest("schema_version = 9\nmode = \"inline\"\n")["schema_version"] == 9
+        @test RustCall.MANIFEST_SCHEMA_VERSION == 10
+        @test RustCall._parse_manifest("schema_version = 10\nmode = \"inline\"\n")["schema_version"] == 10
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 8\nmode = \"inline\"\n")
         # Schema 1 predates the string ABI columns (`abi`, `return_abi`, the
         # helper flags), schema 2 predates the additive `symbol` semantics
@@ -194,7 +194,7 @@ using Libdl
         end
         @test err isa RustCall.ExtractorError
         @test occursin("schema 1", sprint(showerror, err))
-        @test occursin("expects 9", sprint(showerror, err))
+        @test occursin("expects 10", sprint(showerror, err))
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 2\nmode = \"inline\"\n")
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 3\nmode = \"inline\"\n")
         @test_throws RustCall.ExtractorError RustCall._parse_manifest("schema_version = 4\nmode = \"inline\"\n")

--- a/test/test_pyo3_vec_field_payloads.jl
+++ b/test/test_pyo3_vec_field_payloads.jl
@@ -1,0 +1,91 @@
+using RustCall, Test
+include(joinpath(@__DIR__, "pyo3_wrapper_helpers.jl"))
+
+@testset "PyO3 Vec fields use an owned-buffer ABI (#303)" begin
+    mktempdir() do root
+        mkpath(joinpath(root, "src"))
+        write(joinpath(root, "Cargo.toml"), """
+            [package]
+            name = "vec_fields303"
+            version = "0.1.0"
+            edition = "2021"
+            [dependencies]
+            pyo3 = { version = "0.29", default-features = false, features = ["macros"] }
+            """)
+        write(joinpath(root, "src", "lib.rs"), raw"""
+            use pyo3::prelude::*;
+            #[pyclass]
+            pub struct VecFields303 {
+                #[pyo3(get, set)] pub values: Vec<i32>,
+                #[pyo3(set)] pub write_only: Vec<f64>,
+                #[pyo3(get)] pub packed: Vec<bool>,
+            }
+            #[pymethods]
+            impl VecFields303 {
+                #[new] pub fn new() -> Self {
+                    Self { values: vec![1, 2, 3], write_only: vec![], packed: vec![true] }
+                }
+                pub fn write_only_sum(&self) -> f64 { self.write_only.iter().sum() }
+            }
+            """)
+        wrapper = _link_libpython_wrapper(root)
+        if wrapper === nothing
+            @test_skip "no linkable Python here"
+        else
+            binding = @rust_crate root
+            inline = binding.module_ref
+            file = joinpath(root, "VecFields.jl")
+            RustCall.write_bindings_to_file(root, file; output_module_name = "VecFields303File")
+            holder = Module(gensym(:VecFieldHolder303))
+            Base.include(holder, file)
+            written = Base.invokelatest(getfield, holder, :VecFields303File)
+            modules = [inline, written]
+            try
+                for module_ in modules
+                    constructor = Base.invokelatest(getfield, module_, :VecFields303)
+                    object = Base.invokelatest(constructor)
+                    sum_hidden = Base.invokelatest(getfield, module_, :write_only_sum)
+                    try
+                        first = Base.invokelatest(getproperty, object, :values)
+                        @test first isa RustCall.RustVec{Int32}
+                        @test collect(first) == Int32[1, 2, 3]
+                        finalize(first)
+
+                        for value in (Int32[], Int64[4, -5, 6], 7:9)
+                            Base.invokelatest(setproperty!, object, :values, value)
+                            returned = Base.invokelatest(getproperty, object, :values)
+                            @test collect(returned) == Int32[value...]
+                            finalize(returned)
+                        end
+
+                        source = Base.invokelatest(getproperty, object, :values)
+                        Base.invokelatest(setproperty!, object, :values, source)
+                        @test collect(source) == Int32[7, 8, 9]
+                        finalize(source)
+
+                        Base.invokelatest(setproperty!, object, :write_only, [1, 2.5, -0.5])
+                        @test Base.invokelatest(sum_hidden, object) == 3.0
+                        @test_throws Exception Base.invokelatest(getproperty, object, :write_only)
+                        @test_throws Exception Base.invokelatest(getproperty, object, :packed)
+                        @test_throws InexactError Base.invokelatest(setproperty!, object, :values,
+                                                                   [typemax(Int64)])
+
+                        detached = Base.invokelatest(getproperty, object, :values)
+                        finalize(object)
+                        @test collect(detached) == Int32[7, 8, 9]
+                        finalize(detached)
+                    finally
+                        finalize(object)
+                    end
+                    @test_throws RustCall.RustError Base.invokelatest(setproperty!, object, :values,
+                                                                      Int32[])
+                end
+            finally
+                for name in unique(Base.invokelatest(getfield, m, :_LIB_NAME) for m in modules)
+                    RustCall.unload_library(name; close = true)
+                    RustCall.close_retired_handles!(RustCall.retired_handles(name))
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary

- expose public PyO3 `Vec<T>` fields through an owned `(ptr, len, cap)` ABI when `T` has a concrete scalar or pointer FFI layout
- return allocator-matched, generation-aware `RustVec{T}` values and accept Julia iterables in setters
- add manifest schema 10 metadata for the element type and exact vector release export
- keep `Vec<bool>`, nested vectors, private fields, frozen setters, and lookalike container paths unexposed

## Acceptance evidence

- supported/unsupported scan classification and release-symbol collisions → `vec_fields_use_the_owned_buffer_abi`, `vec_release_symbols_are_reserved_too`
- generated getter, release helper, setter, and set-only shape → `pyo3_field_payloads.rs`
- inline and written bindings; empty/converting/RustVec setter inputs; detached ownership; unsupported fields → `test_pyo3_vec_field_payloads.jl`
- schema and Julia FFI contract → `test_julia_attribute.jl`, `test_ffi_contract.jl`

## Validation

- `cargo test` (`deps/rustcall_core`)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (`deps/rustcall_extract`)
- `cargo test --all-features` (`deps/juliacall_macros`)
- all `scripts/lint_*.sh src`
- `julia --project=docs docs/make.jl`
- `Pkg.test()`: 10,314 pass / 5 known broken; serial 651/651

Advances #303. Remaining PyO3 parity work includes callable type aliases, signature defaults, `extends` ownership, and broader `PyResult`/`Result`/`Option` aggregate payloads.
