### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-09-10
+
+### Fixed
+- **Python-owned PyO3 handles keep their lifetime policy after method
+  filtering** ([#371](https://github.com/AtelierArith/RustCall.jl/issues/371)).
+  The wrapper manifest now records the authoritative handle decision before
+  unsupported methods are removed, so generated bindings continue to pin the
+  library image and keep Python-owned finalizers live.
+
 ## [0.3.1] - 2026-09-09
 
 ### Fixed
@@ -1458,7 +1467,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for Rust helpers library
 - Documentation examples tests
 
-[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.0...v0.2.1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustCall"
 uuid = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## Summary

- bump the Julia package version in `Project.toml` from `0.3.1` to `0.3.2`
- keep manifest schema 13 unchanged; release-aligned schema versioning starts with v0.4 under #372

## Validation

- parsed `Project.toml` with Julia's `TOML` stdlib and asserted `version == "0.3.2"`
- `git diff --check`

The v0.3.2 milestone is complete after #371 / #373.
