### PR TITLE
Claim the panic-channel readers in the duplicate-symbol scan (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The crate-wide duplicate-symbol scan sees the panic readers too**
+  ([#338](https://github.com/AtelierArith/RustCall.jl/issues/338)). Every
+  generated wrapper exports a second `#[no_mangle]` item next to itself — the
+  reader of its panic channel, `<symbol>_take_panic` — and the scan did not
+  count it. A crate-root `#[julia] fn a__run_take_panic` next to `#[julia] pub
+  mod a { #[julia] pub fn run }` therefore reached the linker as two items of
+  one symbol instead of being refused with both owners named. Struct methods
+  claim their reader the same way, and inline expansion asks the same question
+  of the manifest it has just built. A plain `#[no_mangle] extern "C"`
+  function claims only its own name: RustCall generates nothing for it, so a
+  hand-written `release` / `release_take_panic` pair stays two unrelated
+  exports.
+
 ### Changed
 - **`BenchmarkTools` is no longer a runtime dependency, and Aqua.jl now
   enforces that** ([#260](https://github.com/AtelierArith/RustCall.jl/issues/260)).

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -733,11 +733,21 @@ fn owned_string_free_symbol(owner: &str) -> String {
 }
 
 impl Function {
-    /// The exported symbols this `#[julia]` function claims — its wrapper and,
-    /// when it returns an owned string, the release function of its buffer —
-    /// with the owner label of [`Manifest::symbol_owners`]; empty when it
-    /// claims none (a PyO3 item, an unexported or generic one, an undecided
-    /// `#[cfg]`).
+    /// The exported symbols this `#[julia]` function claims — its wrapper, the
+    /// reader of that wrapper's panic channel and, when it returns an owned
+    /// string, the release function of its buffer — with the owner label of
+    /// [`Manifest::symbol_owners`]; empty when it claims none (a PyO3 item, an
+    /// unexported or generic one, an undecided `#[cfg]`).
+    ///
+    /// The panic reader is as much an export as the wrapper itself
+    /// (`crate::codegen::panic_channel` emits it `#[no_mangle]` next to it),
+    /// so a crate-root `#[julia] fn a__run_take_panic` next to `a::run` is a
+    /// duplicate symbol even though the two wrappers differ (#338). Only a
+    /// wrapper RustCall generates has one: a plain `#[no_mangle] extern "C"`
+    /// function is reported so Julia can register its return type, is
+    /// exported under its own name, and adds nothing — a hand-written
+    /// `release` / `release_take_panic` pair is two unrelated exports, not a
+    /// collision.
     pub fn claimed_symbols(&self) -> Vec<(String, String)> {
         if self.attribute.is_pyo3_scan()
             || !self.exported
@@ -748,6 +758,9 @@ impl Function {
         }
         let who = symbol_owner(&self.module_path, &self.name, self.line);
         let mut out = vec![(self.symbol.clone(), who.clone())];
+        if self.attribute == Attribute::Julia {
+            out.push((crate::codegen::panic_symbol(&self.symbol), who.clone()));
+        }
         if self.has_owned_string_helper && !self.ffi_name.is_empty() {
             out.push((owned_string_free_symbol(&self.ffi_name), who));
         }
@@ -770,7 +783,8 @@ impl Method {
 
 impl Struct {
     /// The exported symbols this `#[julia]` struct claims — `free`, the field
-    /// accessors, the method wrappers and the release functions of the
+    /// accessors, the method wrappers, the panic-channel reader every one of
+    /// those wrappers exports next to itself, and the release functions of the
     /// owned-string buffers they use — with the owner label of
     /// [`Manifest::symbol_owners`].
     ///
@@ -811,6 +825,7 @@ impl Struct {
             if m.cfg.is_empty() {
                 if !m.symbol.is_empty() {
                     out.push((m.symbol.clone(), who.clone()));
+                    out.push((crate::codegen::panic_symbol(&m.symbol), who.clone()));
                 }
                 if m.declares_owned_string()
                     && !m.string_owner.is_empty()

--- a/deps/rustcall_core/tests/symbols.rs
+++ b/deps/rustcall_core/tests/symbols.rs
@@ -463,3 +463,154 @@ fn an_impl_the_macro_would_qualify_differently_is_refused() {
     .unwrap();
     assert_eq!(ok.structs[0].methods[0].symbol, "rustcall_a__C_run");
 }
+
+/// Every wrapper exports its panic-channel reader next to itself
+/// (`<symbol>_take_panic`, `crate::codegen::panic_channel`), so that reader is
+/// a claimed symbol like any other — for free functions and for struct
+/// methods alike (#338).
+#[test]
+fn panic_readers_are_claimed_symbols() {
+    let m = extract(
+        r#"
+            #[julia] pub mod a { #[julia] pub fn run() -> i32 { 1 } }
+            #[julia] pub struct C { pub v: i32 }
+            #[julia] impl C { #[julia] pub fn get(&self) -> i32 { self.v } }
+        "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    let owners = m.symbol_owners();
+    let claims = |symbol: &str| owners.iter().filter(|(s, _)| s == symbol).count();
+    assert_eq!(claims("rustcall_a__run_take_panic"), 1, "{owners:?}");
+    assert_eq!(claims("rustcall_C_get_take_panic"), 1, "{owners:?}");
+    // The ones the struct already claimed keep their single claim.
+    assert_eq!(claims("C_free_take_panic"), 1, "{owners:?}");
+    assert_eq!(claims("C_get_v_take_panic"), 1, "{owners:?}");
+    // A string release function has no `catch_unwind` boundary and so no
+    // reader (`crate::codegen::owned_string_helper`).
+    assert_eq!(claims("C_free_rust_string_take_panic"), 0, "{owners:?}");
+    assert!(
+        m.duplicate_symbols().is_empty(),
+        "{:?}",
+        m.duplicate_symbols()
+    );
+}
+
+/// A crate-root `#[julia] fn a__run_take_panic` spells the panic reader of
+/// `a::run`. The wrappers differ, so only the derived symbols collide — the
+/// case `symbol_owners` used to miss, letting two `#[no_mangle]` items of one
+/// name reach the linker (#338).
+#[test]
+fn a_duplicate_panic_reader_fails_extraction_with_both_owners() {
+    let err = extract(
+        r#"
+            #[julia] pub mod a { #[julia] pub fn run() -> i32 { 1 } }
+            #[julia] pub fn a__run_take_panic() -> i32 { 2 }
+        "#,
+        Mode::Crate,
+    )
+    .expect_err("a duplicate panic reader must fail the scan")
+    .to_string();
+    assert!(
+        err.contains("duplicate exported symbol `rustcall_a__run_take_panic`"),
+        "{err}"
+    );
+    assert!(err.contains("`a::run` (line 2)"), "{err}");
+    assert!(err.contains("`a__run_take_panic` (line 3)"), "{err}");
+}
+
+/// The same coincidence against a struct method's reader.
+#[test]
+fn a_duplicate_method_panic_reader_fails_extraction() {
+    let err = extract(
+        r#"
+            #[julia] pub struct C { pub v: i32 }
+            #[julia] impl C { #[julia] pub fn get(&self) -> i32 { self.v } }
+            #[julia] pub fn C_get_take_panic() -> i32 { 0 }
+        "#,
+        Mode::Crate,
+    )
+    .expect_err("a duplicate method panic reader must fail the scan")
+    .to_string();
+    assert!(
+        err.contains("duplicate exported symbol `rustcall_C_get_take_panic`"),
+        "{err}"
+    );
+}
+
+/// Inline expansion asks the same question of the manifest it just built, so
+/// a `rust"""` block with the same coincidence fails with a `compile_error!`
+/// naming both items rather than with rustc's duplicate-symbol diagnostic
+/// pointing into generated code (#338, #342).
+#[test]
+fn an_inline_duplicate_panic_reader_is_a_compile_error() {
+    let inline = rustcall_core::expand::expand(
+        r#"
+        #[julia] pub mod a { #[julia] pub fn run() -> i32 { 1 } }
+        #[julia] pub fn a__run_take_panic() -> i32 { 2 }
+        "#,
+    )
+    .unwrap();
+    let dups = inline.manifest.duplicate_symbols();
+    assert_eq!(dups.len(), 1, "{dups:?}");
+    assert_eq!(dups[0].0, "rustcall_a__run_take_panic");
+    assert!(inline.source.contains("compile_error"), "{}", inline.source);
+    assert!(
+        inline.source.contains("rustcall_a__run_take_panic"),
+        "{}",
+        inline.source
+    );
+}
+
+/// A plain `#[no_mangle] extern "C"` function is reported so Julia can
+/// register its return type, but RustCall generates nothing for it: it is
+/// exported under its own name and has no panic channel. A hand-written
+/// destructor and its hand-written channel — the shape `resolve_call_target`
+/// is tested against — are therefore two unrelated exports, not a collision
+/// (#338).
+#[test]
+fn a_hand_written_function_claims_only_its_own_name() {
+    let inline = rustcall_core::expand::expand(
+        r#"
+        #[julia] pub fn value() -> i32 { 111 }
+        #[no_mangle] pub extern "C" fn release() {}
+        #[no_mangle] pub extern "C" fn release_take_panic(_out: *mut u8, _cap: usize) -> usize { 0 }
+        "#,
+    )
+    .unwrap();
+    let owners = inline.manifest.symbol_owners();
+    let claims = |symbol: &str| owners.iter().filter(|(s, _)| s == symbol).count();
+    assert_eq!(claims("release"), 1, "{owners:?}");
+    assert_eq!(claims("release_take_panic"), 1, "{owners:?}");
+    // The `#[julia]` item next to them keeps both of its own exports.
+    assert_eq!(claims("rustcall_value"), 1, "{owners:?}");
+    assert_eq!(claims("rustcall_value_take_panic"), 1, "{owners:?}");
+    assert!(
+        inline.manifest.duplicate_symbols().is_empty(),
+        "{:?}",
+        inline.manifest.duplicate_symbols()
+    );
+    assert!(
+        !inline.source.contains("compile_error"),
+        "{}",
+        inline.source
+    );
+}
+
+/// The converse: a hand-written `#[no_mangle]` function that spells the panic
+/// reader a `#[julia]` wrapper generates *is* a collision, and is reported
+/// against the item that generates it.
+#[test]
+fn a_hand_written_name_may_still_collide_with_a_generated_reader() {
+    let inline = rustcall_core::expand::expand(
+        r#"
+        #[julia] pub fn value() -> i32 { 111 }
+        #[no_mangle] pub extern "C" fn rustcall_value_take_panic(_out: *mut u8, _cap: usize) -> usize { 0 }
+        "#,
+    )
+    .unwrap();
+    let dups = inline.manifest.duplicate_symbols();
+    assert_eq!(dups.len(), 1, "{dups:?}");
+    assert_eq!(dups[0].0, "rustcall_value_take_panic");
+    assert!(inline.source.contains("compile_error"), "{}", inline.source);
+}

--- a/test/test_module_symbols.jl
+++ b/test/test_module_symbols.jl
@@ -344,6 +344,42 @@ end
         end
     end
 
+    @testset "a derived symbol coincidence fails closed (#338)" begin
+        # A wrapper exports more than its entry point: the reader of its panic
+        # channel (`<symbol>_take_panic`) is `#[no_mangle]` too. A crate-root
+        # `a__run_take_panic` therefore spells the reader of `a::run` even
+        # though the two wrappers differ, and the scan must say so rather than
+        # let rustc report a duplicate symbol in generated code.
+        mktempdir() do dir
+            _ms_write_two_module_crate(dir)
+            write(joinpath(dir, "src", "lib.rs"), """
+                use rustcall_julia_macros::julia;
+
+                #[julia]
+                pub mod a {
+                    use rustcall_julia_macros::julia;
+
+                    #[julia]
+                    pub fn run() -> i32 { 1 }
+                }
+
+                #[julia]
+                pub fn a__run_take_panic() -> i32 { 2 }
+                """)
+            err = try
+                RustCall.scan_crate(dir)
+                nothing
+            catch e
+                e
+            end
+            @test err isa RustCall.ExtractorError
+            msg = sprint(showerror, err)
+            @test occursin("duplicate exported symbol `rustcall_a__run_take_panic`", msg)
+            @test occursin("`a::run`", msg)
+            @test occursin("`a__run_take_panic`", msg)
+        end
+    end
+
     @testset "inline rust\"\"\" blocks qualify by the module they walk" begin
         if !RustCall.check_rustc_available()
             @test_skip "rustc is required"


### PR DESCRIPTION
## What

A generated wrapper exports **two** `#[no_mangle]` items: its entry point, and next to it the reader of its thread-local panic channel (`<symbol>_take_panic`, emitted by `codegen::panic_channel`). `Function::claimed_symbols` listed only the entry point, so the crate-wide duplicate check could not see a coincidence on that half:

```rust
#[julia] pub mod a { #[julia] pub fn run() -> i32 { 1 } }
#[julia] pub fn a__run_take_panic() -> i32 { 2 }   // spells a::run's reader
```

The two wrappers differ, so nothing else caught it and the crate reached rustc with two items of one symbol. Struct methods had the same gap; the struct's own destructor, accessors and `clone` already claimed theirs.

Both now claim the reader. Inline expansion asks `duplicate_symbols()` of its own manifest (#342), so a `rust"""` block with the same shape fails with a `compile_error!` naming both items rather than with a duplicate-symbol diagnostic pointing into generated code.

## The case that must **not** become an error

A plain `#[no_mangle] extern "C"` function is reported so Julia can register its return type, but RustCall generates no wrapper and no channel for it. It therefore claims only its own name — otherwise a hand-written destructor and its hand-written channel would read as a collision. That is exactly the shape `test/test_state.jl` builds for `resolve_call_target`, and the first draft of this change broke it. Pinned now by `a_hand_written_function_claims_only_its_own_name`.

## Tests

`deps/rustcall_core/tests/symbols.rs`:

| Test | Asserts |
| --- | --- |
| `panic_readers_are_claimed_symbols` | the reader of a free function and of a struct method is claimed once; a string release function has no reader |
| `a_duplicate_panic_reader_fails_extraction_with_both_owners` | crate scan refuses `a__run_take_panic` next to `a::run`, naming both |
| `a_duplicate_method_panic_reader_fails_extraction` | the same against a method's reader |
| `an_inline_duplicate_panic_reader_is_a_compile_error` | inline expansion emits `compile_error!` naming the symbol |
| `a_hand_written_function_claims_only_its_own_name` | a `release` / `release_take_panic` pair written by hand is not a collision |
| `a_hand_written_name_may_still_collide_with_a_generated_reader` | but `rustcall_value_take_panic` written by hand next to `#[julia] fn value` is |

`test/test_module_symbols.jl`: "a derived symbol coincidence fails closed (#338)" drives the same crate through `RustCall.scan_crate` and checks the error text users see.

## Scope

`Advances #338` — items 1 and 2. Item 1's wider request, sharing one "every symbol this entry claims" function with the PyO3 scan (`pyo3::wrapper_symbols` / `string_helper_symbols`), is not done here; the two sides still derive their lists separately. Items 3 and 4 were closed by #341.

## Verification

- `cargo test` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` in `deps/rustcall_core`: pass, golden corpus unchanged
- `cargo test` in `deps/rustcall_extract`, `cargo test --all-features` in `deps/rustcall_julia_macros`: pass
- `Pkg.test()`: 10340 pass / 5 broken parallel phase + 712 pass serial phase, exit 0 (macOS aarch64, Julia 1.12.7)
- every `scripts/lint_*.sh src`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
