### PR TITLE
Drop BenchmarkTools from runtime deps and adopt Aqua.jl (#260)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,7 +150,7 @@ jobs:
         shell: bash
         env:
           RUSTCALL_EXTRACT: ${{ github.workspace }}/deps/rustcall_extract/target/release/rustcall-extract${{ runner.os == 'Windows' && '.exe' || '' }}
-        run: julia --project benchmark/benchmarks_compile.jl | tee benchmark-${{ runner.os }}.txt
+        run: julia --project=benchmark benchmark/benchmarks_compile.jl | tee benchmark-${{ runner.os }}.txt
       - name: Publish benchmark result
         if: always()
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **`BenchmarkTools` is no longer a runtime dependency, and Aqua.jl now
+  enforces that** ([#260](https://github.com/AtelierArith/RustCall.jl/issues/260)).
+  It was listed in `[deps]` while only `benchmark/*.jl` used it, so every
+  installation of RustCall pulled it and its transitive dependencies into the
+  runtime graph. It moves to a `benchmark/Project.toml` of its own; the
+  benchmark scripts are now run with `--project=benchmark` and resolve the
+  repository checkout through `benchmark/setup.jl`. `test/test_aqua.jl` runs
+  `Aqua.test_all`, which fails on a stale dependency, a missing `[compat]`
+  bound, type piracy, an unbound type parameter or an undefined export, so the
+  class cannot come back silently.
 - **`deps/juliacall_macros` renamed to `deps/rustcall_julia_macros`.** The
   crate's name suggested a companion to the unrelated `juliacall` PyPI
   package (the Python-side counterpart of `PythonCall.jl`) rather than a

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.3.2"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -14,19 +13,25 @@ Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
+Aqua = "0.8"
 BenchmarkTools = "1.6.3"
+Dates = "1"
+FileWatching = "1"
+Libdl = "1"
 ParallelTestRunner = "2.5"
 RustToolChain = "0.1.8"
 SHA = "0.7"
 Scratch = "1.3.0"
 TOML = "1"
+Test = "1"
 julia = "1.12"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ParallelTestRunner = "d3525ed8-44d0-4b2c-a655-542cee43accc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 benchmark = ["BenchmarkTools"]
-test = ["Test", "ParallelTestRunner"]
+test = ["Aqua", "ParallelTestRunner", "Test"]

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,14 @@
+# Environment for the benchmark scripts (issue #260).
+#
+# `BenchmarkTools` is not a runtime dependency of RustCall — only these
+# scripts use it — so it lives here rather than in the package's `[deps]`.
+# `RustCall` itself is resolved from the repository checkout by
+# `benchmark/setup.jl`, which every script loads first.
+
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+RustCall = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
+
+[compat]
+BenchmarkTools = "1.6.3"
+julia = "1.12"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,8 @@
 # Benchmarks for RustCall.jl
 # Performance comparison between native Julia and @rust
 
+include(joinpath(@__DIR__, "setup.jl"))
+
 using RustCall
 using BenchmarkTools
 

--- a/benchmark/benchmarks_arrays.jl
+++ b/benchmark/benchmarks_arrays.jl
@@ -1,6 +1,8 @@
 # Performance benchmarks for array operations in RustCall.jl
 # Tests RustVec, RustSlice, and Julia Vector performance
 
+include(joinpath(@__DIR__, "setup.jl"))
+
 using RustCall
 using BenchmarkTools
 

--- a/benchmark/benchmarks_cfg_probe.jl
+++ b/benchmark/benchmarks_cfg_probe.jl
@@ -1,6 +1,8 @@
 # Cost of always asking Cargo for current cfg (#291).
 # Run: julia --project benchmark/benchmarks_cfg_probe.jl
 # An isolated, dependency-free crate: not a prediction for large workspaces.
+include(joinpath(@__DIR__, "setup.jl"))
+
 using RustCall, Statistics
 
 mktempdir() do root

--- a/benchmark/benchmarks_compile.jl
+++ b/benchmark/benchmarks_compile.jl
@@ -2,13 +2,16 @@
 #
 # Run with:
 #   RUSTCALL_EXTRACT=/path/to/rustcall-extract \
-#     julia --project benchmark/benchmarks_compile.jl
+#     julia --project=benchmark benchmark/benchmarks_compile.jl
 #
 # The cold operation uses a fresh source identity on every sample, so it pays
 # for extraction and rustc without a cache hit. The warm operation first builds
 # one source, then unloads it and measures repeated disk-cache loads; expansion
 # is memoized by that point. BenchmarkTools is used with one evaluation per
 # sample because compiling a Rust cdylib is not a nanosecond-scale operation.
+
+include(joinpath(@__DIR__, "setup.jl"))
+
 using BenchmarkTools
 using Printf
 using RustCall

--- a/benchmark/benchmarks_generics.jl
+++ b/benchmark/benchmarks_generics.jl
@@ -1,6 +1,8 @@
 # Performance benchmarks for generic functions in RustCall.jl
 # Tests monomorphization cost and performance of generic vs specialized functions
 
+include(joinpath(@__DIR__, "setup.jl"))
+
 using RustCall
 using BenchmarkTools
 

--- a/benchmark/benchmarks_ownership.jl
+++ b/benchmark/benchmarks_ownership.jl
@@ -8,6 +8,8 @@
 #
 # Run with: julia --project benchmark/benchmarks_ownership.jl
 
+include(joinpath(@__DIR__, "setup.jl"))
+
 using RustCall
 
 # Check if Rust helpers library is available

--- a/benchmark/benchmarks_retirement.jl
+++ b/benchmark/benchmarks_retirement.jl
@@ -2,6 +2,8 @@
 # Run: julia --threads=4 --project benchmark/benchmarks_retirement.jl
 # This is NOT a reclamation implementation: a correct protocol also needs
 # publication/recheck ordering, live-object pins, and safe finalizer handling.
+include(joinpath(@__DIR__, "setup.jl"))
+
 using BenchmarkTools
 using Printf
 using RustCall

--- a/benchmark/setup.jl
+++ b/benchmark/setup.jl
@@ -1,0 +1,21 @@
+# Resolve the benchmark environment against the repository checkout.
+#
+# `BenchmarkTools` is a benchmark-only dependency (issue #260), so the scripts
+# run under `--project=benchmark` rather than the package project. That
+# environment declares `RustCall` as a dependency but cannot know where the
+# checkout is, so this file develops it from the parent directory the first
+# time and instantiates.
+#
+# Every benchmark script includes this file before `using RustCall`.
+
+import Pkg
+
+const _REPO_ROOT = normpath(joinpath(@__DIR__, ".."))
+
+if Base.active_project() == joinpath(@__DIR__, "Project.toml")
+    _manifest = joinpath(@__DIR__, "Manifest.toml")
+    if !isfile(_manifest)
+        Pkg.develop(Pkg.PackageSpec(path = _REPO_ROOT))
+    end
+    Pkg.instantiate()
+end

--- a/benchmark/setup.jl
+++ b/benchmark/setup.jl
@@ -1,7 +1,7 @@
 # Resolve the benchmark environment against the repository checkout.
 #
 # `BenchmarkTools` is a benchmark-only dependency (issue #260), so the scripts
-# run under `--project=benchmark` rather than the package project. That
+# run under `--project=benchmark` rather than under the package project. That
 # environment declares `RustCall` as a dependency but cannot know where the
 # checkout is, so this file develops it from the parent directory the first
 # time and instantiates.
@@ -11,11 +11,27 @@
 import Pkg
 
 const _REPO_ROOT = normpath(joinpath(@__DIR__, ".."))
+const _BENCH_PROJECT = normpath(joinpath(@__DIR__, "Project.toml"))
 
-if Base.active_project() == joinpath(@__DIR__, "Project.toml")
-    _manifest = joinpath(@__DIR__, "Manifest.toml")
-    if !isfile(_manifest)
-        Pkg.develop(Pkg.PackageSpec(path = _REPO_ROOT))
+let active = Base.active_project()
+    if active !== nothing && normpath(active) == _BENCH_PROJECT
+        if !isfile(joinpath(@__DIR__, "Manifest.toml"))
+            Pkg.develop(Pkg.PackageSpec(path = _REPO_ROOT))
+        end
+        Pkg.instantiate()
+    elseif Base.identify_package("BenchmarkTools") === nothing
+        # Some other environment is active — most likely the package project,
+        # which is where these scripts used to run. `BenchmarkTools` is not a
+        # dependency of RustCall any more (#260), so name the command that
+        # works before the script's own `using BenchmarkTools` fails with
+        # "package not found". A script that needs no BenchmarkTools
+        # (`benchmarks_cfg_probe.jl`) keeps running, which is why this warns
+        # rather than throws.
+        @warn """
+              BenchmarkTools is not available in the active environment. The benchmark
+              scripts have their own since #260; run them with
+
+                  julia --project=benchmark benchmark/<script>.jl
+              """ active_project = active
     end
-    Pkg.instantiate()
 end

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -327,19 +327,19 @@ The following benchmarks were run on Julia 1.12, Rust 1.92.0, macOS.
 ```bash
 # Extractor + rustc compile-time benchmark (cold and warm)
 RUSTCALL_EXTRACT=/path/to/rustcall-extract \
-  julia --project benchmark/benchmarks_compile.jl
+  julia --project=benchmark benchmark/benchmarks_compile.jl
 
 # Basic benchmarks
-julia --project benchmark/benchmarks.jl
+julia --project=benchmark benchmark/benchmarks.jl
 
 # Ownership type benchmarks
-julia --threads=4 --project benchmark/benchmarks_ownership.jl
+julia --threads=4 --project=benchmark benchmark/benchmarks_ownership.jl
 
 # Array operation benchmarks
-julia --project benchmark/benchmarks_arrays.jl
+julia --project=benchmark benchmark/benchmarks_arrays.jl
 
 # Generics benchmarks
-julia --project benchmark/benchmarks_generics.jl
+julia --project=benchmark benchmark/benchmarks_generics.jl
 ```
 
 ### Inline compilation benchmark (#271)

--- a/docs/src/project_guide.md
+++ b/docs/src/project_guide.md
@@ -86,10 +86,10 @@ cd deps/rustcall_julia_macros && cargo test --all-features
 The repository includes benchmark scripts comparing native Julia paths with `@rust`.
 
 ```bash
-julia --project benchmark/benchmarks.jl
-julia --project benchmark/benchmarks_arrays.jl
-julia --project benchmark/benchmarks_generics.jl
-julia --project benchmark/benchmarks_ownership.jl
+julia --project=benchmark benchmark/benchmarks.jl
+julia --project=benchmark benchmark/benchmarks_arrays.jl
+julia --project=benchmark benchmark/benchmarks_generics.jl
+julia --project=benchmark benchmark/benchmarks_ownership.jl
 ```
 
 ## Development Setup

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,0 +1,35 @@
+# Dependency and package hygiene, enforced mechanically (issue #260).
+#
+# The motivating defect: `BenchmarkTools` sat in `[deps]` while only
+# `benchmark/*.jl` used it, so every user of RustCall pulled it (and its
+# transitive dependencies) into their runtime graph. A prose note would not
+# have stopped it coming back; `Aqua.test_all` does, and covers the rest of
+# the same class (missing `[compat]` bounds, stale `[extras]`, type piracy,
+# unbound type parameters, undefined exports).
+#
+# `persistent_tasks` is disabled deliberately. It loads RustCall in a child
+# process and fails the package if the process is still busy after a fixed
+# wall-clock timeout. RustCall's `__init__` probes the Rust toolchain
+# (`check_rustc_available`), which on a machine without `rustc` on PATH asks
+# RustToolChain.jl for its artifact and may download one — a first-run cost
+# that has nothing to do with a leaked task and everything to do with how long
+# the check is willing to wait. Nothing in `__init__` starts a task; the
+# hot-reload watchers are started on demand and stopped by
+# `test/test_hot_reload.jl`.
+
+using Aqua
+using RustCall
+using Test
+
+@testset "Aqua quality assurance" begin
+    Aqua.test_all(RustCall; persistent_tasks = false)
+end
+
+@testset "BenchmarkTools is not a runtime dependency (#260)" begin
+    project = RustCall.TOML.parsefile(joinpath(pkgdir(RustCall), "Project.toml"))
+    # It stays available to `benchmark/benchmarks.jl` through `[extras]` and
+    # the `benchmark` target, but must never reach a user of the package.
+    @test !haskey(project["deps"], "BenchmarkTools")
+    @test haskey(project["extras"], "BenchmarkTools")
+    @test "BenchmarkTools" in project["targets"]["benchmark"]
+end


### PR DESCRIPTION
## What

`BenchmarkTools` was listed in `Project.toml` `[deps]` but never used in `src/` — only by `benchmark/*.jl`. Every installation of RustCall therefore pulled it, and JSON / Profile / Statistics with it, into the runtime dependency graph.

- Removed from `[deps]`; it now lives in a new `benchmark/Project.toml`.
- `benchmark/setup.jl` develops the repository checkout into that environment on first use, so `julia --project=benchmark benchmark/benchmarks.jl` remains a single command. Every benchmark script includes it.
- `docs/src/performance.md` and `docs/src/project_guide.md` updated to `--project=benchmark`.
- Added the `[compat]` bounds Aqua found missing (`Dates`, `FileWatching`, `Libdl`, `Test`).
- `test/test_aqua.jl` runs `Aqua.test_all(RustCall; persistent_tasks = false)` plus a direct assertion that BenchmarkTools is absent from `[deps]` and present in the benchmark target.

`persistent_tasks` is deliberately off and the reason is recorded in the test file: it fails the package when a child process that loaded RustCall is still busy after a fixed wall-clock timeout, and `__init__` probes the Rust toolchain, which may download an artifact on a machine without `rustc`. Nothing in `__init__` starts a task.

## Acceptance criteria (#260)

| Criterion | Test |
| --- | --- |
| `Pkg.add("RustCall")` no longer installs BenchmarkTools | `test/test_aqua.jl`, "BenchmarkTools is not a runtime dependency (#260)" |
| Benchmarks still run | `benchmark/Project.toml` + `benchmark/setup.jl`; verified locally by resolving the environment and loading both packages |
| Aqua stale-deps check passes in CI | `test/test_aqua.jl`, "Aqua quality assurance" (auto-discovered by `test/runtests.jl`) |

## Verification

- `Pkg.test()`: 712 / 712 pass, 3m19s (macOS aarch64, Julia 1.12.7)
- every `scripts/lint_*.sh src`: pass
- benchmark environment resolves and loads BenchmarkTools 1.8.0 + RustCall 0.3.2

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
