### PR TITLE
Refuse a clash on a generated internal name (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A clash on a generated internal name is refused, and named for what it is**
+  ([#338](https://github.com/AtelierArith/RustCall.jl/issues/338)). A wrapper
+  defines more than its exports: the thread-local slot of its panic channel is
+  the wrapper's symbol upper-cased, so `#[julia] fn foo` next to `#[julia] fn
+  FOO` export two different symbols and still define
+  `__RUSTCALL_PANIC_RUSTCALL_FOO` twice. The duplicate check now counts those
+  names, and its two diagnostics tell the kinds apart: an exported symbol
+  keeps the message it had, while an internal item says so and explains where
+  the name comes from, instead of being called an export. The same covers the
+  string buffer types two items with one buffer owner would declare twice.
+
 ### Changed
 - **One list of what a manifest entry claims**
   ([#338](https://github.com/AtelierArith/RustCall.jl/issues/338)). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names, and its two diagnostics tell the kinds apart: an exported symbol
   keeps the message it had, while an internal item says so and explains where
   the name comes from, instead of being called an export. The same covers the
-  string buffer types two items with one buffer owner would declare twice.
+  string buffer types two items with one buffer owner would declare twice. A
+  private name is compared only within the module its wrapper is emitted into
+  and within its own Rust namespace, so two modules may spell one slot name
+  and a generated buffer type may share a spelling with an exported function.
 
 ### Changed
 - **One list of what a manifest entry claims**

--- a/deps/rustcall_core/src/claims.rs
+++ b/deps/rustcall_core/src/claims.rs
@@ -110,6 +110,23 @@ impl Claim {
         }
         self
     }
+
+    /// Replace the module a private claim was scoped to with the real Rust
+    /// module the wrapper is emitted into.
+    ///
+    /// The builders can only use the manifest's `module_path`, which is the
+    /// *symbol-qualification* path: in a crate, a file module (`mod x;`) is
+    /// transparent to the naming scheme and contributes nothing to it, while
+    /// the items of `x.rs` really do live in module `x`. The crate scan knows
+    /// the real path and stamps it here (#338 review). `Global` and `Unknown`
+    /// are left alone: an export is crate-wide however it is nested, and
+    /// `Unknown` is the deliberate "this scan cannot say" answer.
+    pub fn in_real_module(mut self, module: &[String]) -> Claim {
+        if matches!(self.scope, Scope::Module(_)) {
+            self.scope = Scope::Module(module.to_vec());
+        }
+        self
+    }
 }
 
 /// Put every private claim of a list in `scope`; exported ones stay global.

--- a/deps/rustcall_core/src/claims.rs
+++ b/deps/rustcall_core/src/claims.rs
@@ -25,6 +25,46 @@
 use crate::codegen::{panic_symbol, struct_free_symbol};
 use crate::manifest::{Function, Struct};
 
+/// Which of Rust's two name spaces a generated item occupies. `struct Foo`
+/// and `fn Foo` may coexist in one module, so two claims of one spelling are
+/// a clash only when they are in the same one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Namespace {
+    /// A function or a `thread_local!` static.
+    Value,
+    /// A generated `#[repr(C)]` buffer type.
+    Type,
+}
+
+/// Where a generated name has to be unique.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Scope {
+    /// The whole `cdylib`: a `#[no_mangle]` symbol, which the linker sees
+    /// once however many modules it is written across.
+    Global,
+    /// One Rust module of the crate, by path. A private item is emitted next
+    /// to its wrapper, so `mod a { fn foo }` and `mod A { fn FOO }` may spell
+    /// one slot name and still compile.
+    Module(Vec<String>),
+    /// Emitted in a module this scan cannot name — a method wrapped at a
+    /// `#[julia] impl` block in another module than its struct, whose path
+    /// the manifest does not record (#342). Never compared: rustc still
+    /// reports such a clash, and a false duplicate would refuse a crate that
+    /// builds.
+    Unknown,
+}
+
+impl Scope {
+    /// Whether two claims in these scopes can meet. `Unknown` meets nothing.
+    pub fn meets(&self, other: &Scope) -> bool {
+        match (self, other) {
+            (Scope::Global, Scope::Global) => true,
+            (Scope::Module(a), Scope::Module(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
 /// One name the generated code defines.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Claim {
@@ -33,22 +73,51 @@ pub struct Claim {
     /// module-private one: a panic slot or a helper type (a compile-time
     /// clash in the module the wrapper is emitted into).
     pub exported: bool,
+    pub namespace: Namespace,
+    pub scope: Scope,
 }
 
 impl Claim {
+    /// Whether these two claims are the same name in the same place — the
+    /// question both duplicate checks ask.
+    pub fn clashes_with(&self, other: &Claim) -> bool {
+        self.name == other.name
+            && self.namespace == other.namespace
+            && self.scope.meets(&other.scope)
+    }
+
     fn exported(name: String) -> Claim {
         Claim {
             name,
             exported: true,
+            namespace: Namespace::Value,
+            scope: Scope::Global,
         }
     }
 
-    fn private(name: String) -> Claim {
+    fn private(name: String, namespace: Namespace) -> Claim {
         Claim {
             name,
             exported: false,
+            namespace,
+            scope: Scope::Unknown,
         }
     }
+
+    fn in_scope(mut self, scope: &Scope) -> Claim {
+        if !self.exported {
+            self.scope = scope.clone();
+        }
+        self
+    }
+}
+
+/// Put every private claim of a list in `scope`; exported ones stay global.
+fn scoped(claims: Vec<Claim>, scope: &Scope) -> Vec<Claim> {
+    claims
+        .into_iter()
+        .map(|claim| claim.in_scope(scope))
+        .collect()
 }
 
 /// Which string helpers an entry is credited with.
@@ -161,7 +230,7 @@ fn exported_first(mut claims: Vec<Claim>) -> Vec<Claim> {
 /// the slot that reader drains.
 pub fn wrapper_claims(symbol: &str) -> Vec<Claim> {
     let mut out = helper_claims(symbol);
-    out.push(Claim::private(panic_slot(symbol)));
+    out.push(Claim::private(panic_slot(symbol), Namespace::Value));
     out
 }
 
@@ -185,11 +254,11 @@ pub fn string_claims(owner: &str, owned: bool, borrowed: bool, policy: Policy) -
     let mut out = Vec::new();
     if owned {
         let [ty, free] = owned_string_names(owner);
-        out.push(Claim::private(ty));
+        out.push(Claim::private(ty, Namespace::Type));
         out.push(Claim::exported(free));
     }
     if borrowed {
-        out.push(Claim::private(borrowed_string_name(owner)));
+        out.push(Claim::private(borrowed_string_name(owner), Namespace::Type));
     }
     out
 }
@@ -230,7 +299,8 @@ pub fn function_claims(f: &Function, policy: Policy) -> Vec<Claim> {
             policy,
         ));
     }
-    exported_first(out)
+    // The wrapper and its private items are emitted next to the function.
+    exported_first(scoped(out, &Scope::Module(f.module_path.clone())))
 }
 
 /// The same for a PyO3-scanned function, whose ABI columns are not filled in
@@ -260,6 +330,10 @@ pub fn struct_claims(s: &Struct, policy: Policy) -> Vec<Claim> {
     if (policy.skip_cfg_gated && !s.cfg.is_empty()) || s.ffi_name.is_empty() {
         return Vec::new();
     }
+    // Everything a struct's own wrappers define is emitted next to the
+    // struct; a method wrapped at a `#[julia] impl` block in another module
+    // is the exception, handled below.
+    let here = Scope::Module(s.module_path.clone());
     let mut out = Vec::new();
     // A generic struct exports nothing itself.
     if s.type_params.is_empty() {
@@ -275,7 +349,9 @@ pub fn struct_claims(s: &Struct, policy: Policy) -> Vec<Claim> {
             }
         }
         if field.abi == "vec" && !field.getter.is_empty() {
-            out.push(Claim::private(owned_vec_names(&field.getter)));
+            out.push(
+                Claim::private(owned_vec_names(&field.getter), Namespace::Type).in_scope(&here),
+            );
             if !field.free_symbol.is_empty() {
                 out.push(Claim::exported(field.free_symbol.clone()));
             }
@@ -309,7 +385,15 @@ pub fn struct_claims(s: &Struct, policy: Policy) -> Vec<Claim> {
             continue;
         }
         if !m.symbol.is_empty() {
-            out.extend(wrapper_claims(&m.symbol));
+            // A method wrapped next to its struct shares the struct's module
+            // (`string_owner == ffi_name`, #342); one wrapped at a block
+            // elsewhere is emitted in a module the manifest does not record.
+            let where_ = if m.string_owner == s.ffi_name || m.string_owner.is_empty() {
+                here.clone()
+            } else {
+                Scope::Unknown
+            };
+            out.extend(scoped(wrapper_claims(&m.symbol), &where_));
         }
         let abis = [
             m.return_abi.as_str(),
@@ -333,7 +417,15 @@ pub fn struct_claims(s: &Struct, policy: Policy) -> Vec<Claim> {
         );
     }
     for (owner, owned, borrowed) in buffers {
-        out.extend(string_claims(&owner, owned, borrowed, policy));
+        let where_ = if owner == s.ffi_name {
+            here.clone()
+        } else {
+            Scope::Unknown
+        };
+        out.extend(scoped(
+            string_claims(&owner, owned, borrowed, policy),
+            &where_,
+        ));
     }
     exported_first(out)
 }

--- a/deps/rustcall_core/src/claims.rs
+++ b/deps/rustcall_core/src/claims.rs
@@ -70,9 +70,6 @@ pub enum StringHelpers {
 /// How a particular scan reads the generated code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Policy {
-    /// Include module-private names — the `__RUSTCALL_PANIC_<SYMBOL>` slot and
-    /// the string / vector helper types. They are real clashes, not exports.
-    pub include_private: bool,
     pub strings: StringHelpers,
     /// Drop an entry whose `#[cfg]` the scan could not decide.
     ///
@@ -89,21 +86,21 @@ pub struct Policy {
 impl Policy {
     /// The `#[julia]` crate-wide duplicate check.
     ///
-    /// Exported names only, for now. Both diagnostics built on it say
-    /// "duplicate exported symbol" and name the item that claims it; a clash
-    /// on a private name — two wrappers whose symbols differ only in case
-    /// share one `__RUSTCALL_PANIC_<SYMBOL>` slot — is a real defect but needs
-    /// a message that does not call an internal item an export. Adding that
-    /// vocabulary is the remainder of #338.
+    /// Both scans count module-private names, so this differs from
+    /// [`Policy::PYO3_SCAN`] only in the two fields above. Two wrappers whose
+    /// symbols differ only in case share one `__RUSTCALL_PANIC_<SYMBOL>` slot,
+    /// and two items with one string-buffer owner declare one
+    /// `<owner>_RustCallOwnedString` twice; neither is an export, and both are
+    /// a duplicate definition rustc would report inside generated code, so the
+    /// diagnostics distinguish the two kinds rather than calling an internal
+    /// item an export (#338).
     pub const JULIA: Policy = Policy {
-        include_private: false,
         strings: StringHelpers::AsDeclared,
         skip_cfg_gated: true,
     };
 
     /// The PyO3 scan's collision analysis.
     pub const PYO3_SCAN: Policy = Policy {
-        include_private: true,
         strings: StringHelpers::Reserved,
         skip_cfg_gated: false,
     };
@@ -149,13 +146,22 @@ pub fn owned_vec_names(getter: &str) -> String {
     format!("{getter}_RustCallOwnedVec")
 }
 
+/// Stable partition: exported names first.
+///
+/// A clash is usually visible on both an export and the private item derived
+/// from it — a duplicated wrapper symbol duplicates its panic slot too — and
+/// the diagnostics report the first one they meet. The exported name is the
+/// one the user can look up in the naming scheme, so it goes first.
+fn exported_first(mut claims: Vec<Claim>) -> Vec<Claim> {
+    claims.sort_by_key(|claim| !claim.exported);
+    claims
+}
+
 /// The entry point exported as `symbol`, the reader of its panic channel and
 /// the slot that reader drains.
-pub fn wrapper_claims(symbol: &str, include_private: bool) -> Vec<Claim> {
+pub fn wrapper_claims(symbol: &str) -> Vec<Claim> {
     let mut out = helper_claims(symbol);
-    if include_private {
-        out.push(Claim::private(panic_slot(symbol)));
-    }
+    out.push(Claim::private(panic_slot(symbol)));
     out
 }
 
@@ -179,12 +185,10 @@ pub fn string_claims(owner: &str, owned: bool, borrowed: bool, policy: Policy) -
     let mut out = Vec::new();
     if owned {
         let [ty, free] = owned_string_names(owner);
-        if policy.include_private {
-            out.push(Claim::private(ty));
-        }
+        out.push(Claim::private(ty));
         out.push(Claim::exported(free));
     }
-    if borrowed && policy.include_private {
+    if borrowed {
         out.push(Claim::private(borrowed_string_name(owner)));
     }
     out
@@ -217,7 +221,7 @@ pub fn function_claims(f: &Function, policy: Policy) -> Vec<Claim> {
     if !f.attribute.generates_wrapper() {
         return vec![Claim::exported(f.symbol.clone())];
     }
-    let mut out = wrapper_claims(&f.symbol, policy.include_private);
+    let mut out = wrapper_claims(&f.symbol);
     if !f.ffi_name.is_empty() {
         out.extend(string_claims(
             &f.ffi_name,
@@ -226,7 +230,7 @@ pub fn function_claims(f: &Function, policy: Policy) -> Vec<Claim> {
             policy,
         ));
     }
-    out
+    exported_first(out)
 }
 
 /// The same for a PyO3-scanned function, whose ABI columns are not filled in
@@ -237,7 +241,7 @@ pub fn scanned_function_claims(f: &Function, owned: bool, borrowed: bool) -> Vec
         return Vec::new();
     }
     let policy = Policy::PYO3_SCAN;
-    let mut out = wrapper_claims(&f.symbol, policy.include_private);
+    let mut out = wrapper_claims(&f.symbol);
     if !f.ffi_name.is_empty() {
         out.extend(string_claims(&f.ffi_name, owned, borrowed, policy));
     }
@@ -271,9 +275,7 @@ pub fn struct_claims(s: &Struct, policy: Policy) -> Vec<Claim> {
             }
         }
         if field.abi == "vec" && !field.getter.is_empty() {
-            if policy.include_private {
-                out.push(Claim::private(owned_vec_names(&field.getter)));
-            }
+            out.push(Claim::private(owned_vec_names(&field.getter)));
             if !field.free_symbol.is_empty() {
                 out.push(Claim::exported(field.free_symbol.clone()));
             }
@@ -307,7 +309,7 @@ pub fn struct_claims(s: &Struct, policy: Policy) -> Vec<Claim> {
             continue;
         }
         if !m.symbol.is_empty() {
-            out.extend(wrapper_claims(&m.symbol, policy.include_private));
+            out.extend(wrapper_claims(&m.symbol));
         }
         let abis = [
             m.return_abi.as_str(),
@@ -333,5 +335,44 @@ pub fn struct_claims(s: &Struct, policy: Policy) -> Vec<Claim> {
     for (owner, owned, borrowed) in buffers {
         out.extend(string_claims(&owner, owned, borrowed, policy));
     }
-    out
+    exported_first(out)
+}
+
+/// What kind of clash a duplicate [`Claim`] is, as a sentence a user-facing
+/// diagnostic can build on.
+///
+/// The two are different failures: two `#[no_mangle]` items of one name cannot
+/// be exported by one `cdylib`, while two internal items of one name cannot
+/// even be defined in one module. Saying "exported symbol" for the second
+/// would be wrong, and the internal names are not ones the user wrote, so the
+/// message has to say where they come from (#338).
+pub fn clash_kind(claim: &Claim) -> &'static str {
+    if claim.exported {
+        "exported symbol"
+    } else {
+        "generated item"
+    }
+}
+
+/// Why an internal name exists, for a diagnostic that has to explain a name
+/// the user never wrote. Empty for an exported symbol, whose name the user can
+/// read off the scheme.
+pub fn internal_origin(claim: &Claim) -> &'static str {
+    if claim.exported {
+        return "";
+    }
+    if claim.name.starts_with("__RUSTCALL_PANIC_") {
+        "the thread-local slot of a wrapper's panic channel, named by \
+         upper-casing the wrapper's symbol — so two wrappers whose symbols \
+         differ only in case meet here"
+    } else if claim.name.ends_with("_RustCallOwnedString")
+        || claim.name.ends_with("_RustCallBorrowedString")
+    {
+        "the string buffer type a wrapper returns, named after the item that \
+         owns the buffer"
+    } else if claim.name.ends_with("_RustCallOwnedVec") {
+        "the owned-vector buffer type a field getter returns"
+    } else {
+        "an item RustCall generates next to the wrapper"
+    }
 }

--- a/deps/rustcall_core/src/expand.rs
+++ b/deps/rustcall_core/src/expand.rs
@@ -77,15 +77,26 @@ pub fn expand_with_cfg(source: &str, cfg: Option<&CfgSet>) -> Result<Expanded, s
     // struct `Foo_bar` next to a `Foo::bar` that hands back an owned string,
     // both wanting `Foo_bar_free_rust_string`. rustc would report it inside
     // generated code; say which two items collide instead.
-    for (symbol, first, second) in manifest.duplicate_symbols() {
-        let msg = format!(
-            "RustCall would export the symbol `{symbol}` twice in this block: for {first} and \
-             for {second}. The scheme derives every symbol from the item's name and module \
-             path (`rustcall_<fn>`, `rustcall_<Struct>_<method>`, `<Struct>_free`, \
-             `<Struct>_get_<field>`, `<owner>_free_rust_string`, ... — #300), so two items \
-             whose names differ only where the scheme joins them meet here. Rename one of \
-             them."
-        );
+    for (claim, first, second) in manifest.duplicate_claims() {
+        let symbol = &claim.name;
+        let msg = if claim.exported {
+            format!(
+                "RustCall would export the symbol `{symbol}` twice in this block: for {first} \
+                 and for {second}. The scheme derives every symbol from the item's name and \
+                 module path (`rustcall_<fn>`, `rustcall_<Struct>_<method>`, `<Struct>_free`, \
+                 `<Struct>_get_<field>`, `<owner>_free_rust_string`, ... — #300), so two items \
+                 whose names differ only where the scheme joins them meet here. Rename one of \
+                 them."
+            )
+        } else {
+            format!(
+                "RustCall would define the item `{symbol}` twice in this block: for {first} \
+                 and for {second}. It is not exported and not one you wrote — it is {}. Two of \
+                 them in one module are a duplicate definition rustc would report inside \
+                 generated code. Rename one of the items (#338).",
+                crate::claims::internal_origin(&claim)
+            )
+        };
         out.insert(0, syn::parse_quote! { compile_error!(#msg); });
     }
 

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -780,7 +780,7 @@ impl CrateScan {
                     if attribute == Attribute::Julia {
                         let entry = function_entry(f, attribute, true, symbol_path, enclosing_cfg);
                         for (claim, owner) in entry.claims() {
-                            self.claim(claim, owner, file)?;
+                            self.claim(claim, owner, file, module_path)?;
                         }
                         manifest.functions.push(entry);
                     }
@@ -959,7 +959,12 @@ impl CrateScan {
         claim: crate::claims::Claim,
         owner: String,
         file: &str,
+        module: &[String],
     ) -> Result<(), ExtractError> {
+        // The manifest's module path qualifies symbols; it is empty for every
+        // file of the module tree, which is not where the wrapper's private
+        // items land (#338 review).
+        let claim = claim.in_real_module(module);
         let here = if file.is_empty() {
             owner
         } else {
@@ -1062,7 +1067,7 @@ impl CrateScan {
         for scanned in std::mem::take(&mut self.structs) {
             let entry = crate_struct_entry(&scanned.model, &scanned.symbol_path, &scanned.cfg);
             for (claim, owner) in entry.claims() {
-                self.claim(claim, owner, &scanned.file)?;
+                self.claim(claim, owner, &scanned.file, &scanned.module_path)?;
             }
             manifest.structs.push(entry);
         }

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -627,9 +627,12 @@ pub struct CrateScan {
     plain_structs: Vec<PlainStruct>,
     impls: Vec<ScannedImpl>,
     imports: Vec<ScannedImport>,
-    /// Every exported symbol seen so far and the item that claims it, so a
-    /// second claimant is reported with both locations (#300).
-    claimed: Vec<(String, String)>,
+    /// Every name the generated code defines so far and the item that claims
+    /// it, so a second claimant is reported with both locations (#300). A
+    /// claim carries its Rust namespace and the scope it has to be unique in,
+    /// because an exported symbol is crate-global while a private item only
+    /// has to be unique in its own module (#338).
+    claimed: Vec<(crate::claims::Claim, String)>,
 }
 
 #[derive(Debug)]
@@ -962,8 +965,9 @@ impl CrateScan {
         } else {
             format!("{owner} in {file}")
         };
-        let symbol = &claim.name;
-        if let Some((_, first)) = self.claimed.iter().find(|(s, _)| s == symbol) {
+        let symbol = claim.name.clone();
+        let symbol = &symbol;
+        if let Some((_, first)) = self.claimed.iter().find(|(c, _)| c.clashes_with(&claim)) {
             let kind = crate::claims::clash_kind(&claim);
             let detail = if claim.exported {
                 "Two #[julia] items of one crate export the same symbol; only inline modules \
@@ -984,7 +988,7 @@ impl CrateScan {
                 "duplicate {kind} `{symbol}`: claimed by {first} and by {here}. {detail}"
             )));
         }
-        self.claimed.push((claim.name, here));
+        self.claimed.push((claim, here));
         Ok(())
     }
 

--- a/deps/rustcall_core/src/extract.rs
+++ b/deps/rustcall_core/src/extract.rs
@@ -776,8 +776,8 @@ impl CrateScan {
                     }
                     if attribute == Attribute::Julia {
                         let entry = function_entry(f, attribute, true, symbol_path, enclosing_cfg);
-                        for (symbol, owner) in entry.claimed_symbols() {
-                            self.claim(symbol, owner, file)?;
+                        for (claim, owner) in entry.claims() {
+                            self.claim(claim, owner, file)?;
                         }
                         manifest.functions.push(entry);
                     }
@@ -951,22 +951,40 @@ impl CrateScan {
     /// — defining the same `#[julia]` item, or a crate-root name that spells a
     /// qualified one. The `cdylib` could not export both, and a wrong binding
     /// is worse than no binding, so the scan fails closed and names the fix.
-    fn claim(&mut self, symbol: String, owner: String, file: &str) -> Result<(), ExtractError> {
+    fn claim(
+        &mut self,
+        claim: crate::claims::Claim,
+        owner: String,
+        file: &str,
+    ) -> Result<(), ExtractError> {
         let here = if file.is_empty() {
             owner
         } else {
             format!("{owner} in {file}")
         };
-        if let Some((_, first)) = self.claimed.iter().find(|(s, _)| *s == symbol) {
-            return Err(ExtractError::Unsupported(format!(
-                "duplicate exported symbol `{symbol}`: claimed by {first} and by {here}. \
-                 Two #[julia] items of one crate export the same symbol; only inline modules \
-                 marked `#[julia]` (`#[julia] pub mod name {{ ... }}`) qualify a symbol by \
+        let symbol = &claim.name;
+        if let Some((_, first)) = self.claimed.iter().find(|(s, _)| s == symbol) {
+            let kind = crate::claims::clash_kind(&claim);
+            let detail = if claim.exported {
+                "Two #[julia] items of one crate export the same symbol; only inline modules \
+                 marked `#[julia]` (`#[julia] pub mod name { ... }`) qualify a symbol by \
                  their name, while file modules (`mod name;`) do not. Wrap one of the items in \
                  a `#[julia]` module block or rename it (#300)."
+                    .to_string()
+            } else {
+                format!(
+                    "This name is not exported and not one you wrote: it is {}. Two of them in \
+                     one crate are a duplicate definition rather than a duplicate export, and \
+                     rustc would report it inside generated code. Rename one of the items \
+                     (#338).",
+                    crate::claims::internal_origin(&claim)
+                )
+            };
+            return Err(ExtractError::Unsupported(format!(
+                "duplicate {kind} `{symbol}`: claimed by {first} and by {here}. {detail}"
             )));
         }
-        self.claimed.push((symbol, here));
+        self.claimed.push((claim.name, here));
         Ok(())
     }
 
@@ -1039,8 +1057,8 @@ impl CrateScan {
 
         for scanned in std::mem::take(&mut self.structs) {
             let entry = crate_struct_entry(&scanned.model, &scanned.symbol_path, &scanned.cfg);
-            for (symbol, owner) in entry.claimed_symbols() {
-                self.claim(symbol, owner, &scanned.file)?;
+            for (claim, owner) in entry.claims() {
+                self.claim(claim, owner, &scanned.file)?;
             }
             manifest.structs.push(entry);
         }

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -921,7 +921,10 @@ impl Manifest {
         let mut seen: Vec<(crate::claims::Claim, String)> = Vec::new();
         let mut out = Vec::new();
         for (claim, who) in self.claim_owners() {
-            match seen.iter().find(|(c, _)| c.name == claim.name) {
+            // Same name is not enough: an exported symbol is crate-global,
+            // while a private item has to be unique only in its own module
+            // and its own Rust namespace (#338 review).
+            match seen.iter().find(|(c, _)| c.clashes_with(&claim)) {
                 Some((_, first)) => out.push((claim, first.clone(), who)),
                 None => seen.push((claim, who)),
             }

--- a/deps/rustcall_core/src/manifest.rs
+++ b/deps/rustcall_core/src/manifest.rs
@@ -739,11 +739,12 @@ fn symbol_owner(path: &[String], name: &str, line: usize) -> String {
 }
 
 impl Function {
-    /// The exported symbols this `#[julia]` function claims — its wrapper, the
-    /// reader of that wrapper's panic channel and, when it returns an owned
-    /// string, the release function of its buffer — with the owner label of
-    /// [`Manifest::symbol_owners`]; empty when it claims none (a PyO3 item, an
-    /// unexported or generic one, an undecided `#[cfg]`).
+    /// Every name this `#[julia]` function's generated code defines — its
+    /// wrapper, the reader of that wrapper's panic channel, the slot the
+    /// reader drains and, when it returns a string, the buffer type and its
+    /// release function — with the owner label of [`Manifest::symbol_owners`].
+    /// Empty when it defines none (a PyO3 item, an unexported or generic one,
+    /// an undecided `#[cfg]`).
     ///
     /// The panic reader is as much an export as the wrapper itself
     /// (`crate::codegen::panic_channel` emits it `#[no_mangle]` next to it),
@@ -754,16 +755,30 @@ impl Function {
     /// exported under its own name, and adds nothing — a hand-written
     /// `release` / `release_take_panic` pair is two unrelated exports, not a
     /// collision.
-    pub fn claimed_symbols(&self) -> Vec<(String, String)> {
+    pub fn claims(&self) -> Vec<(crate::claims::Claim, String)> {
         if self.attribute.is_pyo3_scan() {
             return Vec::new();
         }
         let who = symbol_owner(&self.module_path, &self.name, self.line);
         crate::claims::function_claims(self, crate::claims::Policy::JULIA)
             .into_iter()
-            .map(|claim| (claim.name, who.clone()))
+            .map(|claim| (claim, who.clone()))
             .collect()
     }
+
+    /// [`Function::claims`] narrowed to the exported ones.
+    pub fn claimed_symbols(&self) -> Vec<(String, String)> {
+        exported_only(self.claims())
+    }
+}
+
+/// Project a claim list onto the `#[no_mangle]` names alone.
+fn exported_only(claims: Vec<(crate::claims::Claim, String)>) -> Vec<(String, String)> {
+    claims
+        .into_iter()
+        .filter(|(claim, _)| claim.exported)
+        .map(|(claim, who)| (claim.name, who))
+        .collect()
 }
 
 impl Method {
@@ -790,15 +805,20 @@ impl Struct {
     /// it: an inline method wrapped next to its struct shares the struct's
     /// (`string_owner == ffi_name`), one wrapped at a `#[julia] impl` block in
     /// another module declares its own (#342).
-    pub fn claimed_symbols(&self) -> Vec<(String, String)> {
+    pub fn claims(&self) -> Vec<(crate::claims::Claim, String)> {
         if self.attribute.is_pyo3_scan() {
             return Vec::new();
         }
         let who = symbol_owner(&self.module_path, &self.name, self.line);
         crate::claims::struct_claims(self, crate::claims::Policy::JULIA)
             .into_iter()
-            .map(|claim| (claim.name, who.clone()))
+            .map(|claim| (claim, who.clone()))
             .collect()
+    }
+
+    /// [`Struct::claims`] narrowed to the exported ones.
+    pub fn claimed_symbols(&self) -> Vec<(String, String)> {
+        exported_only(self.claims())
     }
 }
 
@@ -857,12 +877,21 @@ impl Manifest {
     /// not a clash. PyO3-scanned items are not listed either: the scan marks
     /// their clashes with a `skip_reason` (`crate::pyo3`).
     pub fn symbol_owners(&self) -> Vec<(String, String)> {
+        exported_only(self.claim_owners())
+    }
+
+    /// The same, widened to every name the generated code defines: the
+    /// exported ones plus the module-private panic slots and helper types.
+    /// Two generated items wanting one private name is a duplicate definition
+    /// rustc reports inside generated code, which is exactly what this
+    /// machinery exists to pre-empt (#338).
+    pub fn claim_owners(&self) -> Vec<(crate::claims::Claim, String)> {
         let mut out = Vec::new();
         for f in &self.functions {
-            out.extend(f.claimed_symbols());
+            out.extend(f.claims());
         }
         for s in &self.structs {
-            out.extend(s.claimed_symbols());
+            out.extend(s.claims());
         }
         out
     }
@@ -877,12 +906,24 @@ impl Manifest {
     /// both items rather than with rustc's duplicate-symbol diagnostic
     /// pointing into generated code (#342 review).
     pub fn duplicate_symbols(&self) -> Vec<(String, String, String)> {
-        let mut seen: Vec<(String, String)> = Vec::new();
+        self.duplicate_claims()
+            .into_iter()
+            .filter(|(claim, _, _)| claim.exported)
+            .map(|(claim, first, second)| (claim.name, first, second))
+            .collect()
+    }
+
+    /// The same over every generated name, exported or not, so a caller can
+    /// tell a reader which kind of clash it is looking at: a `#[no_mangle]`
+    /// symbol the `cdylib` cannot export twice, or an internal item — a panic
+    /// slot, a string buffer type — the crate cannot define twice (#338).
+    pub fn duplicate_claims(&self) -> Vec<(crate::claims::Claim, String, String)> {
+        let mut seen: Vec<(crate::claims::Claim, String)> = Vec::new();
         let mut out = Vec::new();
-        for (symbol, who) in self.symbol_owners() {
-            match seen.iter().find(|(s, _)| *s == symbol) {
-                Some((_, first)) => out.push((symbol, first.clone(), who)),
-                None => seen.push((symbol, who)),
+        for (claim, who) in self.claim_owners() {
+            match seen.iter().find(|(c, _)| c.name == claim.name) {
+                Some((_, first)) => out.push((claim, first.clone(), who)),
+                None => seen.push((claim, who)),
             }
         }
         out

--- a/deps/rustcall_core/src/pyo3.rs
+++ b/deps/rustcall_core/src/pyo3.rs
@@ -1063,7 +1063,7 @@ fn is_string_spelling(spelling: &str) -> bool {
 /// and all are checked (#307 review). Field accessors have no reader and
 /// derive nothing.
 fn wrapper_symbols(symbol: &str) -> [String; 3] {
-    let claims = crate::claims::wrapper_claims(symbol, true);
+    let claims = crate::claims::wrapper_claims(symbol);
     let mut names = claims.into_iter().map(|c| c.name);
     [
         names.next().expect("entry point"),

--- a/deps/rustcall_core/tests/symbols.rs
+++ b/deps/rustcall_core/tests/symbols.rs
@@ -934,3 +934,55 @@ fn claims_are_compared_within_their_rust_namespace() {
     );
     assert!(both.is_ok(), "{:?}", both.err());
 }
+
+/// A file module is transparent to the symbol scheme, so `x.rs` and `y.rs`
+/// both carry an empty `module_path` in the manifest — but their items really
+/// do live in modules `x` and `y`. `#[julia] fn foo` in one and `#[julia] fn
+/// FOO` in the other export different symbols and spell one panic-slot name,
+/// in two different Rust modules, and must not be refused. The crate scan
+/// stamps the real module path onto every private claim (#338 review).
+#[test]
+fn a_private_claim_is_scoped_by_the_real_module_not_the_symbol_path() {
+    use rustcall_core::extract::{FilePosition, TreeScan};
+    use rustcall_core::Manifest;
+
+    let mut scan = TreeScan::new();
+    let mut manifest = Manifest::new(Mode::Crate);
+    let pending = scan
+        .file(
+            "pub mod x;\npub mod y;",
+            None,
+            &FilePosition::module(&[], true, &[]),
+            &mut manifest,
+            "src/lib.rs",
+        )
+        .unwrap()
+        .modules;
+    assert_eq!(pending.len(), 2);
+    for (module, body) in pending.iter().zip([
+        "#[julia] pub fn foo() -> i32 { 1 }",
+        "#[julia] pub fn FOO() -> i32 { 2 }",
+    ]) {
+        scan.file(
+            body,
+            None,
+            &FilePosition::module(&module.module_path, module.reachable, &module.cfg),
+            &mut manifest,
+            &format!("src/{}.rs", module.module_path.join("/")),
+        )
+        .expect("two file modules may spell one slot name");
+    }
+    scan.finish(&mut manifest)
+        .expect("two file modules may spell one slot name");
+
+    // The manifest keeps both, under the symbol path the scheme uses (empty
+    // for a file module) and with different exported symbols.
+    let symbols: Vec<&str> = manifest
+        .functions
+        .iter()
+        .map(|f| f.symbol.as_str())
+        .collect();
+    assert!(symbols.contains(&"rustcall_foo"), "{symbols:?}");
+    assert!(symbols.contains(&"rustcall_FOO"), "{symbols:?}");
+    assert!(manifest.functions.iter().all(|f| f.module_path.is_empty()));
+}

--- a/deps/rustcall_core/tests/symbols.rs
+++ b/deps/rustcall_core/tests/symbols.rs
@@ -855,3 +855,82 @@ fn an_exported_clash_is_still_reported_as_an_export() {
     );
     assert!(!err.contains("duplicate generated item"), "{err}");
 }
+
+/// A private name only has to be unique in the module the wrapper is emitted
+/// into. `mod a { fn foo }` and `mod A { fn FOO }` export two different
+/// symbols and spell one slot name, but the two slots are in different Rust
+/// modules and both compile — so this is not a duplicate (#338 review).
+#[test]
+fn private_names_are_compared_within_their_module() {
+    let src = r#"
+        #[julia] pub mod a { #[julia] pub fn foo() -> i32 { 1 } }
+        #[julia] pub mod A { #[julia] pub fn FOO() -> i32 { 2 } }
+    "#;
+    let inline = rustcall_core::expand::expand(src).unwrap();
+    assert!(
+        inline.manifest.duplicate_claims().is_empty(),
+        "{:?}",
+        inline.manifest.duplicate_claims()
+    );
+    assert!(
+        !inline.source.contains("compile_error"),
+        "{}",
+        inline.source
+    );
+    // The crate scan agrees.
+    extract(src, Mode::Crate).expect("two modules may spell one slot name");
+
+    // Within *one* module they really do meet.
+    let same = rustcall_core::expand::expand(
+        r#"
+        #[julia] pub mod a {
+            #[julia] pub fn foo() -> i32 { 1 }
+            #[julia] pub fn FOO() -> i32 { 2 }
+        }
+        "#,
+    )
+    .unwrap();
+    let dups = same.manifest.duplicate_claims();
+    assert_eq!(dups.len(), 1, "{dups:?}");
+    assert!(!dups[0].0.exported);
+}
+
+/// Rust keeps types and values apart, so a generated buffer *type* and an
+/// exported *function* of one spelling may coexist. Comparing names alone
+/// refused a crate that builds (#338 review).
+#[test]
+fn claims_are_compared_within_their_rust_namespace() {
+    use rustcall_core::claims::Namespace;
+
+    let m = extract(
+        r#"
+            #[julia] pub fn peek() -> &'static str { "hi" }
+        "#,
+        Mode::Crate,
+    )
+    .unwrap();
+    let claims = m.claim_owners();
+    let view = claims
+        .iter()
+        .find(|(c, _)| c.name == "peek_RustCallBorrowedString")
+        .expect("a borrowed `&str` declares its view type");
+    assert_eq!(view.0.namespace, Namespace::Type);
+    assert!(!view.0.exported);
+
+    let wrapper = claims
+        .iter()
+        .find(|(c, _)| c.name == "rustcall_peek")
+        .unwrap();
+    assert_eq!(wrapper.0.namespace, Namespace::Value);
+
+    // A second function spelling the view type's name is a value, so the two
+    // do not meet.
+    let both = extract(
+        r#"
+            #[julia] pub fn peek() -> &'static str { "hi" }
+            #[no_mangle] pub extern "C" fn peek_RustCallBorrowedString() -> i32 { 0 }
+        "#,
+        Mode::Crate,
+    );
+    assert!(both.is_ok(), "{:?}", both.err());
+}

--- a/deps/rustcall_core/tests/symbols.rs
+++ b/deps/rustcall_core/tests/symbols.rs
@@ -646,15 +646,37 @@ fn both_scans_read_one_claim_list() {
     assert_eq!(
         names(function_claims(shout, Policy::JULIA)),
         vec![
+            "__RUSTCALL_PANIC_RUSTCALL_SHOUT".to_string(),
+            "rustcall_shout".to_string(),
+            "rustcall_shout_take_panic".to_string(),
+            "shout_RustCallOwnedString".to_string(),
+            "shout_free_rust_string".to_string(),
+        ]
+    );
+    // Both policies count the private panic slot. They part company on the
+    // string helpers only: `shout` returns an owned `String`, so as declared
+    // it never declares a borrowed view, while the scan reserves that name
+    // too because the wrapper crate has not chosen yet.
+    let reserved = names(function_claims(shout, Policy::PYO3_SCAN));
+    assert!(reserved.contains(&"__RUSTCALL_PANIC_RUSTCALL_SHOUT".to_string()));
+    assert!(reserved.contains(&"shout_RustCallBorrowedString".to_string()));
+    assert!(!names(function_claims(shout, Policy::JULIA))
+        .contains(&"shout_RustCallBorrowedString".to_string()));
+    let mut exported: Vec<String> = m
+        .symbol_owners()
+        .into_iter()
+        .filter(|(_, who)| who.contains("`shout`"))
+        .map(|(s, _)| s)
+        .collect();
+    exported.sort();
+    assert_eq!(
+        exported,
+        vec![
             "rustcall_shout".to_string(),
             "rustcall_shout_take_panic".to_string(),
             "shout_free_rust_string".to_string(),
         ]
     );
-    // The scan reserves the helper types too, and the private panic slot.
-    let reserved = names(function_claims(shout, Policy::PYO3_SCAN));
-    assert!(reserved.contains(&"__RUSTCALL_PANIC_RUSTCALL_SHOUT".to_string()));
-    assert!(reserved.contains(&"shout_RustCallOwnedString".to_string()));
 
     // A borrowed `&str` owns nothing, so as declared it claims no release
     // function; the scan still reserves the name because the wrapper crate
@@ -663,6 +685,8 @@ fn both_scans_read_one_claim_list() {
     assert!(
         !names(function_claims(peek, Policy::JULIA)).contains(&"peek_free_rust_string".to_string())
     );
+    assert!(names(function_claims(peek, Policy::JULIA))
+        .contains(&"peek_RustCallBorrowedString".to_string()));
     assert!(names(function_claims(peek, Policy::PYO3_SCAN))
         .contains(&"peek_free_rust_string".to_string()));
 
@@ -737,7 +761,7 @@ fn helper_slots_are_injective_and_unclaimed() {
         Mode::Crate,
     )
     .unwrap();
-    let names: Vec<String> = struct_claims(&m.structs[0], Policy::PYO3_SCAN)
+    let names: Vec<String> = struct_claims(&m.structs[0], Policy::JULIA)
         .into_iter()
         .map(|c| c.name)
         .collect();
@@ -749,4 +773,85 @@ fn helper_slots_are_injective_and_unclaimed() {
         assert!(!names.contains(&helper_panic_slot(symbol)), "{names:?}");
         assert!(names.contains(&symbol.to_string()), "{names:?}");
     }
+}
+
+/// `#[julia] fn foo` next to `#[julia] fn FOO` export two different symbols,
+/// so nothing about the exports collides — but both wrappers name their panic
+/// slot by upper-casing that symbol, so the crate defines
+/// `__RUSTCALL_PANIC_RUSTCALL_FOO` twice. rustc would report it inside
+/// generated code; the scan refuses first, and says the name is an internal
+/// item rather than calling it an export (#338).
+#[test]
+fn a_duplicate_panic_slot_fails_extraction_as_an_internal_item() {
+    let err = extract(
+        r#"
+            #[julia] pub fn foo() -> i32 { 1 }
+            #[julia] pub fn FOO() -> i32 { 2 }
+        "#,
+        Mode::Crate,
+    )
+    .expect_err("two wrappers sharing a panic slot must fail the scan")
+    .to_string();
+    assert!(
+        err.contains("duplicate generated item `__RUSTCALL_PANIC_RUSTCALL_FOO`"),
+        "{err}"
+    );
+    assert!(!err.contains("duplicate exported symbol"), "{err}");
+    assert!(err.contains("`foo` (line 2)"), "{err}");
+    assert!(err.contains("`FOO` (line 3)"), "{err}");
+    // The message explains a name the user never wrote.
+    assert!(err.contains("upper-casing the wrapper's symbol"), "{err}");
+    assert!(err.contains("#338"), "{err}");
+}
+
+/// The same block inline: a `compile_error!` naming both items, with the
+/// wording for an internal item.
+#[test]
+fn an_inline_duplicate_panic_slot_is_a_compile_error() {
+    let inline = rustcall_core::expand::expand(
+        r#"
+        #[julia] pub fn foo() -> i32 { 1 }
+        #[julia] pub fn FOO() -> i32 { 2 }
+        "#,
+    )
+    .unwrap();
+    let dups = inline.manifest.duplicate_claims();
+    assert_eq!(dups.len(), 1, "{dups:?}");
+    assert_eq!(dups[0].0.name, "__RUSTCALL_PANIC_RUSTCALL_FOO");
+    assert!(!dups[0].0.exported);
+    // The exported projection sees nothing: the two wrappers differ.
+    assert!(inline.manifest.duplicate_symbols().is_empty());
+    assert!(
+        inline
+            .source
+            .contains("would define the item `__RUSTCALL_PANIC_RUSTCALL_FOO` twice"),
+        "{}",
+        inline.source
+    );
+    assert!(
+        !inline.source.contains("would export the symbol"),
+        "{}",
+        inline.source
+    );
+}
+
+/// An exported clash keeps the wording it had: a reader can look the name up
+/// in the naming scheme, and the exported name is reported even though the
+/// private item derived from it collides too.
+#[test]
+fn an_exported_clash_is_still_reported_as_an_export() {
+    let err = extract(
+        r#"
+            #[julia] pub mod a { #[julia] pub fn run() -> i32 { 1 } }
+            #[julia] pub fn a__run() -> i32 { 2 }
+        "#,
+        Mode::Crate,
+    )
+    .expect_err("a duplicate exported symbol must fail the scan")
+    .to_string();
+    assert!(
+        err.contains("duplicate exported symbol `rustcall_a__run`"),
+        "{err}"
+    );
+    assert!(!err.contains("duplicate generated item"), "{err}");
 }


### PR DESCRIPTION
## What

The last item of #338. A wrapper defines more than it exports:

```rust
#[julia] pub fn foo() -> i32 { 1 }
#[julia] pub fn FOO() -> i32 { 2 }
```

Two different exported symbols, so the duplicate check saw nothing — and two `__RUSTCALL_PANIC_RUSTCALL_FOO` thread-locals, because the slot is the wrapper's symbol upper-cased. The crate reached rustc as a duplicate definition inside generated code, which is exactly what this machinery exists to pre-empt. The same shape exists for the `<owner>_RustCallOwnedString` / `_RustCallBorrowedString` types two items with one buffer owner declare.

`Policy::JULIA` counts those names now. It was held back for one reason, recorded in #382: both diagnostics said "duplicate exported symbol", and naming an internal item that way would be wrong. The vocabulary is the other half of this change.

## The two kinds of clash

| | exported symbol | generated item |
| --- | --- | --- |
| what fails | the `cdylib` cannot export one name twice — link time | the crate cannot define one name twice — compile time |
| message | unchanged, word for word | says the name is not exported and not one you wrote, and where it comes from |

`claims::clash_kind` and `claims::internal_origin` supply the wording; `CrateScan::claim` and `expand::expand_with_cfg` each pick from the claim.

Claims are ordered exported-first, so a clash visible on both an export and the private item derived from it is still reported on the export — the name a reader can look up in the naming scheme.

## API shape

`Manifest::claims` / `claim_owners` / `duplicate_claims` carry the `Claim`. `claimed_symbols` / `symbol_owners` / `duplicate_symbols` remain as the exported projection, so every existing caller and test keeps its meaning.

With both policies counting private names, `Policy::include_private` had a single value and is removed. The two policies now differ in `strings` and `skip_cfg_gated` alone.

## Tests

`deps/rustcall_core/tests/symbols.rs`:

| Test | Asserts |
| --- | --- |
| `a_duplicate_panic_slot_fails_extraction_as_an_internal_item` | `foo` / `FOO` fail the crate scan, named as a generated item, never as an export, with both owners and the origin of the name |
| `an_inline_duplicate_panic_slot_is_a_compile_error` | the same block inline: one duplicate claim, not exported, `duplicate_symbols()` empty, `compile_error!` with the internal wording |
| `an_exported_clash_is_still_reported_as_an_export` | the exported message is unchanged and the internal wording does not leak into it |

`both_scans_read_one_claim_list` is updated: the two policies now differ only in the string helpers, and `symbol_owners` is shown to be the exported projection of the same list.

## Verification

- `cargo test` / `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` in `deps/rustcall_core`: pass, golden corpus unchanged
- `cargo test` in `deps/rustcall_extract`, `cargo test --all-features` in `deps/rustcall_julia_macros`: pass
- `Pkg.test()`: 10322 pass / 12 skipped + 715 pass, exit 0 (macOS aarch64, Julia 1.12.7)
- every `scripts/lint_*.sh src`: pass

Closes #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
