### PR TITLE
Restore a module before deciding a name is missing (#253)

### DIFF
--- a/src/rustmacro.jl
+++ b/src/rustmacro.jl
@@ -547,8 +547,17 @@ function _rust_call_dynamic_cached(cache::CallTargetCache, mod::Module, lib_name
                                    func_name::String, args::Vararg{Any, N}) where {N}
     hit = cached_target_hit(cache)
     hit === nothing || return _dispatch_with_target(hit, hit.lib_name, func_name, args...)
+    # `_resolve_lib` first, before the generic check. It is what replays a
+    # precompiled caller's recorded blocks, and those blocks are what register
+    # the module's generic functions: asking `is_generic_function` before it has
+    # run answers "no" for every generic in a fresh process, and the symbol
+    # resolution below then fails on a name that only needed monomorphizing
+    # (#390 review). It used to run first by construction — the macro put it in
+    # the argument list, evaluated before the call.
+    resolved = _resolve_lib(mod, lib_name)
     is_generic_function(func_name) && return call_generic_function(func_name, args...)
-    target = cached_macro_call_target(cache, mod, lib_name, func_name)
+    epoch, target = resolve_macro_call_target(resolved, func_name)
+    publish_call_target!(cache, epoch, target)
     return _dispatch_with_target(target, target.lib_name, func_name, args...)
 end
 
@@ -584,9 +593,16 @@ end
                                              lib_name::String, func_name::String,
                                              ::Type{R},
                                              args::Vararg{Any, N}) where {R, N}
+    # Outside the `try`, and before it: restoring a precompiled caller's blocks
+    # is not a symbol resolution, and a block that fails to compile or load must
+    # say so. Inside the `try` below, such a failure was caught and then hidden
+    # by the generic fallback whenever an *earlier* block had already registered
+    # a generic of this name — leaving the module half restored and the real
+    # error swallowed (#390 review).
+    resolved = _resolve_lib(mod, lib_name)
     local epoch, target
     try
-        epoch, target = resolve_macro_call_target(mod, lib_name, func_name)
+        epoch, target = resolve_macro_call_target(resolved, func_name)
     catch e
         # Same fallback as the uncached path: a name the libraries do not
         # export may still be a generic awaiting monomorphization.

--- a/src/ruststr.jl
+++ b/src/ruststr.jl
@@ -215,32 +215,26 @@ end
 end
 
 """
-    cached_macro_call_target(cache, mod, lib_name, func_name) -> CallTarget
-
-`cached_call_target` for an `@rust` call site, which names its library
-the way the macro does (`_resolve_lib`) rather than through the symbol table.
-"""
-@noinline function cached_macro_call_target(cache::CallTargetCache, mod::Module,
-                                            lib_name::String, func_name::String)
-    epoch, target = resolve_macro_call_target(mod, lib_name, func_name)
-    return publish_call_target!(cache, epoch, target)
-end
-
-"""
-    resolve_macro_call_target(mod, lib_name, func_name) -> (epoch, CallTarget)
+    resolve_macro_call_target(lib_name, func_name) -> (epoch, CallTarget)
 
 Resolve an `@rust` call site's snapshot **without** publishing it, returning the
 epoch it was resolved at alongside it.
+
+`lib_name` is already resolved: `_resolve_lib` is the caller's job and must run
+**before** this, because it is what replays a precompiled caller's recorded
+blocks — and therefore what registers that module's generic functions and
+reports a block that fails to load. Doing it here, inside the callers' fallback
+`try`, made a generic invisible on its first call in a fresh process and turned a
+block that failed to load into a "missing symbol" (#390 review).
 
 A caller that has something to verify about the snapshot — `@rust f(x)::T`
 checks the annotation against it — must verify *before* publishing, or a
 rejected snapshot would sit in the cache and be reused by later calls without
 the check ever running again.
 """
-@noinline function resolve_macro_call_target(mod::Module, lib_name::String,
-                                             func_name::String)
+@noinline function resolve_macro_call_target(lib_name::String, func_name::String)
     epoch = artifact_epoch()
