### PR TITLE
Release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-09-12
+
 ### Fixed
 - **A clash on a generated internal name is refused, and named for what it is**
   ([#338](https://github.com/AtelierArith/RustCall.jl/issues/338)). A wrapper
@@ -1572,7 +1574,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests for Rust helpers library
 - Documentation examples tests
 
-[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/atelierarith/RustCall.jl/compare/v0.3.0...v0.3.1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustCall"
 uuid = "7ac5b1a4-9e37-4f0e-9aa3-3305a66bfb1c"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
## What

Bumps `Project.toml` to 0.3.4 and closes the `## [Unreleased]` section. No code changes.

## Contents of the tag

Both issues that v0.3.3 left open are closed.

| Issue | Change | PRs |
| --- | --- | --- |
| #338 | A clash on a generated **internal** name is refused and named for what it is: two wrappers whose symbols differ only in case share one upper-cased panic slot, and two items with one buffer owner declare one string buffer type twice. The diagnostics tell an exported symbol from an internal item instead of calling both an export. Private names are compared within the module the wrapper is emitted into — the *real* Rust module, not the symbol-qualification path — and within their Rust namespace. What an entry claims is derived in one place, shared by the `#[julia]` duplicate check and the PyO3 collision analysis. | #382, #383 |
| #259 | The default test run needs no crate from outside the repository's declared dependency closure. `test/fixtures/offline_prefetch/Cargo.toml` declares the two that are needed (`itoa`, `pyo3`); the fixtures pin their graph with committed lockfiles; and the `Offline tests` job starts from an empty `CARGO_HOME` with no Julia cache and runs the suite with `CARGO_NET_OFFLINE=true`. `test_phase4_pi.jl` dropped `rand` for a seeded generator, which also made it reproducible. | #384 |

A patch bump: one extractor-level fix that refuses a crate it used to let through to rustc, plus test and CI infrastructure. No API change, no manifest schema change.

## After merge

Register by commenting `@JuliaRegistrator register` with a `Release notes:` block on issue #229. TagBot creates the tag once the General PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
