### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-09-11
+
 ### Fixed
 - **The crate-wide duplicate-symbol scan sees the panic readers too**
   ([#338](https://github.com/AtelierArith/RustCall.jl/issues/338)). Every
@@ -1517,7 +1519,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for Rust helpers library
 - Documentation examples tests
 
-[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/atelierarith/RustCall.jl/compare/v0.2.1...v0.3.0

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustCall"
 uuid = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## What

Bumps `Project.toml` to 0.3.3 and closes the `## [Unreleased]` section of the changelog. No code changes.

## Contents of the tag

| Issue | Change | PR |
| --- | --- | --- |
| #338 | The duplicate-symbol scan counts the panic-channel reader each generated wrapper exports, so a name that collides only there is refused with both owners named instead of reaching the linker | #378 |
| #260 | `BenchmarkTools` leaves the runtime dependency graph; `Aqua.test_all` keeps stale deps, missing compat bounds, piracy and undefined exports out | #377 |
| #259 | rustc, cargo and the helpers library are asserted in CI rather than skipped around; the registry-backed integration tests are opt-in behind a scheduled `Network integration` job | #379 |

A patch bump: one bug fix in the extractor's symbol accounting, the rest is build and test hygiene. No API change, no manifest schema change.

## After merge

Register by commenting `@JuliaRegistrator register` with a `Release notes:` block on issue #229, as for every release since 0.1.0. TagBot creates the tag once the General PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
