### PR TITLE
Keep a call site's snapshot instead of re-resolving it (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `@rust f(a, b)::Int32` 8940 ns → **11.9 ns**, and throughput across four
   threads from 0.85× one thread to 5.18×. This does not weaken the generation
   rule of #277: what is cached is one whole snapshot, and it is dropped the
-  moment the epoch moves. `@rust f(a, b)` **without** a return-type annotation
+  moment the epoch moves — and an entry carries the process that wrote it, so a
+  cache serialised into a precompiled package (a downstream package that calls a
+  generated wrapper from a precompile workload does exactly that) can never be
+  mistaken for a live one. `@rust f(a, b)` **without** a return-type annotation
   stays about 68× a raw `ccall` and is the one shape that cannot be fixed — its
   return type is read from the snapshot at run time, so the call is a dynamic
   dispatch by construction; annotate it, or mark the Rust function `#[julia]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **A `@rust` call no longer re-resolves everything on every call**
+  ([#253](https://github.com/AtelierArith/RustCall.jl/issues/253)). Each call
+  walked the calling module's blocks, took the global `REGISTRY_LOCK`, rebuilt
+  the symbol strings, looked up handle, pointer, panic channel and return ABI,
+  and then computed the `ccall` signature from the argument types — about 9.9 µs
+  and a hundred allocations in front of a 5 ns call, all under one lock, so four
+  threads calling Rust ran *slower* than one. A call site now keeps the snapshot
+  it resolved and reuses it while `RustCall.ARTIFACT_EPOCH`, bumped by every
+  write to RustCall's state, says nothing has changed. Measured against a raw
+  `ccall` into the same library (`benchmark/benchmarks_dispatch.jl`): a
+  `#[julia]` function's generated wrapper 9891 ns → **10.0 ns**,
+  `@rust f(a, b)::Int32` 8940 ns → **11.9 ns**, and throughput across four
+  threads from 0.85× one thread to 5.18×. This does not weaken the generation
+  rule of #277: what is cached is one whole snapshot, and it is dropped the
+  moment the epoch moves. `@rust f(a, b)` **without** a return-type annotation
+  stays about 68× a raw `ccall` and is the one shape that cannot be fixed — its
+  return type is read from the snapshot at run time, so the call is a dynamic
+  dispatch by construction; annotate it, or mark the Rust function `#[julia]`
+  and call the wrapper. See `docs/src/performance.md`.
 - **A panic RustCall catches no longer prints `panicked at` to stderr**
   ([#304](https://github.com/AtelierArith/RustCall.jl/issues/304)). Rust runs
   the panic hook before the unwind `catch_unwind` catches, so every panic the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,48 @@ hand-written `#[julia]` crate. `RUSTCALL_PANIC_HOOK=default` and
 `rustcall_julia_macros` dependency, which does not compile. See
 `docs/src/panics.md`.
 
+**A call site keeps its snapshot (#253).** Re-resolving everything on every call
+cost ~9.9 µs and ~100 allocations in front of a 5 ns `ccall`, and did it all
+under `REGISTRY_LOCK`, so four threads calling Rust ran *slower* than one. A
+call site now keeps the `CallTarget` it resolved in a `CallTargetCache` spliced
+into its expansion, and reuses it while `ARTIFACT_EPOCH` says no state write has
+happened since. Four rules hold this together:
+
+* **The epoch is bumped in `_state_mutate_storage!`** (`src/state_filter.jl`),
+  the one helper every state-container write already passes through — never at
+  the mutation sites, which are many and which grow. Over-invalidating costs a
+  re-resolution; under-invalidating is a call into a retired image, so the
+  counter is conservative in the only direction that is safe.
+* **Sample the epoch before resolving, never after.** `_refresh_call_target!`
+  reads it first; a write landing in between then leaves the entry stamped with
+  the older epoch and it is re-resolved, where sampling afterwards could stamp a
+  pre-write snapshot as current and keep it forever.
+* **Verify before publishing.** `@rust f(x)::T` checks the annotation against the
+  snapshot (#245); that check moved to publication time, because both its inputs
+  are fixed for the life of an entry. It must therefore run *before*
+  `publish_call_target!`, or a rejected snapshot would sit in the cache and be
+  reused with the check never running again.
+* **The generation rule of #277 is unchanged.** What is cached is one whole
+  snapshot, taken under one lock by `resolve_call_target`; nothing is ever
+  reassembled from pieces, and `scripts/lint_generation_snapshot.sh` still
+  forbids that everywhere.
+
+Three smaller costs were on the same path and are gone: `normalize_arg_types` is
+`@generated` (pure type arithmetic, 529 ns per call); `ffi_check_by_value_signature`
+decides at compile time for any signature with no aggregate in it, and falls back
+to the runtime check for one that has (so a later `register_ffi_struct` still
+takes effect); and every cached entry point takes `args::Vararg{Any, N}) where {N}`
+rather than `args...`, because a plain vararg method shares one specialisation
+across arities and left the `ccall` behind a dynamic dispatch (590 ns).
+
+`@rust f(a, b)` with no return-type annotation stays ~68× a raw `ccall`: its
+return type is read from the snapshot at run time, so the call is a dynamic
+dispatch by construction. `_call_and_guard` keeps it to exactly one.
+`docs/src/performance.md` says to annotate it or use `#[julia]`.
+`benchmark/benchmarks_dispatch.jl` is the instrument; `test/test_dispatch_cache.jl`
+asserts the invalidation contract, including that a warmed call site completes
+while another task holds `REGISTRY_LOCK`.
+
 **The panic channel is thread-local.** A generated wrapper records a panic in a `thread_local!` slot of its own library and returns a sentinel; Julia reads that slot with a second `ccall` immediately after the first. A Julia task may migrate to another OS thread at any yield point, so nothing that can yield — a lock, logging, I/O — may sit between the two `ccall`s; the channel pointer is resolved *before* the call (cached at load time). `test/test_panics.jl` stresses this with hundreds of tasks on the 4-thread CI job.
 
 **One generation snapshot per call.** A library can be replaced under a running program (hot reload), so every FFI entry point captures its handle, cached pointers, liveness `Ref` and **return ABI** in **one** locked step. Cold function, panic-channel and release/destructor pointers are then resolved on that captured handle outside STATE. No later name lookup may supply any part of the returned target: that could cross a swap and pair an old call with a replacement's channel, allocator or ABI. Cache publication writes only to the captured image's cache. The legacy name-keyed panic cache compares its captured registry entry before publishing, but that comparison never changes the pointer returned to its caller. Explicit closing requires quiescence of the entire FFI operation, including target resolution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,15 @@ happened since. Four rules hold this together:
   the mutation sites, which are many and which grow. Over-invalidating costs a
   re-resolution; under-invalidating is a call into a retired image, so the
   counter is conservative in the only direction that is safe.
+* **A cached entry carries the process that wrote it, not just the epoch.** The
+  cache object is spliced into its wrapper's method body, so a package that calls
+  a generated wrapper **from a precompile workload** serialises a populated entry
+  — native pointers included — into its `.ji`. `ARTIFACT_EPOCH` starts at the
+  same value in every process and cannot tell; a matching counter made the child
+  `ccall` a pointer from the process that wrote it (`signal 10: Bus error`,
+  reproduced). `SESSION_TOKEN` is a freshly allocated object replaced in
+  `__init__` and compared by `===`, so a foreign entry can never validate — an
+  identity, not a random seed that is merely unlikely to repeat.
 * **Sample the epoch before resolving, never after.** `_refresh_call_target!`
   reads it first; a write landing in between then leaves the entry stamped with
   the older epoch and it is re-resolved, where sampling afterwards could stamp a

--- a/benchmark/benchmarks_dispatch.jl
+++ b/benchmark/benchmarks_dispatch.jl
@@ -1,0 +1,211 @@
+# What a `@rust` call costs above a raw `ccall`, and where the time goes (#253).
+#
+# Run: julia --threads=4 --project=benchmark benchmark/benchmarks_dispatch.jl
+#
+# #253 asks for a per-call-site pointer cache and lock-free reads on the hot
+# path. Before designing either, this measures what is actually there — some of
+# the issue's evidence predates #277/#291, which replaced four separate
+# per-call lookups with one `resolve_call_target` snapshot. This script is the
+# instrument its acceptance criteria need ("within ~2x of a raw `ccall`",
+# "scales with thread count"), so it reports a ratio against a raw `ccall` into
+# the same library and a scaling factor across threads, not just absolute times.
+#
+# Four call paths, floor first:
+#
+#   raw        `ccall` on a pointer resolved once, by hand. The floor: no
+#              lookup, no lock, no panic-channel read.
+#   generated  the Julia function a `#[julia]` item defines. What most user
+#              code calls, and the path `src/julia_functions.jl` emits.
+#   typed      `@rust f(a, b)::T`.
+#   dynamic    `@rust f(a, b)`, the return type taken from the snapshot.
+#
+# and then the pieces each of them is made of, so the ratio has an address.
+
+include(joinpath(@__DIR__, "setup.jl"))
+
+using BenchmarkTools
+using Printf
+using RustCall
+
+if !RustCall.check_rustc_available()
+    error("rustc not found. Benchmarks require Rust to be installed.")
+end
+
+rust"""
+#[julia]
+pub fn dispatch_add(a: i32, b: i32) -> i32 {
+    a + b
+}
+"""
+
+# The Rust body is two instructions, so everything measured above the floor is
+# dispatch. That is the point: a heavier body would hide exactly what #253 is
+# about.
+const A = Int32(100)
+const B = Int32(200)
+
+const MOD = @__MODULE__
+const LIB = RustCall.module_symbol_library(MOD, "rustcall_dispatch_add")
+const TARGET = RustCall.resolve_call_target(LIB, "rustcall_dispatch_add")
+const PTR = TARGET.func_ptr
+const CHANNEL = TARGET.channel
+
+@noinline raw_call(ptr, a, b) = ccall(ptr, Int32, (Int32, Int32), a, b)
+@noinline generated_call(a, b) = dispatch_add(a, b)
+@noinline typed_call(a, b) = @rust dispatch_add(a, b)::Int32
+@noinline dynamic_call(a, b) = @rust dispatch_add(a, b)
+
+@assert raw_call(PTR, A, B) == 300
+@assert generated_call(A, B) == 300
+@assert typed_call(A, B) == 300
+@assert dynamic_call(A, B) == 300
+
+# ---------------------------------------------------------------------------
+# Per-call cost
+# ---------------------------------------------------------------------------
+
+paths = [
+    ("raw ccall", @benchmark raw_call($PTR, $A, $B)),
+    ("generated #[julia] fn", @benchmark generated_call($A, $B)),
+    ("@rust f(a,b)::Int32", @benchmark typed_call($A, $B)),
+    ("@rust f(a,b)", @benchmark dynamic_call($A, $B)),
+]
+
+# The pieces. Each is called the way the call paths call it, so the parts are
+# comparable with the whole rather than merely suggestive.
+@noinline piece_resolve_lib() = RustCall._resolve_lib(MOD, "")
+@noinline piece_symbol_library() = RustCall.module_symbol_library(MOD, "rustcall_dispatch_add")
+@noinline piece_resolve_target(lib) = RustCall.resolve_call_target(lib, "rustcall_dispatch_add")
+@noinline piece_call_rust_function(ptr, a, b) = RustCall.call_rust_function(ptr, Int32, a, b)
+@noinline piece_guard(v, ch) = RustCall.guard_rust_panic_ptr(v, ch, "rustcall_dispatch_add")
+
+pieces = [
+    ("_resolve_lib (per call)", @benchmark piece_resolve_lib()),
+    ("module_symbol_library", @benchmark piece_symbol_library()),
+    ("resolve_call_target", @benchmark piece_resolve_target($LIB)),
+    ("call_rust_function (dyn ret)", @benchmark piece_call_rust_function($PTR, $A, $B)),
+    ("guard_rust_panic_ptr", @benchmark piece_guard(Int32(300), $CHANNEL)),
+]
+
+# ---------------------------------------------------------------------------
+# Thread scaling
+# ---------------------------------------------------------------------------
+#
+# #253's second criterion. `REGISTRY_LOCK` is a single global lock taken on the
+# way to every call, so the question is whether N tasks calling Rust get N
+# times the throughput. Reported as calls/second against the 1-task figure of
+# the same path: a path that scales reads ~N, one that serializes reads ~1.
+
+const CALLS_PER_TASK = 20_000
+
+# `F` as a type parameter, and the loop in a function of its own: the loop body
+# must be specialised on the call, or the harness measures its own dynamic
+# dispatch instead of the path under test. The total is returned so nothing here
+# is dead code the compiler may delete.
+@noinline function burn(call::F, n::Int) where {F}
+    total = Int32(0)
+    for _ in 1:n
+        total += call(A, B)
+    end
+    return total
+end
+
+function throughput(call::F, tasks::Int) where {F}
+    elapsed = @elapsed begin
+        results = map(1:tasks) do _
+            Threads.@spawn burn(call, CALLS_PER_TASK)
+        end
+        foreach(wait, results)
+    end
+    return tasks * CALLS_PER_TASK / elapsed
+end
+
+raw_bound(a, b) = raw_call(PTR, a, b)
+
+nthreads = Threads.nthreads()
+task_counts = filter(<=(max(nthreads, 1)), [1, 2, 4])
+
+const SCALING_PATHS = [("raw ccall", raw_bound), ("generated #[julia] fn", generated_call)]
+
+# Every (path, task count) pair is run once and discarded first. Otherwise the
+# first timed region of each path pays the compilation of `burn` and of the
+# spawn closure, which is what made a 2-task run look forty times faster than a
+# 1-task one.
+for (_, call) in SCALING_PATHS, t in task_counts
+    throughput(call, t)
+end
+
+scaling = map(SCALING_PATHS) do (name, call)
+    # Best of three: a scaling factor is a ratio of two timings, so a single
+    # scheduling hiccup in either shows up doubled.
+    (name, [(t, maximum(throughput(call, t) for _ in 1:3)) for t in task_counts])
+end
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+floor_ns = minimum(paths[1][2]).time
+
+println("\n", "="^72)
+println("@rust dispatch overhead (#253)")
+println("="^72)
+@printf("\nJulia %s, %d thread(s), %s\n\n", VERSION, nthreads, Sys.MACHINE)
+
+@printf("%-30s %12s %12s %10s\n", "call path", "min (ns)", "median (ns)", "x raw")
+println("-"^72)
+for (name, result) in paths
+    @printf("%-30s %12.1f %12.1f %10.1f\n", name, minimum(result).time,
+            median(result).time, minimum(result).time / floor_ns)
+end
+
+@printf("\n%-30s %12s %12s %10s\n", "piece", "min (ns)", "median (ns)", "allocs")
+println("-"^72)
+for (name, result) in pieces
+    @printf("%-30s %12.1f %12.1f %10d\n", name, minimum(result).time,
+            median(result).time, minimum(result).allocs)
+end
+
+if length(task_counts) > 1
+    @printf("\n%-30s %10s %14s %10s\n", "thread scaling", "tasks", "Mcalls/s", "x 1 task")
+    println("-"^72)
+    for (name, points) in scaling
+        base = points[1][2]
+        for (tasks, rate) in points
+            @printf("%-30s %10d %14.2f %10.2f\n", name, tasks, rate / 1e6, rate / base)
+        end
+    end
+else
+    println("\nThread scaling skipped: run with --threads=4 to measure #253's second criterion.")
+end
+# ---------------------------------------------------------------------------
+# How the per-call cost grows with the module's library count
+# ---------------------------------------------------------------------------
+#
+# `_resolve_lib` walks **every** `rust"""` block of the calling module and calls
+# `ensure_loaded` on each, on every call, and `collect`s the table first because
+# a reload may rebind it. So the figures above are the *best* case — one block.
+# A module with several blocks pays this again per block, per call.
+
+rust"""
+#[julia]
+pub fn dispatch_filler_one(a: i32) -> i32 { a }
+"""
+growth_two = @benchmark piece_resolve_lib()
+
+rust"""
+#[julia]
+pub fn dispatch_filler_two(a: i32) -> i32 { a }
+"""
+growth_three = @benchmark piece_resolve_lib()
+
+growth = [(1, pieces[1][2]), (2, growth_two), (3, growth_three)]
+
+@printf("\n%-30s %10s %12s %10s\n", "_resolve_lib vs blocks", "blocks", "min (ns)", "allocs")
+println("-"^72)
+for (blocks, result) in growth
+    @printf("%-30s %10d %12.1f %10d\n", "", blocks, minimum(result).time,
+            minimum(result).allocs)
+end
+
+println("\n", "="^72)

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -189,17 +189,70 @@ and was removed in 0.3.0 (see above).
 result = @rust add(Int32(10), Int32(20))::Int32
 ```
 
-### Type Inference Optimization
+### What a call costs
 
-Explicit type specification can reduce type inference overhead:
+Measured by `benchmark/benchmarks_dispatch.jl`, against a raw `ccall` through a
+pointer resolved once by hand — the floor, since that is what every path
+eventually does (macOS, Julia 1.12, two-instruction Rust body, so what is left
+above the floor is dispatch and nothing else):
+
+| call path | before #253 | now | × raw `ccall` |
+| --- | --- | --- | --- |
+| raw `ccall` (the floor) | 5.2 ns | 5.4 ns | 1.0 |
+| a `#[julia]` function's generated wrapper | 9891 ns | 10.0 ns | 1.9 |
+| `@rust f(a, b)::Int32` | 8940 ns | 11.9 ns | 2.2 |
+| `@rust f(a, b)` (no annotation) | 9945 ns | 360 ns | 68 |
+
+and across threads, as calls per second against the same path's one-task figure:
+
+| tasks | raw `ccall` | generated wrapper, before | now |
+| --- | --- | --- | --- |
+| 1 | 1.00× | 1.00× | 1.00× |
+| 2 | 2.06× | 0.94× | 2.24× |
+| 4 | 4.01× | 0.85× | 5.18× |
+
+A call used to re-resolve everything it needed, every time: walk the calling
+module's blocks, take `REGISTRY_LOCK`, rebuild the symbol strings, look up the
+handle, the pointer, the panic channel and the return ABI, then compute the
+`ccall` signature from the argument types. That was ~9.9 µs and about a hundred
+allocations in front of a 5 ns call, and because it all happened under one
+global lock, adding threads made it *slower* rather than faster.
+
+Since #253 a call site keeps the snapshot it resolved and reuses it while
+`RustCall.ARTIFACT_EPOCH` — a counter bumped by every write to RustCall's state —
+says nothing has changed. The fast path is an atomic load, an integer
+comparison, and the `ccall`. This does not weaken the generation rule of #277:
+what is kept is one whole snapshot, taken under one lock in the one place
+allowed to take one, and it is dropped the moment the epoch moves, so a call can
+still never mix an old pointer with a new channel.
+
+### Annotate the return type, or use `#[julia]`
+
+The one path that is still far from the floor is `@rust f(a, b)` with **no**
+return-type annotation, and it is inherent rather than unfinished: the return
+type is read out of the snapshot at run time, so the `ccall` behind it is
+reached by a dynamic dispatch and its result cannot be inferred in the caller.
+
+Both ways out are cheap:
 
 ```julia
-# With type inference (slightly slower)
-result = @rust add(10, 20)
-
-# Explicit type specification (recommended)
-result = @rust add(Int32(10), Int32(20))::Int32
+result = @rust add(Int32(10), Int32(20))::Int32   # 2.2× a raw ccall
 ```
+
+or mark the Rust function `#[julia]` and call the wrapper RustCall generates for
+it, which knows its own signature at definition time:
+
+```julia
+rust"""
+#[julia]
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+"""
+
+result = add(Int32(10), Int32(20))                # 1.9× a raw ccall
+```
+
+This is the same advice as before #253 — it is just no longer "slightly
+slower", it is thirty times slower, and now measured.
 
 ### No registration step
 

--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -56,6 +56,46 @@ end
 
 const STATE = Base.Lockable(RustCallState(Dict{Symbol, Any}()))
 
+"""
+    ARTIFACT_EPOCH
+
+A counter bumped by **every** write to the state container, so a caller that
+resolved something out of it can tell, without taking a lock, whether its answer
+is still the current one (#253).
+
+# Why a counter and not a flag
+
+A call site may keep the `CallTarget` it resolved (`cached_call_target`,
+`src/ruststr.jl`) and reuse it instead of paying `resolve_call_target` again —
+7 µs and a hundred allocations, on the way to a 5 ns `ccall`. That is only sound
+while nothing the snapshot captured has changed: a hot reload, an adoption, an
+alias, a retirement, a newly registered return type or panic channel all make a
+kept snapshot a pointer into the wrong generation, which is the #277 bug class.
+
+So the reuse has to be invalidated, and *nothing may be allowed to forget to
+invalidate it*. The bump therefore lives in `_state_mutate_storage!`
+(`src/state_filter.jl`) — the one helper every state-container write already
+goes through — rather than at the mutation sites, which are many and which grow.
+A write that does not actually change what a snapshot would say costs a
+re-resolution and nothing else; a write that does and went unnoticed would be a
+call into an unmapped image. The counter is deliberately conservative in the
+only direction that is safe.
+
+It is read with a plain atomic load and never taken under `REGISTRY_LOCK`, which
+is what takes the lock off the calling path entirely.
+"""
+const ARTIFACT_EPOCH = Threads.Atomic{Int}(1)
+
+"""
+    artifact_epoch() -> Int
+
+The current value of [`ARTIFACT_EPOCH`](@ref). Read this **before** resolving
+anything that will be cached against it: a mutation landing between the read and
+the resolution then invalidates the cached answer, where reading it afterwards
+could stamp a stale snapshot with a current epoch.
+"""
+artifact_epoch() = ARTIFACT_EPOCH[]
+
 struct StateView
     name::Symbol
     owner::Union{Nothing, Module}

--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -66,7 +66,7 @@ mutable struct SessionToken end
 """
     SESSION_TOKEN
 
-A freshly allocated [`SessionToken`](@ref), replaced by `__init__` in every
+A freshly allocated `SessionToken`, replaced by `__init__` in every
 process, and the first half of what makes a cached `CallTarget` valid.
 
 # Why an object and not a number
@@ -74,7 +74,7 @@ process, and the first half of what makes a cached `CallTarget` valid.
 A `CallTargetCache` is spliced into the body of the wrapper it belongs to, so a
 package that calls a generated wrapper **from a precompile workload** serialises
 that cache into its `.ji` file with a populated entry — and the entry holds raw
-pointers belonging to the process that wrote them. [`ARTIFACT_EPOCH`](@ref)
+pointers belonging to the process that wrote them. `ARTIFACT_EPOCH`
 cannot tell: it starts at the same value in every process, so a deserialised
 epoch can equal a live one, and the entry would be accepted and its pointer
 called. That is a `ccall` into a process that no longer exists (#390 review).
@@ -90,7 +90,7 @@ global SESSION_TOKEN::SessionToken = SessionToken()
 """
     session_token() -> SessionToken
 
-This process's [`SESSION_TOKEN`](@ref).
+This process's `SESSION_TOKEN`.
 """
 session_token() = SESSION_TOKEN
 
@@ -127,7 +127,7 @@ const ARTIFACT_EPOCH = Threads.Atomic{Int}(1)
 """
     artifact_epoch() -> Int
 
-The current value of [`ARTIFACT_EPOCH`](@ref). Read this **before** resolving
+The current value of `ARTIFACT_EPOCH`. Read this **before** resolving
 anything that will be cached against it: a mutation landing between the read and
 the resolution then invalidates the cached answer, where reading it afterwards
 could stamp a stale snapshot with a current epoch.

--- a/src/RustCall.jl
+++ b/src/RustCall.jl
@@ -57,6 +57,44 @@ end
 const STATE = Base.Lockable(RustCallState(Dict{Symbol, Any}()))
 
 """
+    SessionToken
+
+The identity of one Julia process, for a cached answer that must not outlive it.
+"""
+mutable struct SessionToken end
+
+"""
+    SESSION_TOKEN
+
+A freshly allocated [`SessionToken`](@ref), replaced by `__init__` in every
+process, and the first half of what makes a cached `CallTarget` valid.
+
+# Why an object and not a number
+
+A `CallTargetCache` is spliced into the body of the wrapper it belongs to, so a
+package that calls a generated wrapper **from a precompile workload** serialises
+that cache into its `.ji` file with a populated entry — and the entry holds raw
+pointers belonging to the process that wrote them. [`ARTIFACT_EPOCH`](@ref)
+cannot tell: it starts at the same value in every process, so a deserialised
+epoch can equal a live one, and the entry would be accepted and its pointer
+called. That is a `ccall` into a process that no longer exists (#390 review).
+
+Identity settles it with certainty rather than probability. A deserialised entry
+carries the token object of the process that wrote it; this process allocated its
+own in `__init__`, and two distinct objects are never `===`. No counter
+collision, and no random seed that is merely unlikely to repeat, can make a
+foreign entry validate.
+"""
+global SESSION_TOKEN::SessionToken = SessionToken()
+
+"""
+    session_token() -> SessionToken
+
+This process's [`SESSION_TOKEN`](@ref).
+"""
+session_token() = SESSION_TOKEN
+
+"""
     ARTIFACT_EPOCH
 
 A counter bumped by **every** write to the state container, so a caller that
@@ -258,6 +296,12 @@ export @register_ffi_struct
 
 # Module initialization
 function __init__()
+    # A new identity for this process, before anything can consult a cache: a
+    # `CallTargetCache` deserialised from a precompiled module carries the token
+    # of the process that populated it, and must never be mistaken for a live
+    # one (#253, #390 review).
+    global SESSION_TOKEN = SessionToken()
+
     # The deprecated RTLD_GLOBAL escape hatch (#250, #277 Phase B2), read once:
     # a load policy must not change halfway through a session.
     _init_dlopen_global_override!()

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -605,9 +605,19 @@ normalize_arg_type(::Type{R}, ::Type{T}) where {R,T<:AbstractFloat} = T  # Prese
 normalize_arg_type(::Type{R}, ::Type{Ptr{T}}) where {R,T} = Ptr{T}  # Preserve pointer types
 normalize_arg_type(::Type{R}, ::Type{Ref{T}}) where {R,T} = Ref{T}  # Preserve Ref types
 
-function normalize_arg_types(::Type{R}, argt::Type{<:Tuple}) where {R}
-    normalized = map(t -> normalize_arg_type(R, t), argt.parameters)
-    return Core.apply_type(Tuple, normalized...)
+# `@generated`, because this is pure type arithmetic on the hot path (#253).
+#
+# Every method of `normalize_arg_type` above dispatches on types alone and reads
+# no runtime state, so the answer for a given `(R, A)` can never change within a
+# session and belongs at compile time. Computing it per call cost 529 ns and
+# three allocations — a hundred times the 5.1 ns `ccall` it was preparing.
+#
+# This is deliberately *not* what `ffi_check_by_value` does: that one consults
+# layouts `register_ffi_struct` may add later in the session, so it stays a
+# runtime check. The two look similar and are not.
+@generated function normalize_arg_types(::Type{R}, ::Type{A}) where {R, A <: Tuple}
+    normalized = map(t -> normalize_arg_type(R, t), A.parameters)
+    return :($(Core.apply_type(Tuple, normalized...)))
 end
 
 is_supported_arg_type(::Type{T}) where {T<:Integer} = true
@@ -700,8 +710,11 @@ function call_rust_function(func_ptr::Ptr{Cvoid}, ret_type::Type, args...)
     # Fail closed on an aggregate nobody asserted a layout for (#245 item 3).
     # Checked here rather than inside `_call_rust_function`, which is
     # `@generated`: a generated method is not re-generated when
-    # `register_ffi_struct` is called later in the session.
-    ffi_check_by_value(ret_type, argt.parameters)
+    # `register_ffi_struct` is called later in the session. The signature form
+    # keeps that property — it falls back to the runtime check for any
+    # signature containing an aggregate, and elides it only where no
+    # registration could ever be consulted (#253).
+    ffi_check_by_value_signature(ret_type, argt)
     return _call_rust_function(func_ptr, ret_type, argt, args...)
 end
 

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -1809,7 +1809,7 @@ end
 """
     ffi_check_by_value_signature(R, A)
 
-[`ffi_check_by_value`](@ref) for a call whose whole signature is known as a
+`ffi_check_by_value` for a call whose whole signature is known as a
 type: the return type `R` and the argument tuple type `A`.
 
 Same decision, taken at compile time in the case where it cannot depend on

--- a/src/ffi_contract.jl
+++ b/src/ffi_contract.jl
@@ -1805,3 +1805,33 @@ function ffi_check_by_value(@nospecialize(R::Type), arg_types)
     end
     return nothing
 end
+
+"""
+    ffi_check_by_value_signature(R, A)
+
+[`ffi_check_by_value`](@ref) for a call whose whole signature is known as a
+type: the return type `R` and the argument tuple type `A`.
+
+Same decision, taken at compile time in the case where it cannot depend on
+runtime state (#253). `ffi_by_value_allowed` is
+`!ffi_is_aggregate(T) || T <: FFIByValue || ffi_by_value_registered(T)`, and only
+the last of those three reads state `register_ffi_struct` may add to later — it
+is reached only for an *aggregate*. So when no type in the signature is an
+aggregate, the answer is `true` for every element, unconditionally and for the
+whole session; a signature that does contain one keeps the runtime check in
+full, which is what makes a later `register_ffi_struct` still take effect.
+
+This is not a second copy of the policy: the predicate it branches on is
+`ffi_is_aggregate`, the same one `ffi_by_value_allowed` consults.
+
+Scalar calls paid 128 ns per call for this, against the 5.1 ns `ccall` it
+guards.
+"""
+@generated function ffi_check_by_value_signature(::Type{R}, ::Type{A}) where {R, A <: Tuple}
+    if !ffi_is_aggregate(R) && !any(ffi_is_aggregate, A.parameters)
+        return :(nothing)
+    end
+    # An aggregate is in play, so the registration table decides and must be
+    # read on every call.
+    return :(ffi_check_by_value($R, $(A.parameters)))
+end

--- a/src/julia_functions.jl
+++ b/src/julia_functions.jl
@@ -401,14 +401,19 @@ function _generate_single_wrapper(sig::RustFunctionSignature)
     # actually holds the wrapper — otherwise a panic is looked for in the
     # wrong image and silently missed (#244).
     channel_sym = _generated_local("panic_channel", sig.arg_names)
+    # This call site's own cache, spliced into the body as a constant: one
+    # object per generated wrapper, no binding in the caller's module, and a
+    # fresh one if the wrapper is generated again (#253).
+    cache = RustCall.CallTargetCache()
     return quote
         function $func_name($(arg_syms...))
             # One snapshot: pointer and panic channel from the same
             # generation, resolved before the call (the channel is a
             # thread-local, so nothing may yield between call and read) — #244,
-            # #277.
-            $channel_sym =
-                RustCall.resolve_call_target(RustCall.module_symbol_library(@__MODULE__, $symbol_str), $symbol_str)
+            # #277. Reused across calls only while the artifact epoch says no
+            # state write has happened since it was taken (#253) — still one
+            # snapshot of one image per call, never reassembled from pieces.
+            $channel_sym = RustCall.cached_call_target($cache, @__MODULE__, $symbol_str)
             RustCall.guard_rust_panic_ptr(
                 RustCall.call_rust_function($channel_sym.func_ptr, $julia_ret_type, $(converted_args...)),
                 $channel_sym.channel, $rust_name)
@@ -444,14 +449,18 @@ function _generate_inline_string_wrapper(sig, func_name, symbol_str, arg_syms)
               RustCall.call_rust_function($channel_sym.func_ptr, $ret, $(call_args...)),
               $channel_sym.channel, $rust_name))
     end
+    string_cache = RustCall.CallTargetCache()
     quote
         function $func_name($(arg_syms...))
             $(bindings...)
             # The owning library is resolved once; the string helpers take
-            # their own single snapshot, free pointer included (#277).
-            $lib_sym = RustCall.resolve_call_target(
-                RustCall.module_symbol_library(@__MODULE__, $symbol_str), $symbol_str).lib_name
-            $channel_sym = RustCall.resolve_call_target($lib_sym, $symbol_str)
+            # their own single snapshot, free pointer included (#277). One
+            # snapshot serves as both, where this used to resolve twice: the
+            # second call re-resolved the same symbol in the library the first
+            # had already named as its owner, so it could only return the same
+            # target (#253).
+            $channel_sym = RustCall.cached_call_target($string_cache, @__MODULE__, $symbol_str)
+            $lib_sym = $channel_sym.lib_name
             GC.@preserve $(preserved...) begin
                 $call
             end

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -136,16 +136,19 @@ function rust_impl_call(mod, expr, ret_type)
     func_name_str = string(func_name)
     escaped_args = [esc(arg) for arg in args]
 
+    # One cache per expansion, spliced in as a constant: the call site keeps the
+    # snapshot it resolved and re-resolves only when the artifact epoch moves
+    # (#253). `_resolve_lib` moves with it onto the slow path — it walked every
+    # block of the module, on every call.
+    cache = CallTargetCache()
     if ret_type === nothing
         # Dynamic dispatch based on argument types
-        return Expr(:call, GlobalRef(RustCall, :_rust_call_dynamic),
-                    Expr(:call, GlobalRef(RustCall, :_resolve_lib), mod, ""),
-                    func_name_str, escaped_args...)
+        return Expr(:call, GlobalRef(RustCall, :_rust_call_dynamic_cached),
+                    cache, mod, "", func_name_str, escaped_args...)
     else
         # Static dispatch with known return type
-        return Expr(:call, GlobalRef(RustCall, :_rust_call_typed),
-                    Expr(:call, GlobalRef(RustCall, :_resolve_lib), mod, ""),
-                    func_name_str, esc(ret_type), escaped_args...)
+        return Expr(:call, GlobalRef(RustCall, :_rust_call_typed_cached),
+                    cache, mod, "", func_name_str, esc(ret_type), escaped_args...)
     end
 end
 
@@ -276,11 +279,12 @@ function rust_impl_qualified(mod, lib_name, call_expr, ret_type)
     func_name_str = string(func_name)
     escaped_args = map(esc, args)
 
+    cache = CallTargetCache()
     if ret_type === nothing
         return Expr(
             :call,
-            GlobalRef(RustCall, :_rust_call_from_lib),
-            Expr(:call, GlobalRef(RustCall, :_resolve_lib), mod, lib_name_str),
+            GlobalRef(RustCall, :_rust_call_dynamic_cached),
+            cache, mod, lib_name_str,
             func_name_str,
             escaped_args...
         )
@@ -288,8 +292,8 @@ function rust_impl_qualified(mod, lib_name, call_expr, ret_type)
 
     return Expr(
         :call,
-        GlobalRef(RustCall, :_rust_call_typed),
-        Expr(:call, GlobalRef(RustCall, :_resolve_lib), mod, lib_name_str),
+        GlobalRef(RustCall, :_rust_call_typed_cached),
+        cache, mod, lib_name_str,
         func_name_str,
         esc(ret_type),
         escaped_args...
@@ -347,6 +351,41 @@ function _rust_call_dynamic(lib_name::String, func_name::String, args...)
     # same library. Resolving them separately let a reload land in between, so
     # the call entered the retired image and read the replacement's channel.
     target = resolve_call_target(lib_name, func_name)
+    return _dispatch_with_target(target, lib_name, func_name, args...)
+end
+
+"""
+    _call_and_guard(func_ptr, R, channel, func_name, args...)
+
+Make the call and read its channel, with the return type as a **type
+parameter**.
+
+`@rust f(a, b)` without an annotation learns its return type from the snapshot,
+so that type is a runtime value and the call through it is a dynamic dispatch.
+This is the barrier that keeps it to exactly one: everything inside is
+specialised on `R` and on the argument arity, where calling `call_rust_function`
+with a runtime `Type` left the whole chain behind it dynamic — the `@generated`
+`_call_rust_function` reached by a specialisation lookup on every call (#253).
+
+An annotated call (`::T`) and a `#[julia]` wrapper know their type statically and
+do not come through here.
+"""
+@noinline function _call_and_guard(func_ptr::Ptr{Cvoid}, ::Type{R}, channel::Ptr{Cvoid},
+                                   func_name::String, args::Vararg{Any, N}) where {R, N}
+    return guard_rust_panic_ptr(call_rust_function(func_ptr, R, args...), channel, func_name)
+end
+
+"""
+    _dispatch_with_target(target, lib_name, func_name, args...)
+
+The half of `_rust_call_dynamic` that runs once a snapshot is in hand: pick the
+return type the snapshot recorded, call, and read that snapshot's channel.
+
+Shared with the cached call sites (#253), which reach the same snapshot without
+re-resolving it, so the two cannot drift in what they do with one.
+"""
+function _dispatch_with_target(target, lib_name::String, func_name::String,
+                               args::Vararg{Any, N}) where {N}
     func_ptr = target.func_ptr
     channel = target.channel
     owning_lib = target.lib_name
@@ -368,8 +407,7 @@ function _rust_call_dynamic(lib_name::String, func_name::String, args...)
     # replacement's return type — a scalar read as a struct (#277).
     func_info = target.func_info
     if func_info !== nothing && func_info.return_type !== Any
-        return guard_rust_panic_ptr(call_rust_function(func_ptr, func_info.return_type, args...),
-                                    channel, func_name)
+        return _call_and_guard(func_ptr, func_info.return_type, channel, func_name, args...)
     end
 
     # Try to get the return type the owning library registered — again, the one
@@ -377,8 +415,7 @@ function _rust_call_dynamic(lib_name::String, func_name::String, args...)
     ret_type = target.return_type
     if ret_type !== nothing
         @debug "Using registered return type for $func_name: $ret_type"
-        return guard_rust_panic_ptr(call_rust_function(func_ptr, ret_type, args...),
-                                    channel, func_name)
+        return _call_and_guard(func_ptr, ret_type, channel, func_name, args...)
     end
 
     # No last resort. Guessing the return type from the first argument was the
@@ -493,6 +530,81 @@ function _check_return_annotation(target, func_name::AbstractString, declared::T
         "a conversion. Drop the annotation and let the manifest decide, " *
         "write `::$recorded`, or change the Rust signature — and convert the " *
         "result on the Julia side if you wanted a `$declared`."))
+end
+
+"""
+    _rust_call_dynamic_cached(cache, mod, lib_name, func_name, args...)
+
+`@rust f(a, b)` with this call site's snapshot cache (#253).
+
+The generic check stays on the slow path deliberately. A name registered as
+generic is routed to `call_generic_function` before anything is resolved, so it
+never populates the cache — which means a cache hit is by construction a name
+that already answered the generic question with "no", and the per-call
+registry lookup it used to cost is gone for everyone else.
+"""
+function _rust_call_dynamic_cached(cache::CallTargetCache, mod::Module, lib_name::String,
+                                   func_name::String, args::Vararg{Any, N}) where {N}
+    hit = cached_target_hit(cache)
+    hit === nothing || return _dispatch_with_target(hit, hit.lib_name, func_name, args...)
+    is_generic_function(func_name) && return call_generic_function(func_name, args...)
+    target = cached_macro_call_target(cache, mod, lib_name, func_name)
+    return _dispatch_with_target(target, target.lib_name, func_name, args...)
+end
+
+"""
+    _rust_call_typed_cached(cache, mod, lib_name, func_name, ret_type, args...)
+
+`@rust f(a, b)::T` with this call site's snapshot cache (#253).
+"""
+# `args::Vararg{Any, N}) where {N}`, not `args...`: a plain vararg method gets one
+# specialization shared by every arity, so the argument tuple stays abstract and
+# the `ccall` behind `call_rust_function` is reached by dynamic dispatch — 590 ns
+# and four allocations, against 10 ns once `N` makes the arity part of the
+# signature. Every cached entry point below is annotated for that reason (#253).
+function _rust_call_typed_cached(cache::CallTargetCache, mod::Module, lib_name::String,
+                                 func_name::String, ::Type{R},
+                                 args::Vararg{Any, N}) where {R, N}
+    target = cached_target_hit(cache)
+    target === nothing &&
+        return _rust_call_typed_uncached(cache, mod, lib_name, func_name, R, args...)
+    return guard_rust_panic_ptr(call_rust_function(target.func_ptr, R, args...),
+                                target.channel, func_name)
+end
+
+# The `try` lives here rather than in the caller above, and that is the whole
+# reason this is a second function: a variable assigned inside a `try` block is
+# boxed, so keeping the generic-function fallback next to the fast path cost it
+# four allocations and 550 ns — fifty times the call it was making (#253).
+@noinline function _rust_call_typed_uncached(cache::CallTargetCache, mod::Module,
+                                             lib_name::String, func_name::String,
+                                             ::Type{R},
+                                             args::Vararg{Any, N}) where {R, N}
+    local epoch, target
+    try
+        epoch, target = resolve_macro_call_target(mod, lib_name, func_name)
+    catch e
+        # Same fallback as the uncached path: a name the libraries do not
+        # export may still be a generic awaiting monomorphization.
+        is_generic_function(func_name) && return call_generic_function(func_name, args...)
+        rethrow(e)
+    end
+    # Checked here rather than on the fast path, and **before** publishing.
+    #
+    # Both inputs are fixed for as long as the entry lives — the snapshot is the
+    # one just resolved, and `R` is this call site's annotation, spliced in by
+    # the macro — so checking once per snapshot is checking every call, and a
+    # new snapshot is a new check. It cost 550 ns per call where it stood,
+    # because comparing two runtime `Type` values through `ccall_return_type`
+    # is a dynamic call and the annotation check makes two of them.
+    #
+    # Publishing only after it passes is what keeps that true: an entry that
+    # failed the check must not be left behind for later calls to hit, which
+    # would skip the check for the rest of the session (#245, #253).
+    _check_return_annotation(target, func_name, R)
+    publish_call_target!(cache, epoch, target)
+    return guard_rust_panic_ptr(call_rust_function(target.func_ptr, R, args...),
+                                target.channel, func_name)
 end
 
 """

--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -565,7 +565,11 @@ end
 function _rust_call_typed_cached(cache::CallTargetCache, mod::Module, lib_name::String,
                                  func_name::String, ::Type{R},
                                  args::Vararg{Any, N}) where {R, N}
-    target = cached_target_hit(cache)
+    # `R` is part of the hit: the annotation is an expression, so one call site
+    # can ask for a different type on each call while sharing this cache, and an
+    # entry validated for another type would be read at the wrong width
+    # (#245, #390 review).
+    target = cached_target_hit(cache, R)
     target === nothing &&
         return _rust_call_typed_uncached(cache, mod, lib_name, func_name, R, args...)
     return guard_rust_panic_ptr(call_rust_function(target.func_ptr, R, args...),
@@ -602,7 +606,7 @@ end
     # failed the check must not be left behind for later calls to hit, which
     # would skip the check for the rest of the session (#245, #253).
     _check_return_annotation(target, func_name, R)
-    publish_call_target!(cache, epoch, target)
+    publish_call_target!(cache, epoch, target, R)
     return guard_rust_panic_ptr(call_rust_function(target.func_ptr, R, args...),
                                 target.channel, func_name)
 end

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -150,6 +150,14 @@ end
     # is why it stays on the slow path rather than being hoisted away: the first
     # call through this cache must still do it, and a load is a state write, so
     # it bumps the epoch and is resolved again on the next call.
+    #
+    # A cold call site therefore resolves twice before it settles: `dlsym`ing a
+    # symbol for the first time publishes its pointer into the image's own
+    # cache, which is a state write like any other, so the entry this call is
+    # about to publish is stale before it is read. The next call finds the
+    # pointer already there, writes nothing, and sticks. Two resolutions once,
+    # rather than a special case in the invalidation rule that would have to
+    # know which writes "do not count".
     target = resolve_call_target(module_symbol_library(mod, func_name), func_name)
     return publish_call_target!(cache, epoch, target)
 end

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -73,6 +73,117 @@ function _resolve_call(lib_name::String, func_name::String)
 end
 
 """
+    CallTargetCache()
+
+One call site's memory of the `CallTarget` it last resolved (#253).
+
+Not a second way to resolve a call: the thing it holds is a whole
+`resolve_call_target` snapshot, taken under one lock in the one place allowed to
+take one, and it is handed back only while `ARTIFACT_EPOCH` proves no state
+write has happened since. The generation rule of #277 is therefore unchanged —
+a call still uses one snapshot of one image, and still never assembles one from
+pieces. What changes is only how often an unchanged answer is recomputed.
+
+A cache belongs to a call site, not to a name: the generated wrapper of a
+`#[julia]` item gets one, and so does every `@rust` expansion. The object is
+spliced into the expansion rather than bound in the caller's module, so it needs
+no name of its own, cannot collide, and a redefinition gets a fresh one.
+"""
+mutable struct CallTargetCache
+    # A single atomic field holding an immutable record, so a reader sees either
+    # the whole previous answer or the whole new one. Reading is one atomic
+    # pointer load; writing allocates, and happens only when the epoch moved.
+    @atomic entry::Union{Nothing, Tuple{Int, CallTarget}}
+    CallTargetCache() = new(nothing)
+end
+
+"""
+    cached_call_target(cache, mod, func_name) -> CallTarget
+
+The `CallTarget` for `func_name` as called from `mod`, reusing `cache` while the
+artifact epoch it was resolved at still stands.
+
+The fast path is an atomic load, an integer comparison and nothing else — no
+lock, which is what lets `@rust` calls from several threads proceed at once
+instead of queueing on `REGISTRY_LOCK`.
+"""
+function cached_call_target(cache::CallTargetCache, mod::Module, func_name::String)
+    hit = cached_target_hit(cache)
+    hit === nothing || return hit
+    return _refresh_call_target!(cache, mod, func_name)
+end
+
+"""
+    cached_target_hit(cache) -> Union{CallTarget, Nothing}
+
+`cache`'s snapshot if it is still current, `nothing` otherwise. The whole fast
+path: one atomic load and one integer comparison, no lock.
+"""
+@inline function cached_target_hit(cache::CallTargetCache)
+    entry = @atomic :acquire cache.entry
+    entry === nothing && return nothing
+    entry[1] === artifact_epoch() || return nothing
+    return entry[2]
+end
+
+"""
+    publish_call_target!(cache, epoch, target) -> CallTarget
+
+Record `target` as `cache`'s answer for `epoch`. `epoch` must have been sampled
+**before** `target` was resolved.
+"""
+@inline function publish_call_target!(cache::CallTargetCache, epoch::Int, target::CallTarget)
+    @atomic :release cache.entry = (epoch, target)
+    return target
+end
+
+# Out of line: the hot path above should be small enough to inline into the
+# generated wrapper, and this half runs only when the epoch moved.
+@noinline function _refresh_call_target!(cache::CallTargetCache, mod::Module,
+                                         func_name::String)
+    # Sampled **before** resolving. A write landing between here and the
+    # snapshot leaves this entry stamped with the older epoch, so the next call
+    # re-resolves; sampling afterwards could stamp a pre-write snapshot with the
+    # post-write epoch and keep it forever.
+    epoch = artifact_epoch()
+    # `module_symbol_library` also restores a precompiled caller's blocks, which
+    # is why it stays on the slow path rather than being hoisted away: the first
+    # call through this cache must still do it, and a load is a state write, so
+    # it bumps the epoch and is resolved again on the next call.
+    target = resolve_call_target(module_symbol_library(mod, func_name), func_name)
+    return publish_call_target!(cache, epoch, target)
+end
+
+"""
+    cached_macro_call_target(cache, mod, lib_name, func_name) -> CallTarget
+
+[`cached_call_target`](@ref) for an `@rust` call site, which names its library
+the way the macro does (`_resolve_lib`) rather than through the symbol table.
+"""
+@noinline function cached_macro_call_target(cache::CallTargetCache, mod::Module,
+                                            lib_name::String, func_name::String)
+    epoch, target = resolve_macro_call_target(mod, lib_name, func_name)
+    return publish_call_target!(cache, epoch, target)
+end
+
+"""
+    resolve_macro_call_target(mod, lib_name, func_name) -> (epoch, CallTarget)
+
+Resolve an `@rust` call site's snapshot **without** publishing it, returning the
+epoch it was resolved at alongside it.
+
+A caller that has something to verify about the snapshot — `@rust f(x)::T`
+checks the annotation against it — must verify *before* publishing, or a
+rejected snapshot would sit in the cache and be reused by later calls without
+the check ever running again.
+"""
+@noinline function resolve_macro_call_target(mod::Module, lib_name::String,
+                                             func_name::String)
+    epoch = artifact_epoch()
+    return (epoch, resolve_call_target(_resolve_lib(mod, lib_name), func_name))
+end
+
+"""
     resolve_call_target(lib_name, func_name; free_symbol = "") -> CallTarget
 
 Everything one call needs — the function pointer, its panic channel, and

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -93,7 +93,12 @@ mutable struct CallTargetCache
     # A single atomic field holding an immutable record, so a reader sees either
     # the whole previous answer or the whole new one. Reading is one atomic
     # pointer load; writing allocates, and happens only when the epoch moved.
-    @atomic entry::Union{Nothing, Tuple{Int, CallTarget}}
+    #
+    # The record carries the process that wrote it as well as the epoch. This
+    # object is spliced into a method body, so it is serialised with everything
+    # else when a package that calls the wrapper during precompilation is
+    # precompiled — pointers included. See `SESSION_TOKEN`.
+    @atomic entry::Union{Nothing, Tuple{SessionToken, Int, CallTarget}}
     CallTargetCache() = new(nothing)
 end
 
@@ -122,8 +127,12 @@ path: one atomic load and one integer comparison, no lock.
 @inline function cached_target_hit(cache::CallTargetCache)
     entry = @atomic :acquire cache.entry
     entry === nothing && return nothing
-    entry[1] === artifact_epoch() || return nothing
-    return entry[2]
+    # This process first: an entry deserialised from a precompiled module holds
+    # pointers from the process that wrote it, and the epoch alone would let one
+    # through whenever the two counters happened to agree.
+    entry[1] === session_token() || return nothing
+    entry[2] === artifact_epoch() || return nothing
+    return entry[3]
 end
 
 """
@@ -133,7 +142,7 @@ Record `target` as `cache`'s answer for `epoch`. `epoch` must have been sampled
 **before** `target` was resolved.
 """
 @inline function publish_call_target!(cache::CallTargetCache, epoch::Int, target::CallTarget)
-    @atomic :release cache.entry = (epoch, target)
+    @atomic :release cache.entry = (session_token(), epoch, target)
     return target
 end
 

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -89,6 +89,25 @@ A cache belongs to a call site, not to a name: the generated wrapper of a
 spliced into the expansion rather than bound in the caller's module, so it needs
 no name of its own, cannot collide, and a redefinition gets a fresh one.
 """
+struct CachedTarget
+    """The process that resolved this. See `SESSION_TOKEN`."""
+    token::SessionToken
+    """The artifact epoch it was resolved at."""
+    epoch::Int
+    target::CallTarget
+    """
+    The `::T` annotation this entry was validated against, or `nothing` for a
+    call site that has none.
+
+    A `@rust` annotation is an *expression*, not a literal: `f(T) = @rust g()::T`
+    is one call site whose `T` changes between calls, sharing one cache. An entry
+    validated for `Int32` must not be handed to a call that asked for `Float64`,
+    which is the very confusion `_check_return_annotation` exists to refuse
+    (#245) — so the type it was checked for is part of what makes it valid.
+    """
+    checked::Any
+end
+
 mutable struct CallTargetCache
     # A single atomic field holding an immutable record, so a reader sees either
     # the whole previous answer or the whole new one. Reading is one atomic
@@ -98,7 +117,7 @@ mutable struct CallTargetCache
     # object is spliced into a method body, so it is serialised with everything
     # else when a package that calls the wrapper during precompilation is
     # precompiled — pointers included. See `SESSION_TOKEN`.
-    @atomic entry::Union{Nothing, Tuple{SessionToken, Int, CallTarget}}
+    @atomic entry::Union{Nothing, CachedTarget}
     CallTargetCache() = new(nothing)
 end
 
@@ -130,19 +149,43 @@ path: one atomic load and one integer comparison, no lock.
     # This process first: an entry deserialised from a precompiled module holds
     # pointers from the process that wrote it, and the epoch alone would let one
     # through whenever the two counters happened to agree.
-    entry[1] === session_token() || return nothing
-    entry[2] === artifact_epoch() || return nothing
-    return entry[3]
+    entry.token === session_token() || return nothing
+    entry.epoch === artifact_epoch() || return nothing
+    return entry.target
 end
 
 """
-    publish_call_target!(cache, epoch, target) -> CallTarget
+    cached_target_hit(cache, R) -> Union{CallTarget, Nothing}
+
+The same, for a call site that declared `::R` — a hit also requires the entry to
+have been validated against *this* `R`.
+
+`@rust f(x)::T` takes its annotation from an expression, so one call site can ask
+for a different type on every call while sharing one cache. Handing it an entry
+checked for another type would read the return slot at the wrong width, which is
+undefined behaviour rather than a conversion (#245, #390 review).
+"""
+@inline function cached_target_hit(cache::CallTargetCache, ::Type{R}) where {R}
+    entry = @atomic :acquire cache.entry
+    entry === nothing && return nothing
+    entry.token === session_token() || return nothing
+    entry.epoch === artifact_epoch() || return nothing
+    entry.checked === R || return nothing
+    return entry.target
+end
+
+"""
+    publish_call_target!(cache, epoch, target, checked = nothing) -> CallTarget
 
 Record `target` as `cache`'s answer for `epoch`. `epoch` must have been sampled
 **before** `target` was resolved.
+
+`checked` is the `::T` annotation the caller validated this snapshot against, and
+a later call asking for a different one will not be given this entry.
 """
-@inline function publish_call_target!(cache::CallTargetCache, epoch::Int, target::CallTarget)
-    @atomic :release cache.entry = (session_token(), epoch, target)
+@inline function publish_call_target!(cache::CallTargetCache, epoch::Int,
+                                      target::CallTarget, checked = nothing)
+    @atomic :release cache.entry = CachedTarget(session_token(), epoch, target, checked)
     return target
 end
 
@@ -174,7 +217,7 @@ end
 """
     cached_macro_call_target(cache, mod, lib_name, func_name) -> CallTarget
 
-[`cached_call_target`](@ref) for an `@rust` call site, which names its library
+`cached_call_target` for an `@rust` call site, which names its library
 the way the macro does (`_resolve_lib`) rather than through the symbol table.
 """
 @noinline function cached_macro_call_target(cache::CallTargetCache, mod::Module,

--- a/src/state_filter.jl
+++ b/src/state_filter.jl
@@ -70,6 +70,16 @@ function _state_mutate_storage!(value, op::Symbol, args...)
             end
         end
         rethrow()
+    finally
+        # Every state write invalidates every cached `CallTarget` (#253). Here,
+        # rather than at the mutation sites, because this is the one helper they
+        # all already pass through — a new registry or a new call to an existing
+        # one cannot forget to do it. In `finally`, so the partially-applied
+        # write of the `catch` branch above invalidates too, and **after** the
+        # write: a reader that sampled the epoch before it and resolved before
+        # the write now holds a stale epoch and will re-resolve, where bumping
+        # first would let that reader stamp a stale snapshot as current.
+        Threads.atomic_add!(ARTIFACT_EPOCH, 1)
     end
 end
 

--- a/test/test_dispatch_cache.jl
+++ b/test/test_dispatch_cache.jl
@@ -173,6 +173,23 @@ using RustCall
             @test fetch(result) == 1
         end
 
+        @testset "a call site whose annotation varies is checked every time" begin
+            # `::T` is an expression, not a literal, so this is *one* call site —
+            # one spliced cache — asked for a different type on each call. An
+            # entry validated for `Int32` handed to the `Float64` call would read
+            # an `i32` return slot as a `Float64`: undefined behaviour, and
+            # exactly what `_check_return_annotation` exists to refuse (#245).
+            # The declared type is therefore part of what makes an entry a hit
+            # (#390 review).
+            @noinline varying(::Type{T}) where {T} = @rust dispatch_cache_value()::T
+            @test varying(Int32) == 1
+            @test_throws RustCall.RustError varying(Float64)
+            # Both orders: the warm entry must not be a way past the check, and
+            # the rejected one must not have displaced the good entry either.
+            @test varying(Int32) == 1
+            @test_throws RustCall.RustError varying(Float64)
+        end
+
         @testset "a wrapper called during precompilation still calls correctly" begin
             # The end-to-end form of the test above, and the scenario that makes
             # it matter: a package whose module body *calls* a generated wrapper

--- a/test/test_dispatch_cache.jl
+++ b/test/test_dispatch_cache.jl
@@ -95,13 +95,38 @@ using RustCall
         # `test_hot_reload_transaction.jl`, which runs against this same path and
         # is where a stale snapshot would actually show up as a wrong answer.
 
+        @testset "unloading a library moves the epoch" begin
+            # The property the whole scheme rests on, pinned against the one
+            # event that would actually hurt: a snapshot kept across an unload
+            # is a pointer into an image the registry no longer names. The bump
+            # is not written at the unload site — it comes from the state writes
+            # the unload performs — so this asserts the consequence rather than
+            # the mechanism, and keeps holding if the mechanism is rewritten.
+            rust"""
+            #[julia]
+            pub fn dispatch_cache_unload() -> i32 { 7 }
+            """
+            name = RustCall.get_current_library()
+            before = RustCall.artifact_epoch()
+            RustCall.unload_library(name)
+            @test RustCall.artifact_epoch() > before
+        end
+
         @testset "the fast path takes no lock" begin
             # #253's second acceptance criterion, as a property rather than a
             # timing: a warmed call site must complete while another task holds
             # `REGISTRY_LOCK`. Before the cache it could not — every call took
             # that lock on the way to the snapshot, which is why four threads
             # ran slower than one.
-            call_site()   # warm it
+            #
+            # Warmed *twice*, deliberately. The first resolution of a symbol
+            # publishes its pointer into the image's own cache, and that
+            # publication is itself a state write, so it bumps the epoch and
+            # leaves the entry it just produced stale. The second call finds the
+            # pointer already there, writes nothing, and its entry sticks. One
+            # extra resolution per call site, once.
+            call_site()
+            call_site()
             held = Channel{Nothing}(1)
             release = Channel{Nothing}(1)
             holder = Threads.@spawn lock(RustCall.REGISTRY_LOCK) do
@@ -110,13 +135,14 @@ using RustCall
             end
             take!(held)
             result = Threads.@spawn call_site()
-            try
-                @test timedwait(() -> istaskdone(result), 20.0) === :ok
-                @test fetch(result) == 1
-            finally
-                put!(release, nothing)
-                wait(holder)
-            end
+            finished = timedwait(() -> istaskdone(result), 20.0)
+            # Released before anything waits on `result`: if the call did take
+            # the lock, `fetch` would block until the holder let go, and the
+            # holder is waiting for this.
+            put!(release, nothing)
+            wait(holder)
+            @test finished === :ok
+            @test fetch(result) == 1
         end
 
         @testset "a return annotation is still checked after a cache hit" begin

--- a/test/test_dispatch_cache.jl
+++ b/test/test_dispatch_cache.jl
@@ -1,0 +1,134 @@
+using Test
+using RustCall
+
+# A call site keeps the `CallTarget` it resolved and reuses it while the artifact
+# epoch says no state write has happened since (#253). That is the whole reason
+# `@rust` went from ~9.9 µs to ~12 ns and stopped serialising on `REGISTRY_LOCK`
+# — and it is only sound while the invalidation is airtight, because a snapshot
+# reused across a reload is a call into a retired image with the replacement's
+# channel, which is the #277 bug class.
+#
+# So these tests are about exactly two things: that the epoch moves whenever the
+# state does, and that a moved epoch is what the fast path checks.
+
+@testset "cached dispatch (#253)" begin
+    @testset "every state write moves the epoch" begin
+        # Not "the writes we remembered to annotate": the bump lives in
+        # `_state_mutate_storage!`, the one helper every state-container write
+        # already passes through, so a registry added later cannot forget it.
+        before = RustCall.artifact_epoch()
+        view = RustCall._state_view(:dispatch_cache_probe, Dict{String, Int}())
+        try
+            view["a"] = 1
+            after_write = RustCall.artifact_epoch()
+            @test after_write > before
+            delete!(view, "a")
+            @test RustCall.artifact_epoch() > after_write
+        finally
+            lock(RustCall.REGISTRY_LOCK) do
+                delete!(RustCall.STATE.value.values, :dispatch_cache_probe)
+            end
+        end
+    end
+
+    @testset "a hit is dropped as soon as the epoch moves" begin
+        cache = RustCall.CallTargetCache()
+        @test RustCall.cached_target_hit(cache) === nothing
+        # Publish a fabricated entry: this testset is about the epoch check, and
+        # it must hold whatever the snapshot happens to be.
+        target = RustCall.CallTarget(Ptr{Cvoid}(1), Ptr{Cvoid}(2), C_NULL, Ref(true),
+                                     Ptr{Cvoid}(3), "lib", nothing, nothing, 0, C_NULL)
+        RustCall.publish_call_target!(cache, RustCall.artifact_epoch(), target)
+        @test RustCall.cached_target_hit(cache) === target
+        Threads.atomic_add!(RustCall.ARTIFACT_EPOCH, 1)
+        @test RustCall.cached_target_hit(cache) === nothing
+    end
+
+    @testset "an epoch sampled after resolving would be wrong" begin
+        # The ordering rule, asserted rather than only commented: a snapshot
+        # stamped with an epoch taken *after* a concurrent write would look
+        # current forever. `_refresh_call_target!` samples before resolving, so
+        # the stale stamp loses the race instead of winning it.
+        source = read(joinpath(dirname(@__DIR__), "src", "ruststr.jl"), String)
+        body = source[findfirst("function _refresh_call_target!", source)[1]:end]
+        body = body[1:findfirst("\nend", body)[1]]
+        @test findfirst("artifact_epoch()", body)[1] <
+              findfirst("resolve_call_target(", body)[1]
+    end
+
+    if !RustCall.check_rustc_available()
+        @info "Skipping the cached-dispatch call tests: no Rust toolchain"
+        @test_skip "needs rustc"
+    else
+        rust"""
+        #[julia]
+        pub fn dispatch_cache_value() -> i32 { 1 }
+        """
+
+        # One call site, fixed for the rest of this file: its cache object is
+        # created when the macro expands and never again, which is what makes
+        # the reload below a test of invalidation rather than of redefinition.
+        @noinline call_site() = @rust dispatch_cache_value()::Int32
+
+        @testset "a warm call site re-resolves once the epoch moves" begin
+            @test call_site() == 1
+            # Warm, then invalidated by an unrelated state write — the same
+            # thing a reload does to it, without needing a second block
+            # exporting the same name, which one module may not have (#300).
+            view = RustCall._state_view(:dispatch_cache_reresolve, Dict{String, Int}())
+            try
+                view["x"] = 1
+            finally
+                lock(RustCall.REGISTRY_LOCK) do
+                    delete!(RustCall.STATE.value.values, :dispatch_cache_reresolve)
+                end
+            end
+            # The call site has to go all the way back through
+            # `module_symbol_library` + `resolve_call_target` here, and still
+            # answer correctly.
+            @test call_site() == 1
+            @test call_site() == 1
+        end
+
+        # The adversarial end-to-end version of the above — a reload loop racing
+        # tasks that call, panic, allocate and drop — is
+        # `test_hot_reload_transaction.jl`, which runs against this same path and
+        # is where a stale snapshot would actually show up as a wrong answer.
+
+        @testset "the fast path takes no lock" begin
+            # #253's second acceptance criterion, as a property rather than a
+            # timing: a warmed call site must complete while another task holds
+            # `REGISTRY_LOCK`. Before the cache it could not — every call took
+            # that lock on the way to the snapshot, which is why four threads
+            # ran slower than one.
+            call_site()   # warm it
+            held = Channel{Nothing}(1)
+            release = Channel{Nothing}(1)
+            holder = Threads.@spawn lock(RustCall.REGISTRY_LOCK) do
+                put!(held, nothing)
+                take!(release)
+            end
+            take!(held)
+            result = Threads.@spawn call_site()
+            try
+                @test timedwait(() -> istaskdone(result), 20.0) === :ok
+                @test fetch(result) == 1
+            finally
+                put!(release, nothing)
+                wait(holder)
+            end
+        end
+
+        @testset "a return annotation is still checked after a cache hit" begin
+            # The check moved to publication time (both its inputs are fixed for
+            # the life of an entry), so the thing to prove is that a rejected
+            # snapshot leaves no reusable entry behind: the second call must
+            # raise exactly as the first did, not sail through on a hit.
+            @noinline bad_site() = @rust dispatch_cache_value()::Float64
+            @test_throws RustCall.RustError bad_site()
+            @test_throws RustCall.RustError bad_site()
+            # And the honest call site is unaffected.
+            @test call_site() == 1
+        end
+    end
+end

--- a/test/test_dispatch_cache.jl
+++ b/test/test_dispatch_cache.jl
@@ -112,6 +112,34 @@ using RustCall
             @test RustCall.artifact_epoch() > before
         end
 
+        @testset "an entry from another process is never a hit" begin
+            # A `CallTargetCache` is spliced into the body of the wrapper it
+            # belongs to, so a package that calls a generated wrapper from a
+            # precompile workload serialises it — pointers and all — into its
+            # `.ji`. The epoch cannot tell: it starts at the same value in every
+            # process, so a deserialised one can equal a live one. Only the
+            # session token can, and it does so by identity rather than by luck
+            # (#390 review).
+            cache = RustCall.CallTargetCache()
+            target = RustCall.CallTarget(Ptr{Cvoid}(1), Ptr{Cvoid}(2), C_NULL, Ref(true),
+                                         Ptr{Cvoid}(3), "lib", nothing, nothing, 0, C_NULL)
+            RustCall.publish_call_target!(cache, RustCall.artifact_epoch(), target)
+            @test RustCall.cached_target_hit(cache) === target
+            # Exactly what loading into a fresh process does: a new token, while
+            # the epoch is left alone so that it *would* have matched.
+            previous = RustCall.session_token()
+            epoch_then = RustCall.artifact_epoch()
+            try
+                @eval RustCall SESSION_TOKEN = SessionToken()
+                @test RustCall.session_token() !== previous
+                @test RustCall.artifact_epoch() === epoch_then
+                @test RustCall.cached_target_hit(cache) === nothing
+            finally
+                @eval RustCall SESSION_TOKEN = $previous
+            end
+            @test RustCall.cached_target_hit(cache) === target
+        end
+
         @testset "the fast path takes no lock" begin
             # #253's second acceptance criterion, as a property rather than a
             # timing: a warmed call site must complete while another task holds
@@ -143,6 +171,72 @@ using RustCall
             wait(holder)
             @test finished === :ok
             @test fetch(result) == 1
+        end
+
+        @testset "a wrapper called during precompilation still calls correctly" begin
+            # The end-to-end form of the test above, and the scenario that makes
+            # it matter: a package whose module body *calls* a generated wrapper
+            # is precompiled with that call's cache entry — native pointers and
+            # all — written into its `.ji` file.
+            #
+            # What makes this a test rather than a coincidence is the third
+            # line of the child script. A fresh process would normally be at a
+            # different epoch, and the entry would be rejected for the wrong
+            # reason; putting the counter back where it stood when the entry was
+            # written removes that accident, so the only thing that can reject it
+            # is the session token. Before the token, this printed garbage or
+            # crashed the child.
+            root = mktempdir()
+            pkg_name = "DispatchCachePrecomp"
+            # Hard-coded, like the other precompilation tests: `UUIDs` is not a
+            # test dependency, and a fixed id is fine for a package that is
+            # created, loaded and deleted inside one testset.
+            pkg_uuid = "4e6b2c18-9d07-4a35-8f21-6c3d9b5e7a02"
+            pkgdir_ = joinpath(root, pkg_name)
+            mkpath(joinpath(pkgdir_, "src"))
+            write(joinpath(pkgdir_, "Project.toml"), """
+            name = "$pkg_name"
+            uuid = "$pkg_uuid"
+            version = "0.1.0"
+
+            [deps]
+            RustCall = "$(Base.PkgId(RustCall).uuid)"
+            """)
+            write(joinpath(pkgdir_, "src", "$pkg_name.jl"), """
+            module $pkg_name
+            using RustCall
+            rust\"\"\"
+            #[julia]
+            pub fn dispatch_cache_precomp(a: i32) -> i32 { a + 1 }
+            \"\"\"
+            # Called here, while the package is being precompiled: this is what
+            # populates the wrapper's cache and serialises it.
+            const AT_PRECOMPILE = dispatch_cache_precomp(Int32(41))
+            const EPOCH_AT_PRECOMPILE = RustCall.artifact_epoch()
+            end
+            """)
+            project = pkgdir(RustCall)
+            sep = Sys.iswindows() ? ";" : ":"
+            cache_dir = joinpath(root, "rustcall-cache")
+            function in_child(script::AbstractString)
+                withenv("JULIA_LOAD_PATH" => join((project, root, "@stdlib"), sep),
+                        "RUSTCALL_CACHE_DIR" => cache_dir,
+                        "RUSTCALL_SUPPRESS_HELPERS_WARNING" => "1") do
+                    readchomp(pipeline(`$(Base.julia_cmd()) --startup-file=no -e $script`;
+                                       stderr = stderr))
+                end
+            end
+            try
+                @test in_child("using $pkg_name; print($pkg_name.AT_PRECOMPILE)") == "42"
+                out = in_child("""
+                    using RustCall, $pkg_name
+                    RustCall.ARTIFACT_EPOCH[] = $pkg_name.EPOCH_AT_PRECOMPILE
+                    print($pkg_name.dispatch_cache_precomp(Int32(41)))
+                    """)
+                @test out == "42"
+            finally
+                rm(root; force = true, recursive = true)
+            end
         end
 
         @testset "a return annotation is still checked after a cache hit" begin

--- a/test/test_regressions.jl
+++ b/test/test_regressions.jl
@@ -110,9 +110,20 @@ signature_for(code, name; mode = "inline") = only(
 
     @testset "Qualified @rust calls resolve libraries consistently" begin
         qualified = Expr(:call, Expr(:(::), :fake_lib, :fake_fn), :(Int32(1)))
-        expanded = sprint(show, RustCall.rust_impl(@__MODULE__, qualified))
-        @test occursin("_rust_call_from_lib", expanded)
-        @test occursin("_resolve_lib", expanded)
+        expansion = RustCall.rust_impl(@__MODULE__, qualified)
+        expanded = sprint(show, expansion)
+        # `lib::f(x)` must reach the dispatcher *naming its library*, so the
+        # resolution starts there rather than at the module's active one. Since
+        # #253 the library is resolved on the call site's slow path — the
+        # expansion carries the name and a cache of its own instead of calling
+        # `_resolve_lib` inline on every call — so this asserts the name is
+        # carried, not which function carries it.
+        @test occursin("_rust_call_dynamic_cached", expanded)
+        @test occursin("\"fake_lib\"", expanded)
+        @test any(arg -> arg isa RustCall.CallTargetCache, expansion.args)
+        # And the dispatcher it names still resolves through `_resolve_lib`.
+        @test occursin("_resolve_lib",
+                       read(joinpath(dirname(@__DIR__), "src", "ruststr.jl"), String))
     end
 
     @testset "Manifest handles strings, chars, comments, and closures (#85/#124)" begin


### PR DESCRIPTION
#253 asks for a per-call-site pointer cache and estimates the overhead it would
remove at 100 ns – 1 µs. The first commit here is the microbenchmark its own
fourth item asks for, because two things needed settling before designing
anything:

* **Part of the issue's evidence was stale.** "`_rust_call_dynamic` then calls
  `is_generic_function`, `get_function_pointer`, `get_function_info`,
  `get_function_return_type`" was fixed in passing by #277/#291 — that path
  takes one `resolve_call_target` snapshot today.
* **The estimate was low by two orders of magnitude.** It is 9.9 µs, not 1 µs.
  And the two largest single costs are ones the issue does not mention at all.

## Measured

`benchmark/benchmarks_dispatch.jl`, against a raw `ccall` through a pointer
resolved once by hand — the floor, since that is what every path eventually
does. Two-instruction Rust body, so everything above the floor is dispatch.

| call path | before | after | × raw `ccall` |
| --- | --- | --- | --- |
| raw `ccall` | 5.2 ns | 5.4 ns | 1.0 |
| generated `#[julia]` wrapper | 9891 ns | **10.0 ns** | 1.9 |
| `@rust f(a,b)::Int32` | 8940 ns | **11.9 ns** | 2.2 |
| `@rust f(a,b)` (no annotation) | 9945 ns | 360 ns | 68 |

Throughput across threads, against each path's own 1-task figure:

| tasks | raw `ccall` | generated wrapper, before | after |
| --- | --- | --- | --- |
| 1 | 1.00× | 1.00× | 1.00× |
| 2 | 2.06× | 0.94× | 2.24× |
| 4 | 4.01× | **0.85×** | **5.18×** |

Adding threads used to make it *slower*. That is the global lock, and it is the
half of #253 a pointer cache alone would not have fixed.

## Four costs, four fixes

| what | cost/call | fix |
| --- | --- | --- |
| `module_symbol_library` + `resolve_call_target` | ~7 µs, ~100 allocs | epoch-validated call-site snapshot cache |
| `args...` not specialised per arity | 590 ns | `args::Vararg{Any, N}) where {N}` |
| `normalize_arg_types` | 529 ns | `@generated` — pure type arithmetic, no runtime state |
| `ffi_check_by_value` | 128 ns | decided at compile time when the signature holds no aggregate |

The last one is the only delicate one. `ffi_by_value_allowed` is
`!ffi_is_aggregate(T) || T <: FFIByValue || ffi_by_value_registered(T)`, and only
the third reads state a later `register_ffi_struct` can add to — reached only for
an aggregate. So a signature with no aggregate in it is decidable at compile
time, for the whole session; one that has an aggregate keeps the full runtime
check. It branches on `ffi_is_aggregate`, the same predicate
`ffi_by_value_allowed` consults, so it is not a second copy of the policy.

## The invalidation, and why it is where it is

A kept snapshot reused across a reload is a call into a retired image with the
replacement's channel — the #277 bug class. So the reuse must be invalidated,
and **nothing may be allowed to forget to invalidate it**. That is the same
shape as the `LoadPolicy` flag in #388 that silently missed a whole flavour, so
the counter is not bumped at the mutation sites. It is bumped in
`_state_mutate_storage!` — the one helper every state-container write already
passes through — so a registry added later cannot miss it. Over-invalidating
costs a re-resolution; under-invalidating is a wild call.

Three ordering rules hold the rest together, each with a test:

* **Sample the epoch before resolving.** A write landing in between then leaves
  the entry stale and it is re-resolved; sampling afterwards could stamp a
  pre-write snapshot as current and keep it forever.
* **Verify before publishing.** `@rust f(x)::T` checks its annotation against the
  snapshot (#245). That check moved to publication time — both inputs are fixed
  for the life of an entry — so it must run *before* `publish_call_target!`, or a
  rejected snapshot would sit in the cache with the check never running again.
* **#277 is unchanged.** What is cached is one whole snapshot, taken under one
  lock by `resolve_call_target`. Nothing is reassembled from pieces and
  `scripts/lint_generation_snapshot.sh` still forbids it everywhere.

## Something the tests found

`the fast path takes no lock` deadlocked at first, and the reason is worth
keeping: a cold call site resolves **twice** before its entry sticks, because
the first `dlsym` publishes the pointer into the image's own cache and that
publication is a state write like any other. The alternative was an invalidation
rule that knows which writes "do not count" — exactly the kind of exception that
gets a stale pointer called later — so the behaviour is documented at the source
and the test warms twice.

## Criteria

| criterion | status |
| --- | --- |
| `@rust` steady-state within ~2× a raw `ccall` | met for `@rust f(a,b)::T` (2.2×) and the `#[julia]` wrapper (1.9×); **not** for unannotated `@rust f(a,b)` — see below |
| a `Threads.@threads` loop scales with thread count | met: 0.85× → 5.18× at four tasks, against 4.01× for a raw `ccall`. Asserted as a property too, not only a timing: a warmed call site completes while another task holds `REGISTRY_LOCK` |
| hot reload still takes effect | met (`test/test_dispatch_cache.jl`), and `test_hot_reload_transaction.jl` exercises this path adversarially |
| a microbenchmark tracked over time with a documented target | met (`benchmark/benchmarks_dispatch.jl`, `docs/src/performance.md`) |

## Advances, not Closes

Two things stay above the bar, both measured rather than assumed:

1. **`@rust f(a, b)` with no return-type annotation: 360 ns (68×).** Inherent —
   the return type is read from the snapshot at run time, so the call is a
   dynamic dispatch and its result cannot be inferred in the caller.
   `_call_and_guard` keeps it to exactly one dispatch. `docs/src/performance.md`
   now says to annotate it or use `#[julia]`, replacing the old "explicit types
   are slightly slower" line, which was wrong by thirty times.
2. **`@rust_crate` generated modules: 965 ns, 14 allocs, still lock-taking.**
   Their `_call_target` is a *different* snapshot constructor, reading `_LIB_GEN`
   (a StateView deref, so a lock) and building the channel symbol string on
   every call. It wants the same epoch check, but that template can be written
   out as source (`write_bindings_to_file`), so a spliced cache object will not
   survive — it needs a named binding in the generated module, which touches the
   precompile machinery and the module-state scan. Its own change.

## Verification

* `Pkg.test()` green; `test/test_dispatch_cache.jl` 15 assertions.
* All six `scripts/lint_*.sh` pass — including `lint_generation_snapshot.sh`.
* `julia --project=docs docs/make.jl` green.
* One existing test changed: `Qualified @rust calls resolve libraries
  consistently` asserted the *expansion spelling* (`_rust_call_from_lib`,
  `_resolve_lib`). It now asserts what that test is for — the qualified form
  reaches the dispatcher carrying its library name — since library resolution
  moved to the call site's slow path.

Advances #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
