### PR TITLE
Count skipped testsets and drop sleep-based synchronisation (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Skipped testsets are counted, and the hot-reload tests no longer use a
+  fixed `sleep` to synchronise**
+  ([#259](https://github.com/AtelierArith/RustCall.jl/issues/259)). Sixty-five
+  testsets announced a missing toolchain with `@warn` and returned, so they
+  vanished from the summary rather than appearing as skips; they use
+  `@test_skip` now. In `test/test_hot_reload.jl`, the five sleeps that waited
+  for a watcher to stop are gone — `disable_hot_reload` already waits for the
+  task through `stop_watch_task` — and the lock-serialisation test hands off
+  through a channel and `wait(t)` instead of two fixed sleeps.
+
 ## [0.3.3] - 2026-09-11
 
 ### Fixed

--- a/test/test_advanced_examples.jl
+++ b/test/test_advanced_examples.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Advanced Examples" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping advanced examples tests"
+        @test_skip "rustc not found, skipping advanced examples tests"
         return
     end
 

--- a/test/test_basic_examples.jl
+++ b/test/test_basic_examples.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Basic Examples" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping basic examples tests"
+        @test_skip "rustc not found, skipping basic examples tests"
         return
     end
 

--- a/test/test_cache.jl
+++ b/test/test_cache.jl
@@ -663,6 +663,6 @@ end
             end
         end
     else
-        @warn "rustc not found, skipping cache integration tests"
+        @test_skip "rustc not found, skipping cache integration tests"
     end
 end

--- a/test/test_core_api.jl
+++ b/test/test_core_api.jl
@@ -428,7 +428,7 @@ using Test
             end
         end
     else
-        @warn "rustc not found, skipping compilation tests"
+        @test_skip "rustc not found, skipping compilation tests"
     end
 
     @testset "Temp directory cleanup (issue #88)" begin
@@ -472,7 +472,7 @@ using Test
                 rm(debug_dir, recursive=true, force=true)
             end
         else
-            @warn "rustc not found, skipping temp directory cleanup tests"
+            @test_skip "rustc not found, skipping temp directory cleanup tests"
         end
     end
 
@@ -544,7 +544,7 @@ using Test
                 rm(dirname(lib_path), recursive=true, force=true)
             end
         else
-            @warn "rustc not found, skipping error handling enhancement tests"
+            @test_skip "rustc not found, skipping error handling enhancement tests"
         end
     end
 end

--- a/test/test_crate_bindings.jl
+++ b/test/test_crate_bindings.jl
@@ -35,7 +35,7 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
 
     @testset "scan_crate" begin
         if !isdir(SAMPLE_CRATE_PATH)
-            @warn "Sample crate not found, skipping scan_crate tests"
+            @test_skip "Sample crate not found, skipping scan_crate tests"
             return
         end
 
@@ -65,7 +65,7 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
     @testset "parse_cargo_toml" begin
         cargo_toml_path = joinpath(SAMPLE_CRATE_PATH, "Cargo.toml")
         if !isfile(cargo_toml_path)
-            @warn "Cargo.toml not found, skipping test"
+            @test_skip "Cargo.toml not found, skipping test"
             return
         end
 
@@ -78,7 +78,7 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
 
     @testset "find_rust_sources" begin
         if !isdir(SAMPLE_CRATE_PATH)
-            @warn "Sample crate not found, skipping test"
+            @test_skip "Sample crate not found, skipping test"
             return
         end
 
@@ -91,7 +91,7 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
 
     @testset "scan_crate skips include!() fragments" begin
         if !RustCall.check_rustc_available()
-            @warn "rustc not found, skipping"
+            @test_skip "rustc not found, skipping"
         else
             mktempdir() do dir
                 mkpath(joinpath(dir, "src"))
@@ -119,7 +119,7 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
 
     @testset "crate-mode manifest: #[julia] structs" begin
         if !RustCall.check_rustc_available()
-            @warn "rustc not found, skipping"
+            @test_skip "rustc not found, skipping"
         else
             code = """
             use rustcall_julia_macros::julia;
@@ -151,7 +151,7 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
     end
     @testset "create_wrapper_crate" begin
         if !isdir(SAMPLE_CRATE_PATH)
-            @warn "Sample crate not found, skipping test"
+            @test_skip "Sample crate not found, skipping test"
             return
         end
 
@@ -178,7 +178,7 @@ const _SRC_DIR_CB = joinpath(dirname(dirname(pathof(RustCall))), "src")
 
     @testset "compute_crate_hash" begin
         if !isdir(SAMPLE_CRATE_PATH)
-            @warn "Sample crate not found, skipping test"
+            @test_skip "Sample crate not found, skipping test"
             return
         end
 
@@ -245,7 +245,7 @@ end
 # This is a heavier test that requires cargo and takes longer
 @testset "Crate Bindings Integration" begin
     if !isdir(SAMPLE_CRATE_PATH)
-        @warn "Sample crate not found, skipping integration tests"
+        @test_skip "Sample crate not found, skipping integration tests"
         return
     end
 
@@ -253,7 +253,7 @@ end
     try
         run(pipeline(`$(cargo()) --version`, devnull))
     catch
-        @warn "Cargo not available, skipping integration tests"
+        @test_skip "Cargo not available, skipping integration tests"
         return
     end
 
@@ -273,7 +273,7 @@ end
 
 @testset "Result and Option Type Parsing" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping"
+        @test_skip "rustc not found, skipping"
     else
         sigs(code) = RustCall.manifest_function_signatures(RustCall.extract_manifest(code; mode = "crate"))
 
@@ -439,14 +439,14 @@ end
 
 @testset "Result and Option Runtime Wrappers" begin
     if !isdir(SAMPLE_CRATE_PATH)
-        @warn "Sample crate not found, skipping Result/Option wrapper tests"
+        @test_skip "Sample crate not found, skipping Result/Option wrapper tests"
         return
     end
 
     try
         run(pipeline(`$(cargo()) --version`, devnull))
     catch
-        @warn "Cargo not available, skipping Result/Option wrapper tests"
+        @test_skip "Cargo not available, skipping Result/Option wrapper tests"
         return
     end
 
@@ -476,14 +476,14 @@ end
 
 @testset "Function Scope Usage" begin
     if !isdir(SAMPLE_CRATE_PATH)
-        @warn "Sample crate not found, skipping function scope usage tests"
+        @test_skip "Sample crate not found, skipping function scope usage tests"
         return
     end
 
     try
         run(pipeline(`$(cargo()) --version`, devnull))
     catch
-        @warn "Cargo not available, skipping function scope usage tests"
+        @test_skip "Cargo not available, skipping function scope usage tests"
         return
     end
 
@@ -509,7 +509,7 @@ end
 
 @testset "Precompilation Support" begin
     if !isdir(SAMPLE_CRATE_PATH)
-        @warn "Sample crate not found, skipping precompilation tests"
+        @test_skip "Sample crate not found, skipping precompilation tests"
         return
     end
 
@@ -517,7 +517,7 @@ end
     try
         run(pipeline(`$(cargo()) --version`, devnull))
     catch
-        @warn "Cargo not available, skipping precompilation tests"
+        @test_skip "Cargo not available, skipping precompilation tests"
         return
     end
 

--- a/test/test_cross_module_impl.jl
+++ b/test/test_cross_module_impl.jl
@@ -141,7 +141,7 @@ end
     end
 
     if !_CMI_HAVE_CARGO || !RustCall.check_rustc_available()
-        @warn "cargo/rustc not available, skipping the behavioural #315 tests"
+        @test_skip "cargo/rustc not available, skipping the behavioural #315 tests"
     else
         @testset "the methods are callable through @rust_crate" begin
             mktempdir() do dir
@@ -200,7 +200,7 @@ end
 
 @testset "A literal include! is part of the including module (#315 review)" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping the include! scan test"
+        @test_skip "rustc not found, skipping the include! scan test"
     else
         mktempdir() do dir
             mkpath(joinpath(dir, "src"))
@@ -461,7 +461,7 @@ end
 # of the crate root here, not of anything called `frag`.
 @testset "A mod declared inside an include! fragment is followed (#343)" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping the include!-plus-mod scan test"
+        @test_skip "rustc not found, skipping the include!-plus-mod scan test"
     else
         mktempdir() do dir
             mkpath(joinpath(dir, "src", "frag"))
@@ -522,7 +522,7 @@ end
 # see rather than failing (#343).
 @testset "A mod inside a fragment that names no file is skipped (#343)" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping the missing-mod-in-fragment test"
+        @test_skip "rustc not found, skipping the missing-mod-in-fragment test"
     else
         mktempdir() do dir
             mkpath(joinpath(dir, "src"))
@@ -563,7 +563,7 @@ end
 # review).
 @testset "A fragment included under two modules is scanned twice (#343 review)" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping the twice-included fragment test"
+        @test_skip "rustc not found, skipping the twice-included fragment test"
     else
         mktempdir() do dir
             write(joinpath(dir, "frag.rs"), """
@@ -599,7 +599,7 @@ end
 # review).
 @testset "A mod declared inside a fragment is followed without a crate root (#343 review)" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping the no-root fragment-module test"
+        @test_skip "rustc not found, skipping the no-root fragment-module test"
     else
         mktempdir() do dir
             mkpath(joinpath(dir, "frag"))
@@ -648,7 +648,7 @@ end
 # module position (#356).
 @testset "a listed include fragment keeps its module position (#356)" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping the listed-fragment position test"
+        @test_skip "rustc not found, skipping the listed-fragment position test"
     else
         mktempdir() do dir
             frag = joinpath(dir, "frag.rs")
@@ -704,7 +704,7 @@ end
 # last — the *off* branch, for a build that enables the feature (#357).
 @testset "cfg-exclusive modules including one fragment are both scanned (#357)" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping the cfg-exclusive fragment test"
+        @test_skip "rustc not found, skipping the cfg-exclusive fragment test"
     else
         mktempdir() do dir
             mkpath(joinpath(dir, "src"))

--- a/test/test_error_handling.jl
+++ b/test/test_error_handling.jl
@@ -110,7 +110,7 @@ using Test
             compiler = RustCall.RustCompiler(debug_mode=false)
             @test_throws RustCall.CompilationError RustCall.compile_rust_to_shared_lib(invalid_code; compiler=compiler)
         else
-            @warn "rustc not available, skipping CompilationError display test"
+            @test_skip "rustc not available, skipping CompilationError display test"
         end
     end
 
@@ -136,7 +136,7 @@ using Test
                 rm(debug_dir, recursive=true, force=true)
             end
         else
-            @warn "rustc not available, skipping debug mode test"
+            @test_skip "rustc not available, skipping debug mode test"
         end
     end
 

--- a/test/test_generic_struct.jl
+++ b/test/test_generic_struct.jl
@@ -287,7 +287,7 @@ end
 
 @testset "Generic Struct Test" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping generic struct tests"
+        @test_skip "rustc not found, skipping generic struct tests"
         return
     end
 

--- a/test/test_hot_reload.jl
+++ b/test/test_hot_reload.jl
@@ -11,7 +11,7 @@ const SAMPLE_CRATE_PATH = joinpath(@__DIR__, "fixtures", "sample_crate")
 
     @testset "File discovery" begin
         if !isdir(SAMPLE_CRATE_PATH)
-            @warn "Sample crate not found, skipping file discovery tests"
+            @test_skip "Sample crate not found, skipping file discovery tests"
             return
         end
 
@@ -115,14 +115,24 @@ const SAMPLE_CRATE_PATH = joinpath(@__DIR__, "fixtures", "sample_crate")
     end
 
     @testset "Per-library lock serializes reload across tasks" begin
-        # Verify that acquiring the lock blocks other tasks
+        # Verify that acquiring the lock blocks other tasks.
+        #
+        # No fixed sleep is used to establish state (#259): the task announces
+        # that it is about to take the lock through a channel, and the test
+        # then asserts that it does *not* get through within a generous
+        # window. A timeout asserting an absence is sound where a fixed sleep
+        # asserting a presence is a race. The far side is deterministic —
+        # `wait(t)` returns when the task really has run.
         lib_lock = RustCall._get_reload_lock("test_serialization")
         order = Int[]
+        about_to_lock = Channel{Nothing}(1)
+        # `try` opens a scope, so the task handle is bound outside it.
+        t = nothing
 
         lock(lib_lock)
         try
-            # Spawn a task that tries to acquire the same lock
             t = @async begin
+                put!(about_to_lock, nothing)
                 lock(lib_lock)
                 try
                     push!(order, 2)
@@ -131,17 +141,16 @@ const SAMPLE_CRATE_PATH = joinpath(@__DIR__, "fixtures", "sample_crate")
                 end
             end
 
-            # Give the async task time to attempt the lock
-            sleep(0.1)
-            # Task should be blocked — order should still be empty
-            @test isempty(order)
+            take!(about_to_lock)
+            # The task is blocked on the lock we hold, so it must not push
+            # within the window; `:timed_out` is the passing outcome.
+            @test timedwait(() -> !isempty(order), 1.0) === :timed_out
             push!(order, 1)
         finally
             unlock(lib_lock)
         end
 
-        # Now the async task should complete
-        sleep(0.1)
+        wait(t)
         @test order == [1, 2]
 
         # Clean up
@@ -155,7 +164,7 @@ end
 # Integration tests with actual crate (slower)
 @testset "Hot Reload Integration" begin
     if !isdir(SAMPLE_CRATE_PATH)
-        @warn "Sample crate not found, skipping hot reload integration tests"
+        @test_skip "Sample crate not found, skipping hot reload integration tests"
         return
     end
 
@@ -163,7 +172,7 @@ end
     try
         run(pipeline(`$(cargo()) --version`, devnull))
     catch
-        @warn "Cargo not available, skipping hot reload integration tests"
+        @test_skip "Cargo not available, skipping hot reload integration tests"
         return
     end
 
@@ -192,14 +201,12 @@ end
 
             # Disable hot reload
             RustCall.disable_hot_reload("SampleCrateHotReload")
-            sleep(0.1)  # Give task time to stop
 
             @test !RustCall.HOT_RELOAD_REGISTRY["SampleCrateHotReload"].enabled
 
         finally
             # Clean up
             RustCall.disable_all_hot_reload()
-            sleep(0.1)
             empty!(RustCall.HOT_RELOAD_REGISTRY)
         end
     end
@@ -295,7 +302,6 @@ end
             @test ptr != C_NULL
         finally
             RustCall.disable_all_hot_reload()
-            sleep(0.1)
             empty!(RustCall.HOT_RELOAD_REGISTRY)
             lock(RustCall.REGISTRY_LOCK) do
                 delete!(RustCall.RUST_LIBRARIES, lib_name)
@@ -323,7 +329,6 @@ end
 
         finally
             RustCall.disable_all_hot_reload()
-            sleep(0.1)
             empty!(RustCall.HOT_RELOAD_REGISTRY)
         end
     end
@@ -351,7 +356,6 @@ end
 
         finally
             RustCall.disable_all_hot_reload()
-            sleep(0.1)
             empty!(RustCall.HOT_RELOAD_REGISTRY)
         end
     end

--- a/test/test_julia_attribute.jl
+++ b/test/test_julia_attribute.jl
@@ -8,7 +8,7 @@ using Libdl
     # Signatures come from the FFI manifest produced by rustcall-extract; Julia
     # never parses Rust source. These tests exercise the manifest round trip.
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping manifest tests"
+        @test_skip "rustc not found, skipping manifest tests"
         return
     end
 

--- a/test/test_julia_to_rust_generic.jl
+++ b/test/test_julia_to_rust_generic.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Julia to Rust Generic" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping julia_to_rust_generic tests"
+        @test_skip "rustc not found, skipping julia_to_rust_generic tests"
         return
     end
 

--- a/test/test_julia_to_rust_simple.jl
+++ b/test/test_julia_to_rust_simple.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Julia to Rust Simple" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping julia_to_rust_simple tests"
+        @test_skip "rustc not found, skipping julia_to_rust_simple tests"
         return
     end
 

--- a/test/test_julia_to_rust_struct.jl
+++ b/test/test_julia_to_rust_struct.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Julia to Rust Struct" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping julia_to_rust_struct tests"
+        @test_skip "rustc not found, skipping julia_to_rust_struct tests"
         return
     end
 

--- a/test/test_manifest.jl
+++ b/test/test_manifest.jl
@@ -27,7 +27,7 @@ using TOML
 
 @testset "FFI Manifest" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping manifest tests"
+        @test_skip "rustc not found, skipping manifest tests"
         return
     end
 
@@ -381,7 +381,7 @@ using TOML
 
             off = RustCall.pyo3_link_plan(dir)
             if !off.resolved
-                @warn "Cargo could not resolve the temp crate; skipping the resolved half"
+                @test_skip "Cargo could not resolve the temp crate; skipping the resolved half"
             else
                 # Defaults: no pyo3 in the graph at all, and the gated item is
                 # gone — pruned by the extractor's evaluator, not by a guess.

--- a/test/test_module_symbols.jl
+++ b/test/test_module_symbols.jl
@@ -429,7 +429,7 @@ end
     end
 
     if !_MS_HAVE_CARGO || !RustCall.check_rustc_available()
-        @warn "cargo/rustc not available, skipping the behavioural #300 tests"
+        @test_skip "cargo/rustc not available, skipping the behavioural #300 tests"
     else
         @testset "both `run`s and both `C`s are callable through @rust_crate" begin
             mktempdir() do dir

--- a/test/test_ownership.jl
+++ b/test/test_ownership.jl
@@ -126,7 +126,7 @@ using Test
             @test !isdefined(RustCall, :update_arc_finalizer)
         end
 
-        @warn "Rust helpers library not available, skipping full integration tests"
+        @test_skip "Rust helpers library not available, skipping full integration tests"
         @warn "To enable these tests, build the library with: using Pkg; Pkg.build(\"RustCall\")"
     else
         # Full integration tests with actual Rust library

--- a/test/test_ownership_examples.jl
+++ b/test/test_ownership_examples.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Ownership Examples" begin
     if !RustCall.is_rust_helpers_available()
-        @warn "Rust helpers library not available, skipping ownership examples tests"
+        @test_skip "Rust helpers library not available, skipping ownership examples tests"
         return
     end
 

--- a/test/test_parsing_generics_hotreload_fixes.jl
+++ b/test/test_parsing_generics_hotreload_fixes.jl
@@ -10,7 +10,7 @@ using RustCall
     # #168 - Field type parsing regex fails for generic types with commas
     # ========================================================================
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping manifest-based parsing tests"
+        @test_skip "rustc not found, skipping manifest-based parsing tests"
         return
     end
 
@@ -173,7 +173,10 @@ using RustCall
             nothing
         )
 
-        # Start a task that runs briefly
+        # Start a task that runs briefly. The sleep is this stand-in
+        # watcher's own poll interval, not test synchronisation (#259): the
+        # test below waits for the task through `stop_watch_task`, which
+        # returns only once it has really finished.
         state.watch_task = @async begin
             while state.enabled
                 sleep(0.05)

--- a/test/test_phase4_pi.jl
+++ b/test/test_phase4_pi.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Phase 4: Monte Carlo Pi Example" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping phase4_pi tests"
+        @test_skip "rustc not found, skipping phase4_pi tests"
         return
     end
 

--- a/test/test_pyo3_link_plan.jl
+++ b/test/test_pyo3_link_plan.jl
@@ -552,7 +552,7 @@ _manifest(text::AbstractString) = TOML.parse(text)
     end
 
     if probe === nothing || !probe.resolved
-        @warn "Cargo could not resolve the example crates; skipping the resolved link-plan tests"
+        @test_skip "Cargo could not resolve the example crates; skipping the resolved link-plan tests"
     else
         @testset "resolved: mandatory pyo3 links libpython" begin
             plan = RustCall.pyo3_link_plan(mandatory_crate)
@@ -642,7 +642,7 @@ _manifest(text::AbstractString) = TOML.parse(text)
                 """)
                 plan = RustCall.pyo3_link_plan(dir)
                 if !plan.resolved
-                    @warn "Cargo could not resolve the dev-dependency crate; skipping"
+                    @test_skip "Cargo could not resolve the dev-dependency crate; skipping"
                 else
                     @test plan.mode === :link_libpython
                     @test !("extension-module" in plan.pyo3_features)

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -539,7 +539,7 @@ end
 # is gone.
 @testset "#279: name -> symbol resolution is scoped to one library" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping per-library symbol resolution test"
+        @test_skip "rustc not found, skipping per-library symbol resolution test"
         return
     end
 
@@ -607,7 +607,7 @@ end
 # but not the mapping, and resolved `f` to `f` instead of `rustcall_f`.
 @testset "#279: a library and its symbol mappings are published together" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping concurrent publication test"
+        @test_skip "rustc not found, skipping concurrent publication test"
         return
     end
 
@@ -651,7 +651,7 @@ end
 # cross-library search.
 @testset "#279: an aliased library keeps its symbol mappings" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping alias mapping test"
+        @test_skip "rustc not found, skipping alias mapping test"
         return
     end
 
@@ -698,7 +698,7 @@ end
 # none at all, instead of the type the aliased block declared.
 @testset "#279: an aliased library keeps its return-type hints" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping alias return-type test"
+        @test_skip "rustc not found, skipping alias return-type test"
         return
     end
 
@@ -751,7 +751,7 @@ end
 # library that is no longer in `RUST_LIBRARIES`.
 @testset "#279: re-registering an unloaded library is refused" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping unload-race test"
+        @test_skip "rustc not found, skipping unload-race test"
         return
     end
 
@@ -800,7 +800,7 @@ end
 # same name.
 @testset "#279: return-type hints do not outlive their library" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping stale return-type test"
+        @test_skip "rustc not found, skipping stale return-type test"
         return
     end
 
@@ -866,7 +866,7 @@ end
 # ambiguity error after any identity change.
 @testset "#279: an aliased handle is one candidate, not an ambiguity" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping alias ambiguity test"
+        @test_skip "rustc not found, skipping alias ambiguity test"
         return
     end
 
@@ -942,7 +942,7 @@ end
 # wrong ABI.
 @testset "#279: a return-type hint is never borrowed across libraries" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping cross-library ABI test"
+        @test_skip "rustc not found, skipping cross-library ABI test"
         return
     end
 
@@ -1007,7 +1007,7 @@ end
 # features exactly belongs to #277 Phase B.)
 @testset "#279: ambiguous cfg variants register no return type" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping ambiguous cfg variant test"
+        @test_skip "rustc not found, skipping ambiguous cfg variant test"
         return
     end
 
@@ -1725,7 +1725,7 @@ end
 # allocated the value.
 @testset "#249: the free symbol is resolved inside the allocating library" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping per-library free-symbol test"
+        @test_skip "rustc not found, skipping per-library free-symbol test"
     else
         source = n -> """
         #[julia]

--- a/test/test_rust_helpers_integration.jl
+++ b/test/test_rust_helpers_integration.jl
@@ -78,7 +78,7 @@ end
                 end
             end
         else
-            @warn "Rust helpers library not loaded. Skipping integration tests."
+            @test_skip "Rust helpers library not loaded. Skipping integration tests."
             @warn "Build with: using Pkg; Pkg.build(\"RustCall\")"
         end
     end
@@ -154,7 +154,7 @@ end
                 end
             end
         else
-            @warn "Rust helpers library not available. Skipping end-to-end tests."
+            @test_skip "Rust helpers library not available. Skipping end-to-end tests."
         end
     end
 

--- a/test/test_static_methods.jl
+++ b/test/test_static_methods.jl
@@ -67,7 +67,7 @@ end
 
     @testset "inline rust\"\"\" path agrees" begin
         if !RustCall.check_rustc_available()
-            @warn "rustc not available, skipping the inline #323 test"
+            @test_skip "rustc not available, skipping the inline #323 test"
         else
             # A free `twice` and a static `Yeller::twice` in one block, plus a
             # static `thrice` that collides with nothing — whose argument is
@@ -109,7 +109,7 @@ end
     end
 
     if !_SM_HAVE_CARGO || !RustCall.check_rustc_available()
-        @warn "cargo/rustc not available, skipping the behavioural #323 tests"
+        @test_skip "cargo/rustc not available, skipping the behavioural #323 tests"
     else
         @testset "both `shout`s are callable, in memory" begin
             bindings = @rust_crate SM_SAMPLE_CRATE name="StaticMethodBindings"

--- a/test/test_struct_examples.jl
+++ b/test/test_struct_examples.jl
@@ -4,7 +4,7 @@ using Test
 
 @testset "Struct Examples" begin
     if !RustCall.check_rustc_available()
-        @warn "rustc not found, skipping struct examples tests"
+        @test_skip "rustc not found, skipping struct examples tests"
         return
     end
 

--- a/test/test_types_memory_safety.jl
+++ b/test/test_types_memory_safety.jl
@@ -210,7 +210,7 @@ using Test
             @test isfile(lib_path)
             rm(dirname(lib_path), recursive=true, force=true)
         else
-            @warn "rustc not found, skipping IOBuffer leak test"
+            @test_skip "rustc not found, skipping IOBuffer leak test"
         end
     end
 


### PR DESCRIPTION
## What

The last two reliability problems #259 names. Test-only changes; no `src/` edits.

### Skips were invisible

Sixty-five testsets announced a missing toolchain or fixture with `@warn "... skipping ..."` and returned, leaving no trace in the summary. A run that skipped its whole FFI core looked exactly like a run that passed it. They use `@test_skip` with the same message now, which the summary counts in its Broken column.

The conversion is mechanical: only `@warn` lines whose message contains "skip" are touched, so informational warnings ("Build with: using Pkg…") are left alone. Every one of the 25 changed files was parse-checked.

### Fixed sleeps stood in for synchronisation

In `test/test_hot_reload.jl`:

- five `sleep(0.1)` calls waited for a watcher task to stop after `disable_hot_reload` / `disable_all_hot_reload`. Both already wait — they go through `stop_watch_task`, which calls `wait(task)`. The sleeps were superstition and are gone.
- the lock-serialisation test used one sleep to let a task reach a `lock` and another to let it finish. It now hands off through a channel the task writes before it blocks, asserts the absence with `timedwait(...) === :timed_out`, and waits for the far side with `wait(t)`.

A timeout asserting that something does **not** happen is sound; a fixed sleep asserting that something **has** happened is the race.

### What is deliberately left

- `test_parsing_generics_hotreload_fixes.jl` keeps one `sleep(0.05)`: it is the poll interval of a stand-in watcher task, not test synchronisation, and the test waits for that task through `stop_watch_task`. Commented as such.
- `test_hot_reload_transaction.jl` keeps its sleeps: the debounce window and the Rust-side `thread::sleep` are what that file is testing, and two of them wait for a `FileWatching` subscription the API cannot signal. Making those look deterministic without a signal would be worse than leaving them.

## Acceptance criteria (#259)

| Criterion | State |
| --- | --- |
| CI fails if rustc/cargo cannot be provisioned | met in #379 |
| Default `Pkg.test()` performs no crates.io access beyond RustToolChain | **not met** — `test_cargo.jl` builds `itoa`, the PyO3 fixtures need pyo3 |
| Hot-reload tests contain no fixed `sleep` used for synchronisation | **met here** |
| Skipped testsets appear as skipped | **met here** |
| Examples covered in CI | already true — the `Examples` workflow |

`Advances #259`. Pinning `Cargo.lock` for the fixtures, which the issue also suggests, is the lever left for the remaining criterion.

## Verification

- `Pkg.test()`: 10322 pass / 12 skipped + 715 pass, exit 0 (macOS aarch64, Julia 1.12.7)
- `test_hot_reload` + `test_parsing_generics_hotreload_fixes` alone: 240 pass
- all 25 modified test files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