-    return (epoch, resolve_call_target(_resolve_lib(mod, lib_name), func_name))
+    return (epoch, resolve_call_target(lib_name, func_name))
 end
 
 """

--- a/test/test_dispatch_cache.jl
+++ b/test/test_dispatch_cache.jl
@@ -173,6 +173,94 @@ using RustCall
             @test fetch(result) == 1
         end
 
+        @testset "a generic is still found on its first call in a fresh process" begin
+            # `_resolve_lib` replays a precompiled caller's recorded blocks, and
+            # those blocks are what register the module's generic functions. It
+            # used to run before the call by construction — the macro put it in
+            # the argument list. Moving library resolution onto the call site's
+            # slow path (#253) put it *after* the generic check, so in a fresh
+            # process every generic looked like a plain symbol that no library
+            # exports, and an unannotated `@rust` on one failed on first call
+            # instead of monomorphizing (#390 review).
+            root = mktempdir()
+            pkg_name = "DispatchCacheGeneric"
+            pkg_uuid = "b1d54f26-0a83-4c71-9e52-7d38a0c6b415"
+            pkgdir_ = joinpath(root, pkg_name)
+            mkpath(joinpath(pkgdir_, "src"))
+            write(joinpath(pkgdir_, "Project.toml"), """
+            name = "$pkg_name"
+            uuid = "$pkg_uuid"
+            version = "0.1.0"
+
+            [deps]
+            RustCall = "$(Base.PkgId(RustCall).uuid)"
+            """)
+            write(joinpath(pkgdir_, "src", "$pkg_name.jl"), """
+            module $pkg_name
+            using RustCall
+            rust\"\"\"
+            #[julia]
+            pub fn dispatch_cache_generic<T: std::fmt::Display>(x: T) -> String {
+                format!("<{x}>")
+            }
+            \"\"\"
+            # `@rust` without an annotation, inside the package, so the call site
+            # belongs to the precompiled module.
+            call_it(x) = @rust dispatch_cache_generic(x)
+            end
+            """)
+            project = pkgdir(RustCall)
+            sep = Sys.iswindows() ? ";" : ":"
+            cache_dir = joinpath(root, "rustcall-cache")
+            function in_child(script::AbstractString)
+                withenv("JULIA_LOAD_PATH" => join((project, root, "@stdlib"), sep),
+                        "RUSTCALL_CACHE_DIR" => cache_dir,
+                        "RUSTCALL_SUPPRESS_HELPERS_WARNING" => "1") do
+                    readchomp(pipeline(`$(Base.julia_cmd()) --startup-file=no -e $script`;
+                                       stderr = stderr))
+                end
+            end
+            try
+                # Precompile first, so the second session is the fresh process
+                # that loads a `.ji` and has an empty generic registry.
+                in_child("using $pkg_name")
+                @test in_child("using $pkg_name; print($pkg_name.call_it(Int32(7)))") ==
+                      "<7>"
+            finally
+                rm(root; force = true, recursive = true)
+            end
+        end
+
+        @testset "restoring a module is not a symbol resolution" begin
+            # The other half of the same ordering. `_resolve_lib` must sit
+            # *outside* the fallback `try`: a block that fails to compile or load
+            # is not "this name is a generic", and catching it there let an
+            # earlier block's generic of the same name swallow the real error and
+            # leave the module half restored (#390 review).
+            #
+            # Asserted on the source because the failure needs a package whose
+            # *second* recorded block fails to load in a fresh process, which
+            # cannot be staged without making the test depend on how a build is
+            # made to fail.
+            source = read(joinpath(dirname(@__DIR__), "src", "rustmacro.jl"), String)
+            # Comments only: the prose below explains this ordering and names
+            # both `try` and `_resolve_lib`, so searching the raw text would
+            # measure the comment rather than the code.
+            code_of(name) = begin
+                body = source[findfirst("function $(name)", source)[1]:end]
+                body = body[1:findfirst("\nend", body)[1]]
+                join((line for line in split(body, '\n')
+                      if !startswith(strip(line), "#")), '\n')
+            end
+            typed = code_of("_rust_call_typed_uncached")
+            @test findfirst("_resolve_lib(", typed)[1] < findfirst("try", typed)[1]
+            # And the dynamic path resolves the library before it asks whether
+            # the name is generic.
+            dynamic = code_of("_rust_call_dynamic_cached")
+            @test findfirst("_resolve_lib(", dynamic)[1] <
+                  findfirst("is_generic_function(", dynamic)[1]
+        end
+
         @testset "a call site whose annotation varies is checked every time" begin
             # `::T` is an expression, not a literal, so this is *one* call site —
             # one spliced cache — asked for a different type on each call. An


### PR DESCRIPTION
Codex posted these two against `abe68c5` on #390, seven minutes before that PR
merged, so they went in unfixed. This is the fix on top of `61cd1ac`.

Both are the same mistake. #390 moved `_resolve_lib` off the macro expansion and
onto the call site's slow path — and in doing so moved it *later* than two
decisions that depend on it. The macro used to put it in the argument list, so it
ran before the call by construction. Nothing said so out loud, and the caching
change did not preserve it.

`_resolve_lib` replays a precompiled caller's recorded `rust"""` blocks. Those
blocks are what register the module's generic functions, and they are where a
block that fails to compile or load reports it.

| | where | what broke |
| --- | --- | --- |
| **P1** | `_rust_call_dynamic_cached` | `is_generic_function` was asked *before* the replay, so in a fresh process every generic answered "no" and an unannotated `@rust` on one tried to resolve a symbol no library exports, instead of monomorphizing |
| **P2** | `_rust_call_typed_uncached` | the replay sat *inside* the fallback `try`, so a later block failing to load was caught and then hidden whenever an earlier block had registered a generic of that name — the real error swallowed, the module left half restored |

Both paths now resolve the library first, and outside the `try`: **restoring a
module is not a symbol resolution.** `resolve_macro_call_target` takes a library
name that is already resolved, so it cannot reintroduce the ordering by accident.

## Tests

* `a generic is still found on its first call in a fresh process` — P1 end to
  end: a package whose block registers a generic, precompiled, then called
  unannotated through `@rust` from a second session.
* `restoring a module is not a symbol resolution` — P2, asserted on the source.
  Staging the real thing needs a package whose *second* recorded block fails to
  load in a fresh process, which cannot be built without the test depending on
  how a build is made to fail. The assertion skips comment lines, because the
  prose there names both `try` and `_resolve_lib`.

`Pkg.test()` green, all six `scripts/lint_*.sh` pass.

Advances #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015g2djpBMno5orCJnHQNR7g
